### PR TITLE
System-info fixes with offline cpus

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -469,7 +469,10 @@ def sysinfo():
             line = f.readline()
 
     # get cores count
-    cpu_count = psutil.cpu_count()
+    cpu_count = psutil.cpu_count(logical=True)
+    phys_cpu_count = psutil.cpu_count(logical=False)
+    cpu_count = psutil.cpu_count(logical=True)
+    threads_per_core = cpu_count // phys_cpu_count
     print("Cores:", cpu_count)
 
     # get architecture
@@ -480,53 +483,37 @@ def sysinfo():
     driver = getoutput("cpufreqctl --driver")
     print("Driver: " + driver)
 
-
     print("\n" + "-" * 30 + " Current CPU states " + "-" * 30 + "\n")
     print(f"CPU max frequency: {psutil.cpu_freq().max:.0f} MHz")
-    print(f"CPU min frequency: {psutil.cpu_freq().min:.0f} MHz")
+    print(f"CPU min frequency: {psutil.cpu_freq().min:.0f} MHz\n")
 
-    core_usage = psutil.cpu_freq(percpu=True)
-
-    print("\nCPU frequency for each core:\n")
-    core_num = 0
-    while core_num < cpu_count:
-        print(f"CPU{core_num}: {core_usage[core_num].current:.0f} MHz")
-        core_num += 1
-
-    # get number of core temp sensors
-    core_temp_num = psutil.cpu_count(logical=False)
     # get hardware temperatures
-    core_temp = psutil.sensors_temperatures()
+    core_temp = psutil.sensors_temperatures()    
+    temp_per_core = [float("nan")] * cpu_count
+    try:
+        if "coretemp" in core_temp:
+            # list labels in 'coretemp'
+            core_temp_labels = [temp.label for temp in core_temp['coretemp']]
+            for core_num in range(phys_cpu_count):
+                # get correct index in core_temp
+                core_temp_index = core_temp_labels.index(f'Core {core_num}')
+                for thread in range(threads_per_core):
+                    temp_per_core[core_num * threads_per_core + thread] = core_temp['coretemp'][core_temp_index].current
+        elif "k10temp" in core_temp:
+            # https://www.kernel.org/doc/Documentation/hwmon/k10temp
+            temp_per_core = [core_temp['k10temp'][0].current] * cpu_count
+        elif "acpitz" in core_temp:
+            temp_per_core = [core_temp['acpitz'][0].current] * cpu_count
+    except:
+        pass
 
-    print("\nCPU usage per each core:\n")
+    # get usage and freq info for all cores
     usage_per_core = psutil.cpu_percent(interval=1, percpu=True)
+    freq_per_core = [freq_obj.current for freq_obj in psutil.cpu_freq(percpu=True)]
 
-    for core_num in range(len(usage_per_core)):
-        print(f"CPU{core_num}: {usage_per_core[core_num]} %")
-        core_num += 1
-
-    # get number of core temp sensors
-    core_temp_num = psutil.cpu_count(logical=False)
-    # get hardware temperatures
-    core_temp = psutil.sensors_temperatures()
-
-    print("\nTemperature for each physical core:\n")
-    core_num = 0
-    while core_num < core_temp_num:
-        temp = float("nan")
-        try:
-            if "coretemp" in core_temp:
-                temp = core_temp['coretemp'][core_num].current
-            elif "k10temp" in core_temp:
-                # https://www.kernel.org/doc/Documentation/hwmon/k10temp
-                temp = core_temp['k10temp'][0].current
-            elif "acpitz" in core_temp:
-                temp = core_temp['acpitz'][0].current
-        except:
-            pass
-
-        print(f"CPU{core_num} temp: {temp:.0f}°C")
-        core_num += 1
+    print('Core\t Usage     Frequency    Temperature')
+    for (num, usage, freq, temp) in zip(range(cpu_count), usage_per_core, freq_per_core, temp_per_core):
+        print(f"CPU{num}:\t{usage:>5.1f}%    {freq:>5.0f} MHz    {temp:>3.0f} °C")
 
     # print current fan speed | temporarily commented
     # current_fans = psutil.sensors_fans()['thinkpad'][0].current

--- a/source/core.py
+++ b/source/core.py
@@ -520,9 +520,9 @@ def sysinfo():
     except:
         pass
 
-    print("Core\t Usage     Frequency    Temperature")
+    print("\t Usage  Temperature  Frequency")
     for (cpu, usage, freq, temp) in zip(cpu_core, usage_per_cpu, freq_per_cpu, temp_per_cpu):
-        print(f"CPU{cpu}:\t{usage:>5.1f}%    {freq:>5.0f} MHz    {temp:>3.0f} °C")
+        print(f"CPU{cpu}:\t{usage:>5.1f}%    {temp:>3.0f} °C    {freq:>5.0f} MHz")
 
     if offline_cpus:
         print(f"\nDisabled CPUs: {','.join(offline_cpus)}")

--- a/source/core.py
+++ b/source/core.py
@@ -460,14 +460,12 @@ def sysinfo():
     """
 
     # processor_info
-    model_name = getoutput('egrep "model name" /proc/cpuinfo -m 1').split(':')[-1].strip()
-    print(f'Procesor: {model_name}')
+    model_name = getoutput("egrep 'model name' /proc/cpuinfo -m 1").split(":")[-1]
+    print(f"Procesor:{model_name}")
 
-    # get cores count
-    cpu_count = psutil.cpu_count(logical=True)
-    phys_cpu_count = psutil.cpu_count(logical=False)
-    threads_per_core = cpu_count // phys_cpu_count
-    print("Cores:", cpu_count)
+    # get core count
+    total_cpu_count = int(getoutput("nproc --all"))
+    print("Cores:", total_cpu_count)
 
     # get architecture
     cpu_arch = pl.machine()
@@ -481,34 +479,47 @@ def sysinfo():
     print(f"CPU max frequency: {psutil.cpu_freq().max:.0f} MHz")
     print(f"CPU min frequency: {psutil.cpu_freq().min:.0f} MHz\n")
 
-    # get hardware temperatures
-    core_temp = psutil.sensors_temperatures()    
-    temp_per_core = [float("nan")] * cpu_count
+    # get coreid's of online cpus by parsing /proc/cpuinfo
+    coreid_info = getoutput("egrep 'processor|core id' /proc/cpuinfo").split("\n")
+    cpu_core = dict()
+    for i in range(0, len(coreid_info), 2):
+        cpu = int(coreid_info[i].split(':')[-1])
+        core = int(coreid_info[i + 1].split(':')[-1])
+        cpu_core[cpu] = core
+
+    online_cpu_count = len(cpu_core)
+    offline_cpus = [str(cpu) for cpu in range(total_cpu_count) if cpu not in cpu_core]
+
+    # temperatures
+    core_temp = psutil.sensors_temperatures()
+    temp_per_cpu = [float("nan")] * online_cpu_count
     try:
         if "coretemp" in core_temp:
             # list labels in 'coretemp'
-            core_temp_labels = [temp.label for temp in core_temp['coretemp']]
-            for core_num in range(phys_cpu_count):
+            core_temp_labels = [temp.label for temp in core_temp["coretemp"]]
+            for i, cpu in enumerate(cpu_core):
                 # get correct index in core_temp
-                core_temp_index = core_temp_labels.index(f'Core {core_num}')
-                for thread in range(threads_per_core):
-                    temp_per_core[core_num * threads_per_core + thread] = core_temp['coretemp'][core_temp_index].current
+                core = cpu_core[cpu]
+                cpu_temp_index = core_temp_labels.index(f"Core {core}")
+                temp_per_cpu[i] = core_temp["coretemp"][cpu_temp_index].current
         elif "k10temp" in core_temp:
             # https://www.kernel.org/doc/Documentation/hwmon/k10temp
-            temp_per_core = [core_temp['k10temp'][0].current] * cpu_count
+            temp_per_cpu = [core_temp["k10temp"][0].current] * online_cpu_count
         elif "acpitz" in core_temp:
-            temp_per_core = [core_temp['acpitz'][0].current] * cpu_count
+            temp_per_cpu = [core_temp["acpitz"][0].current] * online_cpu_count
     except:
         pass
 
-    # get usage and freq info for all cores
-    usage_per_core = psutil.cpu_percent(interval=1, percpu=True)
-    freq_per_core = [freq_obj.current for freq_obj in psutil.cpu_freq(percpu=True)]
+    # get usage and freq info of cpus
+    usage_per_cpu = psutil.cpu_percent(interval=1, percpu=True)
+    freq_per_cpu = [freq_obj.current for freq_obj in psutil.cpu_freq(percpu=True)]
 
-    print('Core\t Usage     Frequency    Temperature')
-    for (num, usage, freq, temp) in zip(range(cpu_count), usage_per_core, freq_per_core, temp_per_core):
-        print(f"CPU{num}:\t{usage:>5.1f}%    {freq:>5.0f} MHz    {temp:>3.0f} °C")
+    print("Core\t Usage     Frequency    Temperature")
+    for (cpu, usage, freq, temp) in zip(cpu_core, usage_per_cpu, freq_per_cpu, temp_per_cpu):
+        print(f"CPU{cpu}:\t{usage:>5.1f}%    {freq:>5.0f} MHz    {temp:>3.0f} °C")
 
+    if offline_cpus:
+        print(f"\nDisabled CPUs: {','.join(offline_cpus)}")
     # print current fan speed | temporarily commented
     # current_fans = psutil.sensors_fans()['thinkpad'][0].current
     # print("\nCPU fan speed:", current_fans, "RPM")

--- a/source/core.py
+++ b/source/core.py
@@ -471,7 +471,6 @@ def sysinfo():
     # get cores count
     cpu_count = psutil.cpu_count(logical=True)
     phys_cpu_count = psutil.cpu_count(logical=False)
-    cpu_count = psutil.cpu_count(logical=True)
     threads_per_core = cpu_count // phys_cpu_count
     print("Cores:", cpu_count)
 

--- a/source/core.py
+++ b/source/core.py
@@ -459,8 +459,9 @@ def sysinfo():
     get system information
     """
 
-    # processor_info, looks for first match of "model name"
-    print(getoutput('egrep "model name" /proc/cpuinfo -m 1'))
+    # processor_info
+    model_name = getoutput('egrep "model name" /proc/cpuinfo -m 1').split(':')[-1].strip()
+    print(f'Procesor: {model_name}')
 
     # get cores count
     cpu_count = psutil.cpu_count(logical=True)

--- a/source/core.py
+++ b/source/core.py
@@ -459,14 +459,8 @@ def sysinfo():
     get system information
     """
 
-    # processor_info
-    with open("/proc/cpuinfo", "r")  as f:
-        line = f.readline()
-        while line:
-            if "model name" in line:
-                print("Processor:" + line.split(':')[1].rstrip())
-                break
-            line = f.readline()
+    # processor_info, looks for first match of "model name"
+    print(getoutput('egrep "model name" /proc/cpuinfo -m 1'))
 
     # get cores count
     cpu_count = psutil.cpu_count(logical=True)


### PR DESCRIPTION
Partially addresses #119.

Fixed total core number reporting, cpu numbering and temperatures, and now disabled cores are reported if any. Also tried sticking to the core/cpu definitions in linux topology tooling for variable naming this time.

What do you think, should we report real overall max and min frequencies, or report these frequency limits for each core? 


Current output looks like this:
-------------------------------------------------------------------------------

Linux distro: Manjaro Linux 20.1 Mikah
Linux kernel: 5.8.6-1-MANJARO

Procesor: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Cores: 12
Architecture: x86_64
Driver: intel_pstate

------------------------------ Current CPU states ------------------------------

CPU max frequency: 4078 MHz
CPU min frequency: 800 MHz

Core	 Usage     Frequency    Temperature
CPU0:	 23.5%      800 MHz     51 °C
CPU1:	 23.0%      800 MHz     52 °C
CPU3:	 21.8%     1090 MHz     51 °C
CPU4:	 19.8%      800 MHz     51 °C
CPU5:	 22.0%      800 MHz     51 °C
CPU8:	 22.3%      800 MHz     49 °C
CPU9:	 21.6%     4398 MHz     51 °C
CPU10:	 19.8%      800 MHz     51 °C
CPU11:	 22.5%      800 MHz     51 °C

Disabled CPUs: 2,6,7

---------------------------- CPU frequency scaling ----------------------------

Battery is: discharging

Setting to use: "powersave" governor
/usr/bin/cpufreqctl: line 143: echo: write error: Invalid argument
/usr/bin/cpufreqctl: line 143: echo: write error: Invalid argument
/usr/bin/cpufreqctl: line 143: echo: write error: Invalid argument
/usr/bin/cpufreqctl: line 267: echo: write error: Invalid argument
/usr/bin/cpufreqctl: line 267: echo: write error: Invalid argument
/usr/bin/cpufreqctl: line 267: echo: write error: Invalid argument
Setting to use: "balance_power" EPP

Total CPU usage: 20.3 %
Total system load: 2.09 

High load, setting turbo boost: on

-------------------------------------------------------------------------------
