### PR TITLE
Adds OpenSUSE Tumbleweed to detected distributions

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -100,6 +100,21 @@ then
     separator
     complete_msg
     separator
+# OpenSUSE Tumbleweed
+elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [ $ID == "opensuse-tumbleweed" ];
+then
+    separator
+    echo -e "\nDetected OpenSUSE Tumbleweed distribution\n"
+    echo -e "\nSetting up Python environment\n"
+    zypper install python38 python3-pip python3-setuptools
+    echo -e "\nInstalling necessary Python packages\n"
+    pip_pkg_install
+    separator
+    echo -e "\ninstalling auto-cpufreq tool\n"
+    install
+    separator
+    complete_msg
+    separator
 # Other
 else
     separator


### PR DESCRIPTION
Hi all,
I added the detection of the OpenSUSE Tumbleweed distribution to the installer script as I'm using a laptop with it and I wanted to install auto-cpufreq.

I used this commit to install it, it shouldn't give problems to others using the same distro.