### PR TITLE
Remove pacman wildcard

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -72,7 +72,7 @@ def app_version():
         if aur_pkg_check == 1:
             print("Git commit:", check_output(["git", "describe", "--always"]).strip().decode())
         else:
-            print(getoutput("pacman -Qi auto-cpufreq* | grep Version"))
+            print(getoutput("pacman -Qi auto-cpufreq | grep Version"))
     else:        
         # source code (auto-cpufreq-installer)
         try:


### PR DESCRIPTION
```
❯ pacman -Qs auto-cpufreq
local/auto-cpufreq-git 1.6.0.r0.g0ce8311-1
    Automatic CPU speed & power optimizer
```

With wildcard:
```
auto-cpufreq version:
error: package 'auto-cpufreq*' was not found
```
```
❯ pacman -Qi auto-cpufreq* | grep Version
zsh: no matches found: auto-cpufreq*
```

Without wildcard:
```
auto-cpufreq version:
Version         : 1.6.0.r0.g0ce8311-1
```
```
❯ pacman -Qi auto-cpufreq | grep Version
Version         : 1.6.0.r0.g0ce8311-1
```

It turns out it only works with the wildcard in my `pkgbuilds` directory where `auto-cpufreq-git` lives. Weird.