### PR TITLE
Use nproc in cpufreqctl.sh

### DIFF
--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VERSION='20'
-cpucount=`cat /proc/cpuinfo|grep processor|wc -l`
+cpucount=`nproc`
 FLROOT=/sys/devices/system/cpu
 DRIVER=auto
 VERBOSE=0


### PR DESCRIPTION
Use **nproc** tool to get the number of processing units available. It is part of the GNU coreutils and comes preinstalled in all modern linux distributions.
