### PR TITLE
Improved turbo trigger on 1 core 100% load and on load average >1m wh…

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -301,10 +301,10 @@ def set_powersave():
     print("Total system load:", load1m, "\n")
 
     # conditions for setting turbo in powersave
-    if load1m > CPUS / 7:
+    if load1m > (15*CPUS)/100: 
         print("High load, setting turbo boost: on")
         turbo(True)
-    elif psutil.cpu_percent(percpu=False) >= 25.0 or isclose(max(psutil.cpu_percent(percpu=True)), 100):
+    elif psutil.cpu_percent(percpu=False, interval=0.01) >= 25.0 or isclose(max(psutil.cpu_percent(percpu=True, interval=0.01)), 100):
         print("High CPU load, setting turbo boost: on")
         turbo(True)
     else:
@@ -324,15 +324,14 @@ def mon_powersave():
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m, "\n")
 
-    if load1m > CPUS / 7:
+    if load1m > (15*CPUS)/100:
         print("High load, suggesting to set turbo boost: on")
         if turbo():
             print("Currently turbo boost is: on")
         else:
             print("Currently turbo boost is: off")
         footer()
-
-    elif psutil.cpu_percent(percpu=False) >= 25.0 or isclose(max(psutil.cpu_percent(percpu=True)), 100):
+    elif psutil.cpu_percent(percpu=False, interval=0.01) >= 25.0 or isclose(max(psutil.cpu_percent(percpu=True, interval=0.01)), 100):
         print("High CPU load, suggesting to set turbo boost: on")
         if turbo():
             print("Currently turbo boost is: on")
@@ -362,10 +361,10 @@ def set_performance():
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m, "\n")
 
-    if load1m >= CPUS / 5:
+    if load1m >= (10*CPUS)/100:
         print("High load, setting turbo boost: on")
         turbo(True)
-    elif psutil.cpu_percent(percpu=False) >= 15.0 or isclose(max(psutil.cpu_percent(percpu=True)), 100):
+    elif psutil.cpu_percent(percpu=False, interval=0.01) >= 15.0 or isclose(max(psutil.cpu_percent(percpu=True, interval=0.01)), 100):
         print("High CPU load, setting turbo boost: on")
         turbo(True)
     else:


### PR DESCRIPTION
I've included last @Red-Eyed code suggestion, and also included an optimization for detect correct load when there are more than 8 CPUS (now based on percentage).

I've checked the results with geekbench with charging state and battery. Turbo gets enabled and disabled fast (some times when the system get very high load takes a bit to get disabled).

Based on geekbench results, I'm getting very good results: https://browser.geekbench.com/v5/cpu/search?page=1&q=3700u&utf8=%E2%9C%93

![batterymode](https://user-images.githubusercontent.com/70445358/92047112-8faa7380-ed84-11ea-8712-96a106fe29ba.png)
![performance](https://user-images.githubusercontent.com/70445358/92047117-91743700-ed84-11ea-87ea-049d415b6398.png)

Please take a look, maybe some parameters could be improved a bit, but for me works really well.