### PR TITLE
Improve domain language around logging and stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # snap
 *.snap
+
+# pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Necessary changes are temporarily made to the system which are lost with system 
 
 ### Install - auto-cpufreq daemon
 
-Necessary changes are made to the system for auto-cpufreq CPU optimizaton to persist across reboots. Daemon is deployed and then started as a systemd service. Changes are made automatically and live log is made for monitoring purposes.
+Necessary changes are made to the system for auto-cpufreq CPU optimizaton to persist across reboots. Daemon is deployed and then started as a systemd service. Changes are made automatically and live stats are generated for monitoring purposes.
 
 `sudo auto-cpufreq --install`
 
-After daemon is installed, `auto-cpufreq` is available as a binary and is running in the background. Its logs can be viewed by running: `auto-cpufreq --log`
+After daemon is installed, `auto-cpufreq` is available as a binary and is running in the background. Its stats can be viewed by running: `auto-cpufreq --stats`
 
 Since daemon is running as a systemd service, its status can be seen by running:
 
@@ -115,11 +115,11 @@ auto-cpufreq daemon and its systemd service, along with all its persistent chang
 
 `sudo auto-cpufreq --remove`
 
-### Log
+### Stats
 
-If daemon has been instaled, live log of CPU/system load monitoring and optimizaiton can be seen by running:
+If daemon has been installed, live stats of CPU/system load monitoring and optimization can be seen by running:
 
-`auto-cpufreq --log`
+`auto-cpufreq --stats`
 
 ## Discussion:
 

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -168,7 +168,7 @@ files="files.txt"
 share_dir="/usr/local/share/auto-cpufreq/"
 srv_install="/usr/bin/auto-cpufreq-install"
 srv_remove="/usr/bin/auto-cpufreq-remove"
-log_file="/var/log/auto-cpufreq.log"
+stats_file="/var/log/auto-cpufreq.log"
 tool_proc_rm="auto-cpufreq --remove"
 
 # stop any running auto-cpufreq argument (daemon/live/monitor)
@@ -192,7 +192,7 @@ fi
 # files cleanup
 [ -f $srv_install ] && rm $srv_install
 [ -f $srv_remove ] && rm $srv_remove
-[ -f $log_file ] && rm $log_file
+[ -f $stats_file ] && rm $stats_file
 
 separator
 echo -e "\nauto-cpufreq tool and all its supporting files successfully removed."

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -168,7 +168,7 @@ files="files.txt"
 share_dir="/usr/local/share/auto-cpufreq/"
 srv_install="/usr/bin/auto-cpufreq-install"
 srv_remove="/usr/bin/auto-cpufreq-remove"
-stats_file="/var/log/auto-cpufreq.log"
+stats_file="/var/run/auto-cpufreq.stats"
 tool_proc_rm="auto-cpufreq --remove"
 
 # stop any running auto-cpufreq argument (daemon/live/monitor)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -38,22 +38,22 @@ CPUS = os.cpu_count()
 powersave_load_threshold = (75*CPUS)/100
 performance_load_threshold = (50*CPUS)/100
 
-# auto-cpufreq log file path
-auto_cpufreq_log_path = None
-auto_cpufreq_log_file = None
+# auto-cpufreq stats file path
+auto_cpufreq_stats_path = None
+auto_cpufreq_stats_file = None
 
 if os.getenv("PKG_MARKER") == "SNAP":
-    auto_cpufreq_log_path = Path("/var/snap/auto-cpufreq/current/auto-cpufreq.log")
+    auto_cpufreq_stats_path = Path("/var/snap/auto-cpufreq/current/auto-cpufreq.log")
 else:
-    auto_cpufreq_log_path = Path("/var/log/auto-cpufreq.log")
+    auto_cpufreq_stats_path = Path("/var/log/auto-cpufreq.log")
 
 # daemon check
 dcheck = getoutput("snapctl get daemon")
 
-def file_logging():
-    global auto_cpufreq_log_file
-    auto_cpufreq_log_file = open(auto_cpufreq_log_path, "w")
-    sys.stdout = auto_cpufreq_log_file
+def file_stats():
+    global auto_cpufreq_stats_file
+    auto_cpufreq_stats_file = open(auto_cpufreq_stats_path, "w")
+    sys.stdout = auto_cpufreq_stats_file
 
 # ToDo: read version from snap/snapcraft.yaml and write to $SNAP/version for use with snap installs
 # also come up with same kind of solution for AUR
@@ -201,7 +201,7 @@ def daemon_not_found():
 
 def deploy_complete_msg():
     print("\n" + "-" * 17 + " auto-cpufreq daemon installed and running " + "-" * 17 + "\n")
-    print("To view live log, run:\nauto-cpufreq --log")
+    print("To view live stats, run:\nauto-cpufreq --stats")
     print("\nTo disable and remove auto-cpufreq daemon, run:\nsudo auto-cpufreq --remove")
     footer()
 
@@ -230,7 +230,7 @@ def deploy_daemon():
     except:
         print("\nERROR:\nWas unable to turn off bluetooth on boot")
 
-    auto_cpufreq_log_path.touch(exist_ok=True)
+    auto_cpufreq_stats_path.touch(exist_ok=True)
 
     print("\n* Deploy auto-cpufreq install script")
     shutil.copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install")
@@ -270,12 +270,12 @@ def remove():
     # remove auto-cpufreq-remove
     os.remove("/usr/bin/auto-cpufreq-remove")
 
-    # delete log file
-    if auto_cpufreq_log_path.exists():
-        if auto_cpufreq_log_file is not None:
-            auto_cpufreq_log_file.close()
+    # delete stats file
+    if auto_cpufreq_stats_path.exists():
+        if auto_cpufreq_stats_file is not None:
+            auto_cpufreq_stats_file.close()
 
-        auto_cpufreq_log_path.unlink()
+        auto_cpufreq_stats_path.unlink()
 
     # restore original cpufrectl script
     cpufreqctl_restore()
@@ -298,7 +298,7 @@ def root_check():
 
 # refresh countdown
 def countdown(s):
-    # Fix for wrong log output and "TERM environment variable not set"
+    # Fix for wrong stats output and "TERM environment variable not set"
     os.environ['TERM'] = 'xterm'
 
     for remaining in range(s, 0, -1):
@@ -307,9 +307,9 @@ def countdown(s):
         sys.stdout.flush()
         time.sleep(1)
 
-    if auto_cpufreq_log_file is not None:
-        auto_cpufreq_log_file.seek(0)
-        auto_cpufreq_log_file.truncate(0)
+    if auto_cpufreq_stats_file is not None:
+        auto_cpufreq_stats_file.seek(0)
+        auto_cpufreq_stats_file.truncate(0)
     else:
         run("clear")
 
@@ -708,7 +708,7 @@ def sysinfo():
     # max and min freqs, psutil reports wrong max/min freqs whith offline cores with percpu=False
     max_freq = max([freq.max for freq in minmax_freq_per_cpu])
     min_freq = min([freq.min for freq in minmax_freq_per_cpu])
-    print("\n" + "-" * 30 + " Current CPU states " + "-" * 30 + "\n")
+    print("\n" + "-" * 30 + " Current CPU stats " + "-" * 30 + "\n")
     print(f"CPU max frequency: {max_freq:.0f} MHz")
     print(f"CPU min frequency: {min_freq:.0f} MHz\n")
 
@@ -748,7 +748,7 @@ def sysinfo():
     except:
         pass
 
-    print("\t Usage  Temperature  Frequency")
+    print("Core\tUsage\tTemperature\tFrequency")
     for (cpu, usage, freq, temp) in zip(cpu_core, usage_per_cpu, freq_per_cpu, temp_per_cpu):
         print(f"CPU{cpu}:\t{usage:>5.1f}%    {temp:>3.0f} °C    {freq:>5.0f} MHz")
 
@@ -765,17 +765,17 @@ def sysinfo():
     # print("\nCPU fan speed:", current_fans, "RPM")
 
 
-def no_log_msg():
-    print("\n" + "-" * 30 + " auto-cpufreq log " + "-" * 31 + "\n")
-    print("ERROR: auto-cpufreq log is missing.\n\nMake sure to run: \"auto-cpufreq --install\" first")
+def no_stats_msg():
+    print("\n" + "-" * 29 + " auto-cpufreq stats " + "-" * 30 + "\n")
+    print("ERROR: auto-cpufreq stats are missing.\n\nMake sure to run: \"auto-cpufreq --install\" first")
 
-# read log func
-def read_log():
-    # readlog
-    if os.path.isfile(auto_cpufreq_log_path):
-        call(["tail", "-n 50", "-f", str(auto_cpufreq_log_path)], stderr=DEVNULL)
+# read stats func
+def read_stats():
+    # read stats
+    if os.path.isfile(auto_cpufreq_stats_path):
+        call(["tail", "-n 50", "-f", str(auto_cpufreq_stats_path)], stderr=DEVNULL)
     else:
-        no_log_msg()
+        no_stats_msg()
     footer()
 
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -205,6 +205,10 @@ def deploy_complete_msg():
     print("\nTo disable and remove auto-cpufreq daemon, run:\nsudo auto-cpufreq --remove")
     footer()
 
+def deprecated_log_msg():
+    print("\nThe --log flag has been renamed to --stats")
+    print("To view live stats, run:\nauto-cpufreq --stats")
+    footer()
 
 def remove_complete_msg():
     print("\n" + "-" * 25 + " auto-cpufreq daemon removed " + "-" * 25 + "\n")

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -43,9 +43,9 @@ auto_cpufreq_stats_path = None
 auto_cpufreq_stats_file = None
 
 if os.getenv("PKG_MARKER") == "SNAP":
-    auto_cpufreq_stats_path = Path("/var/snap/auto-cpufreq/current/auto-cpufreq.log")
+    auto_cpufreq_stats_path = Path("/var/snap/auto-cpufreq/current/auto-cpufreq.stats")
 else:
-    auto_cpufreq_stats_path = Path("/var/log/auto-cpufreq.log")
+    auto_cpufreq_stats_path = Path("/var/run/auto-cpufreq.stats")
 
 # daemon check
 dcheck = getoutput("snapctl get daemon")

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -16,10 +16,10 @@ from auto_cpufreq.core import *
 @click.option("--monitor", is_flag=True, help="Monitor and see suggestions for CPU optimizations")
 @click.option("--live", is_flag=True, help="Monitor and make (temp.) suggested CPU optimizations")
 @click.option("--install/--remove", default=True, help="Install/remove daemon for (permanent) automatic CPU optimizations")
-@click.option("--log", is_flag=True, help="View live CPU optimization log made by daemon")
+@click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--daemon", is_flag=True, hidden=True)
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
-def main(monitor, live, daemon, install, log, debug):
+def main(monitor, live, daemon, install, stats, debug):
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
@@ -31,7 +31,7 @@ def main(monitor, live, daemon, install, log, debug):
     else:
         # Important: order does matter
         if daemon:
-            file_logging()
+            file_stats()
             if os.getenv("PKG_MARKER") == "SNAP" and dcheck == "enabled":
                 while True:
                     root_check()
@@ -76,8 +76,8 @@ def main(monitor, live, daemon, install, log, debug):
                 sysinfo()
                 set_autofreq()
                 countdown(5)
-        elif log:
-            read_log()
+        elif stats:
+            read_stats()
         elif debug:
             root_check()
             footer()
@@ -121,11 +121,11 @@ def main(monitor, live, daemon, install, log, debug):
                 root_check()
                 run("snapctl set daemon=disabled", shell=True)
                 run("snapctl stop --disable auto-cpufreq", shell=True)
-                if auto_cpufreq_log_path.exists():
-                    if auto_cpufreq_log_file is not None:
-                        auto_cpufreq_log_file.close()
+                if auto_cpufreq_stats_path.exists():
+                    if auto_cpufreq_stats_file is not None:
+                        auto_cpufreq_stats_file.close()
 
-                    auto_cpufreq_log_path.unlink()
+                    auto_cpufreq_stats_path.unlink()
                 remove_complete_msg()
             else:
                 root_check()

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -17,9 +17,10 @@ from auto_cpufreq.core import *
 @click.option("--live", is_flag=True, help="Monitor and make (temp.) suggested CPU optimizations")
 @click.option("--install/--remove", default=True, help="Install/remove daemon for (permanent) automatic CPU optimizations")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
+@click.option("--log", is_flag=True, help="Deprecated flag replaced by --stats")
 @click.option("--daemon", is_flag=True, hidden=True)
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
-def main(monitor, live, daemon, install, stats, debug):
+def main(monitor, live, install, stats, log, daemon, debug):
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
@@ -78,6 +79,8 @@ def main(monitor, live, daemon, install, stats, debug):
                 countdown(5)
         elif stats:
             read_stats()
+        elif log:
+            deprecated_log_msg()
         elif debug:
             root_check()
             footer()

--- a/scripts/snapdaemon.sh
+++ b/scripts/snapdaemon.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 #
 # workaround for running Daemon without polluting syslog (#53, #82)
-$SNAP/bin/auto-cpufreq --daemon 2>&1 >> $SNAP_DATA/auto-cpufreq.log
+$SNAP/bin/auto-cpufreq --daemon 2>&1 >> $SNAP_DATA/auto-cpufreq.stats


### PR DESCRIPTION
This PR attempts to improve the logging/stats domain names as per #156:

* renames all stdout occurrences of `log` to `stats`
* update all code references accordingly
* rename `.log` file to `.stats`
* move the stats file from `/var/log` to `/var/run`
