### PR TITLE
Improves opensuse detection

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -101,12 +101,17 @@ then
     complete_msg
     separator
 # OpenSUSE Tumbleweed
-elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [ $ID == "opensuse-tumbleweed" ];
+elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [[ $ID == "opensuse"* ]];
 then
     separator
-    echo -e "\nDetected OpenSUSE Tumbleweed distribution\n"
+    echo -e "\nDetected an OpenSUSE distribution\n"
     echo -e "\nSetting up Python environment\n"
-    zypper install python38 python3-pip python3-setuptools
+    if [[ $ID == "opensuse-leap" ]];
+    then
+        zypper install -y python3 python3-pip python3-setuptools python3-devel gcc
+    else
+        zypper install python38 python3-pip python3-setuptools
+    fi
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
     separator

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -100,7 +100,7 @@ then
     separator
     complete_msg
     separator
-# OpenSUSE Tumbleweed
+# OpenSUSE
 elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [[ $ID == "opensuse"* ]];
 then
     separator

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -110,7 +110,7 @@ then
     then
         zypper install -y python3 python3-pip python3-setuptools python3-devel gcc
     else
-        zypper install python38 python3-pip python3-setuptools
+        zypper install -y python38 python3-pip python3-setuptools python3-devel gcc
     fi
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install


### PR DESCRIPTION
Hi, I managed to create a VM and install opensuse leap, so I made this changes to install auto-cpufreq without errors:
* Adds detection of openSUSE Leap by using a regexp when checking for the distribution ID.
* Adds `python3-devel` and `gcc` packages to be installed with zypper, as a new OS Leap install does not include them, they are also added to tumbleweed to be sure they are present (and for symmetry, too).
* Changes the bash comment to include both Tumbleweed and Leap version of openSUSE.