### PR TITLE
Improve domain language around logging and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Necessary changes are temporarily made to the system which are lost with system 
 
 ### Install - auto-cpufreq daemon
 
-Necessary changes are made to the system for auto-cpufreq CPU optimizaton to persist across reboots. Daemon is deployed and then started as a systemd service. Changes are made automatically and live log is made for monitoring purposes.
+Necessary changes are made to the system for auto-cpufreq CPU optimizaton to persist across reboots. Daemon is deployed and then started as a systemd service. Changes are made automatically and live stats are generated for monitoring purposes.
 
 `sudo auto-cpufreq --install`
 
-After daemon is installed, `auto-cpufreq` is available as a binary and is running in the background. Its logs can be viewed by running: `auto-cpufreq --log`
+After daemon is installed, `auto-cpufreq` is available as a binary and is running in the background. Its stats can be viewed by running: `auto-cpufreq --stats`
 
 Since daemon is running as a systemd service, its status can be seen by running:
 
@@ -115,11 +115,11 @@ auto-cpufreq daemon and its systemd service, along with all its persistent chang
 
 `sudo auto-cpufreq --remove`
 
-### Log
+### Stats
 
-If daemon has been instaled, live log of CPU/system load monitoring and optimizaiton can be seen by running:
+If daemon has been installed, live stats of CPU/system load monitoring and optimization can be seen by running:
 
-`auto-cpufreq --log`
+`auto-cpufreq --stats`
 
 ## Discussion:
 

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -168,7 +168,7 @@ files="files.txt"
 share_dir="/usr/local/share/auto-cpufreq/"
 srv_install="/usr/bin/auto-cpufreq-install"
 srv_remove="/usr/bin/auto-cpufreq-remove"
-log_file="/var/log/auto-cpufreq.log"
+stats_file="/var/log/auto-cpufreq.log"
 tool_proc_rm="auto-cpufreq --remove"
 
 # stop any running auto-cpufreq argument (daemon/live/monitor)
@@ -192,7 +192,7 @@ fi
 # files cleanup
 [ -f $srv_install ] && rm $srv_install
 [ -f $srv_remove ] && rm $srv_remove
-[ -f $log_file ] && rm $log_file
+[ -f $stats_file ] && rm $stats_file
 
 separator
 echo -e "\nauto-cpufreq tool and all its supporting files successfully removed."

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -748,7 +748,7 @@ def sysinfo():
     except:
         pass
 
-    print("\t Usage  Temperature  Frequency")
+    print("Core\tUsage\tTemperature\tFrequency")
     for (cpu, usage, freq, temp) in zip(cpu_core, usage_per_cpu, freq_per_cpu, temp_per_cpu):
         print(f"CPU{cpu}:\t{usage:>5.1f}%    {temp:>3.0f} °C    {freq:>5.0f} MHz")
 

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -16,10 +16,10 @@ from auto_cpufreq.core import *
 @click.option("--monitor", is_flag=True, help="Monitor and see suggestions for CPU optimizations")
 @click.option("--live", is_flag=True, help="Monitor and make (temp.) suggested CPU optimizations")
 @click.option("--install/--remove", default=True, help="Install/remove daemon for (permanent) automatic CPU optimizations")
-@click.option("--log", is_flag=True, help="View live CPU optimization log made by daemon")
+@click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--daemon", is_flag=True, hidden=True)
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
-def main(monitor, live, daemon, install, log, debug):
+def main(monitor, live, daemon, install, stats, debug):
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
@@ -31,7 +31,7 @@ def main(monitor, live, daemon, install, log, debug):
     else:
         # Important: order does matter
         if daemon:
-            file_logging()
+            file_stats()
             if os.getenv("PKG_MARKER") == "SNAP" and dcheck == "enabled":
                 while True:
                     root_check()
@@ -77,7 +77,7 @@ def main(monitor, live, daemon, install, log, debug):
                 set_autofreq()
                 countdown(5)
         elif log:
-            read_log()
+            read_stats()
         elif debug:
             root_check()
             footer()
@@ -121,8 +121,8 @@ def main(monitor, live, daemon, install, log, debug):
                 root_check()
                 run("snapctl set daemon=disabled", shell=True)
                 run("snapctl stop --disable auto-cpufreq", shell=True)
-                if auto_cpufreq_log_file.exists():
-                    auto_cpufreq_log_file.unlink()
+                if auto_cpufreq_stats_file.exists():
+                    auto_cpufreq_stats_file.unlink()
                 remove_complete_msg()
             else:
                 root_check()


### PR DESCRIPTION
This PR attempts to improve the logging/stats domain names as per #156:
* renames all stdout occurrences of `log` to `stats`
* update all code references accordingly
* rename `.log` file to `.stats`
* move the stats file from `/var/log` to `/var/run`