### PR TITLE
Rewrote charging check function

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -117,8 +117,8 @@ def charging():
     # Possible values: Charging, Discharging, Unknown
     battery_info = getoutput(f"grep . {power_dir}BAT*/status")
 
-    # need to explicitly check for each state,
-    # one could appear while others ccouldn't deppending on firmware
+    # need to explicitly check for each state in this order
+    # considering multiple batteries
     if "Discharging" in battery_info:
         battery_state = False
     elif "Charging" in battery_info:


### PR DESCRIPTION
Adresses #85  and #108.

The solution I opted for was reading from AC-adapters and laptop batteries in /sys/class/power_supply/. With some configurations this can become a tad messy however (altho there's no other way to do this automatically afaik). Psutil actually reads from this directory, but it doesn't take into account some scenarios.

Looking into it I've seen the following kind of devices in this directory:

**AC Adapters**
- ACAD
- AC
- AC0
- ADP0
- ADP1

**Laptop Batteries**
- BAT0
- BAT1

**Peripheral Batteries** (mice, etc)
- hidpp_battery
- hidpp_battery_2
- battery_hid_somethingsomethingsomething_battery

There is also the case where a laptop has two ac-adapters and/or two batteries, and the case where the kernel can't properly read battery and/or ac-adapter information due to firmware issues. Which while investigating, turned out to be the case for my own laptop:

dmesg:
battery: ACPI: Battery Slot [BAT1] (battery present)
battery: [Firmware Bug]: battery: (dis)charge rate invalid.

Resulting in battery status 'Unknown' (when battery fully charged), and also psutil wrongly deciding it's charging state.

In the "weird" case that both ac-adapter and battery status are unknown by the kernel the function defaults to returning False which I thought appropriate (erring on the safe side). Also opted for using grep's output, because it looked too messy doing it with python.

I'd like your opinion on these liberties I've taken. Also I'd like some verification on other machines.