### PR TITLE
Improve logging & prevent log size growth 

### DIFF
--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -31,6 +31,7 @@ def main(monitor, live, daemon, install, log, debug):
     else:
         # Important: order does matter
         if daemon:
+            file_logging()
             if os.getenv("PKG_MARKER") == "SNAP" and dcheck == "enabled":
                 while True:
                     root_check()
@@ -41,7 +42,6 @@ def main(monitor, live, daemon, install, log, debug):
                     sysinfo()
                     set_autofreq()
                     countdown(5)
-                    run("clear")
             elif os.getenv("PKG_MARKER") != "SNAP":
                 while True:
                     root_check()
@@ -52,7 +52,6 @@ def main(monitor, live, daemon, install, log, debug):
                     sysinfo()
                     set_autofreq()
                     countdown(5)
-                    run("clear")
             else:
                 daemon_not_found()
         elif monitor:
@@ -66,7 +65,6 @@ def main(monitor, live, daemon, install, log, debug):
                 sysinfo()
                 mon_autofreq()
                 countdown(5)
-                run("clear")
         elif live:
             while True:
                 root_check()
@@ -78,7 +76,6 @@ def main(monitor, live, daemon, install, log, debug):
                 sysinfo()
                 set_autofreq()
                 countdown(5)
-                run("clear")
         elif log:
             read_log()
         elif debug:

--- a/scripts/auto-cpufreq.service
+++ b/scripts/auto-cpufreq.service
@@ -1,12 +1,10 @@
 [Unit]
 Description=auto-cpufreq - Automatic CPU speed & power optimizer for Linux
 After=network.target network-online.target
-ConditionPathExists=/var/log/auto-cpufreq.log
 
 [Service]
 Type=simple
 User=root
 ExecStart=/usr/local/bin/auto-cpufreq --daemon
-StandardOutput=append:/var/log/auto-cpufreq.log
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Now auto-cpufreq will write directly to the logfile (if running as a daemon) or stdout.
The file (instead of just stdout) will automatically be cleared when on each refresh.

I am not that experienced with python and did test this for a decent while.