### PR TITLE
Create logfile before starting the deamon

### DIFF
--- a/scripts/auto-cpufreq-install.sh
+++ b/scripts/auto-cpufreq-install.sh
@@ -11,6 +11,9 @@ then
 	exit 1
 fi
 
+# this is needed on SELinux enabled systems (see also ConditionPathExists in .service)
+touch /var/log/auto-cpufreq.log
+
 echo -e "\n* Reloading systemd manager configuration"
 systemctl daemon-reload
 

--- a/scripts/auto-cpufreq.service
+++ b/scripts/auto-cpufreq.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=auto-cpufreq - Automatic CPU speed & power optimizer for Linux
 After=network.target network-online.target
+ConditionPathExists=/var/log/auto-cpufreq.log
 
 [Service]
 Type=simple


### PR DESCRIPTION
- on SELinux enabled systems, the daemon fails to start unless
  the logfile is already present, because the systemd unit file
  redirects the STDOUT to a file.