### PR TITLE
WIP: More extensive chassis detection for laptops

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -119,14 +119,62 @@ def charging():
 
     computer_type = getoutput('dmidecode --string chassis-type')
     
-    if computer_type == "Notebook":
+    if computer_type == "Desktop":
+        ac_state = True
+    elif computer_type == "Low Profile Desktop":
+        ac_state = True
+    elif computer_type == "Tower":
+        ac_state = True
+    elif computer_type == "Mini Tower":
+        ac_state = True
+    elif computer_type == "All in One":
+        ac_state = True
+    elif computer_type == "Pizza Box":
+        ac_state = True
+    elif computer_type == "Lunch Box":
+        ac_state = True
+    elif computer_type == "Main Server Chassis":
+        ac_state = True
+    elif computer_type == "RAID Chassis":
+        ac_state = True
+    elif computer_type == "Rack Mount Chassis":
+        ac_state = True
+    elif computer_type == "Blade":
+        ac_state = True
+    elif computer_type == "Blade Enclosure":
+        ac_state = True
+    elif computer_type == "Multi-system chassis":
+        ac_state = True
+    elif computer_type == "Sealed-case PC":
+        ac_state = True
+    elif computer_type == "Mini PC":
+        ac_state = True
+    elif computer_type == "Stick PC":
+        ac_state = True
+    elif computer_type == "Embedded PC":
+        ac_state = True
+    elif computer_type == "Advanced TCA":
+        ac_state = True
+    elif computer_type == "Compact PCI":
+        ac_state = True
+    elif computer_type == "IoT Gateway":
+        ac_state = True
+    elif computer_type == "Expansion Chassis":
+        ac_state = True
+    elif computer_type == "Bus Expansion Chassis":
+        ac_state = True
+    elif computer_type == "SubChassis":
+        ac_state = True
+    elif computer_type == "Peripheral Chassis":
+        ac_state = True
+    elif computer_type == "Space-saving":
+        ac_state = True
+    else:
+        #Defaults to laptop power determination
         # AC adapter states: 0, 1, unknown
         ac_info = getoutput(f"grep . {power_dir}A*/online").splitlines()
         # if there's one ac-adapter on-line, ac_state is True
         ac_state = any(['1' in ac.split(':')[-1] for ac in ac_info])
-    else:
-        # if desktop ac_state is true
-        ac_state = True
 
     # Possible values: Charging, Discharging, Unknown
     battery_info = getoutput(f"grep . {power_dir}BAT*/status")

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -714,7 +714,7 @@ def python_info():
 def distro_info():
     dist = "UNKNOWN distro"
     version = "UNKNOWN version"
-
+ 
     # get distro information in snap env.
     if os.getenv("PKG_MARKER") == "SNAP":
         try:
@@ -734,8 +734,9 @@ def distro_info():
         # get distro information
         fdist = distro.linux_distribution()
         dist = " ".join(x for x in fdist)
-
-    print("Computer type: " + computer_type)
+        computer = getoutput('dmidecode --string chassis-type')
+    
+    print("Computer type: " + computer)
     print("Linux distro: " + dist)
     print("Linux kernel: " + pl.release())
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -687,6 +687,7 @@ def distro_info():
         fdist = distro.linux_distribution()
         dist = " ".join(x for x in fdist)
 
+    print("Computer type: " + computer_type)
     print("Linux distro: " + dist)
     print("Linux kernel: " + pl.release())
 


### PR DESCRIPTION
I think this should work. This should address issue #164 

Once again, I don't have a way to fully test it. I tried compiling from the AUR and replacing the github link in the PKGBUILD to my fork, but I couldn't get it to work. I don't have access to the pkgbuild used on the Chaotic-AUR, unfortunately, because that would likely work.

Anyways, this sets the SMBIOS Chassis types that don't have batteries to ac_state=true
This switches the if else order from pull request #163.
In the new order, the default state if a desktop is not detected is a laptop.

I also added computer type to the  auto-cpufreq --stats command. It is up to your discretion whether or not that is a worthwhile addition. I think it could be useful, but it is not necessary. 

Update to core.py fixes variable not found for computer_type in the --stats
I managed to get it to kind of run, but auto-cpufreq --stats doesn't work. Only sudo auto-cpufreq --monitor works, but that's enough to see that the issue is fixed

Links to: #166, #164