### PR TITLE
add power package for better power source control

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ Please note: this tool doesn't conflict and [works great in tandem with TLP](htt
 
 All requirements can be installed by running:
 
-`sudo apt install python3 python3-distro python3-psutil python3-click -y`
+`sudo apt install python3 python3-distro python3-psutil python3-click python3-power -y`
 
 Since APT packages may contain older version of necessary Python packages, please make sure to have latest version by running:
-`sudo pip3 install --upgrade psutil click distro`
+`sudo pip3 install --upgrade psutil click distro power`
 
 ##### Requirements installation for all other Linux distributions
 
 If you have python3 and pip3 installed simply run:
 
-`sudo pip3 install psutil click distro`
+`sudo pip3 install psutil click distro power`
 
 Note: libraries must be installed using root user as tool will be run as root.
 

--- a/auto-cpufreq.py
+++ b/auto-cpufreq.py
@@ -246,8 +246,11 @@ def set_autofreq():
     elif bat_state == False:
         print("Battery is: discharging")
         set_powersave()
+    # temp fix for https://github.com/giampaolo/psutil/issues/1658
+    elif bat_state == None:
+        print("Couldn't determine battery status. Supposing battery is: charging")
     else:
-        print("Couldn't detrmine battery status. Please report this issue.")
+        print("Couldn't determine battery status. Please report this issue.")
 
 # make cpufreq suggestions
 def mon_autofreq():
@@ -265,8 +268,13 @@ def mon_autofreq():
         print("Battery is: discharging")
         print("Suggesting use of \"powersave\" governor\nCurrently using:", gov_state)
         mon_powersave()
+    # temp fix for https://github.com/giampaolo/psutil/issues/1658
+    elif bat_state == None:
+        print("Couldn't determine battery status. Supposing battery is: charging")
+        print("Suggesting use of \"performance\" governor\nCurrently using:", gov_state)
+        mon_performance()
     else:
-        print("Couldn't detrmine battery status. Please report this issue.")
+        print("Couldn't determine battery status. Please report this issue.")
     
 # get system information
 def sysinfo():

--- a/auto-cpufreq.py
+++ b/auto-cpufreq.py
@@ -33,8 +33,6 @@ gov_state = get_cur_gov.split()[0]
 # get battery state
 bat_state = power.PowerManagement().get_providing_power_source_type()
 
-
-
 # auto-cpufreq log file
 auto_cpufreq_log_file = "/var/log/auto-cpufreq.log"
 

--- a/auto-cpufreq.py
+++ b/auto-cpufreq.py
@@ -249,6 +249,7 @@ def set_autofreq():
     # temp fix for https://github.com/giampaolo/psutil/issues/1658
     elif bat_state == None:
         print("Couldn't determine battery status. Supposing battery is: charging")
+        set_performance()
     else:
         print("Couldn't determine battery status. Please report this issue.")
 

--- a/auto-cpufreq.py
+++ b/auto-cpufreq.py
@@ -11,6 +11,7 @@ import time
 import psutil
 import platform
 import click
+import power
 
 # ToDo:
 # - re-enable CPU fan speed display and make more generic and not only for thinkpad
@@ -30,7 +31,9 @@ get_cur_gov = s.getoutput("cpufreqctl --governor")
 gov_state = get_cur_gov.split()[0]
 
 # get battery state
-bat_state = p.sensors_battery().power_plugged
+bat_state = power.PowerManagement().get_providing_power_source_type()
+
+
 
 # auto-cpufreq log file
 auto_cpufreq_log_file = "/var/log/auto-cpufreq.log"
@@ -237,20 +240,16 @@ def set_autofreq():
     print("\n" + "-" * 28 + " CPU frequency scaling " + "-" * 28 + "\n")
 
     # get battery state
-    bat_state = p.sensors_battery().power_plugged
+    bat_state = power.PowerManagement().get_providing_power_source_type()
 
     # determine which governor should be used
-    if bat_state == True:
+    if bat_state == power.POWER_TYPE_AC:
         print("Battery is: charging")
         set_performance()
-    elif bat_state == False:
+    elif bat_state == power.POWER_TYPE_BATTERY:
         print("Battery is: discharging")
         set_powersave()
-    # temp fix for https://github.com/giampaolo/psutil/issues/1658
-    elif bat_state == None:
-        print("Couldn't determine battery status. Supposing battery is: charging")
-        set_performance()
-    else:
+    else: 
         print("Couldn't determine battery status. Please report this issue.")
 
 # make cpufreq suggestions
@@ -258,22 +257,17 @@ def mon_autofreq():
     print("\n" + "-" * 28 + " CPU frequency scaling " + "-" * 28 + "\n")
 
     # get battery state
-    bat_state = p.sensors_battery().power_plugged
+    bat_state = power.PowerManagement().get_providing_power_source_type()
 
     # determine which governor should be used
-    if bat_state == True:
+    if bat_state == power.POWER_TYPE_AC:
         print("Battery is: charging")
         print("Suggesting use of \"performance\" governor\nCurrently using:", gov_state)
         mon_performance()
-    elif bat_state == False:
+    elif bat_state == power.POWER_TYPE_BATTERY:
         print("Battery is: discharging")
         print("Suggesting use of \"powersave\" governor\nCurrently using:", gov_state)
         mon_powersave()
-    # temp fix for https://github.com/giampaolo/psutil/issues/1658
-    elif bat_state == None:
-        print("Couldn't determine battery status. Supposing battery is: charging")
-        print("Suggesting use of \"performance\" governor\nCurrently using:", gov_state)
-        mon_performance()
     else:
         print("Couldn't determine battery status. Please report this issue.")
     


### PR DESCRIPTION
psutil method `sensors_battery().power_plugged` doesn't always give accurate information of power source. I think it takes into account the charging the battery status. If battery is 100%, this method returns `None` for me. But with the `power` utility, the measuring of the AC-battery status is more accurate.