### PR TITLE
Modified fixed cpu usage percentage 

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -303,7 +303,7 @@ def set_powersave():
     if load1m > CPUS / 7:
         print("High load, setting turbo boost: on")
         turbo(True)
-    elif cpuload > 25:
+    elif cpuload > 100 / CPUS:
         print("High CPU load, setting turbo boost: on")
         turbo(True)
     else:
@@ -331,7 +331,7 @@ def mon_powersave():
             print("Currently turbo boost is: off")
         footer()
 
-    elif cpuload > 25:
+    elif cpuload > 100 / CPUS:
         print("High CPU load, suggesting to set turbo boost: on")
         if turbo():
             print("Currently turbo boost is: on")

--- a/source/core.py
+++ b/source/core.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import time
 import warnings
+from math import isclose
 from pathlib import Path
 from pprint import pformat
 from subprocess import getoutput, call, run
@@ -303,7 +304,7 @@ def set_powersave():
     if load1m > CPUS / 7:
         print("High load, setting turbo boost: on")
         turbo(True)
-    elif cpuload > 100 / CPUS:
+    elif psutil.cpu_percent(percpu=False) >= 25.0 or isclose(max(psutil.cpu_percent(percpu=True)), 100):
         print("High CPU load, setting turbo boost: on")
         turbo(True)
     else:
@@ -331,7 +332,7 @@ def mon_powersave():
             print("Currently turbo boost is: off")
         footer()
 
-    elif cpuload > 100 / CPUS:
+    elif psutil.cpu_percent(percpu=False) >= 25.0 or isclose(max(psutil.cpu_percent(percpu=True)), 100):
         print("High CPU load, suggesting to set turbo boost: on")
         if turbo():
             print("Currently turbo boost is: on")
@@ -364,7 +365,7 @@ def set_performance():
     if load1m >= CPUS / 5:
         print("High load, setting turbo boost: on")
         turbo(True)
-    elif cpuload > 100 / (CPUS * 2):
+    elif psutil.cpu_percent(percpu=False) >= 15.0 or isclose(max(psutil.cpu_percent(percpu=True)), 100):
         print("High CPU load, setting turbo boost: on")
         turbo(True)
     else:

--- a/source/core.py
+++ b/source/core.py
@@ -364,7 +364,7 @@ def set_performance():
     if load1m >= CPUS / 5:
         print("High load, setting turbo boost: on")
         turbo(True)
-    elif cpuload > 20:
+    elif cpuload > 100 / (CPUS * 2):
         print("High CPU load, setting turbo boost: on")
         turbo(True)
     else:


### PR DESCRIPTION
Turbo should be enabled when one thread reach 100% of usage, in original version there was a fixed value of 25%, but this only works when there're 4 threads, in CPUs with more threads 

Reference: #98 