### PR TITLE
Only query pacman when on arch and not a snap install.

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -60,8 +60,6 @@ dist_name = distro.id()
 # display running version of auto-cpufreq
 def app_version():
 
-    aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
-
     print("auto-cpufreq version:")
 
     # snap package
@@ -69,6 +67,7 @@ def app_version():
         print(getoutput("echo Snap: $SNAP_VERSION"))
     # aur package
     elif dist_name in ["arch", "manjaro", "garuda"]:
+        aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
         if aur_pkg_check == 1:
             print("Git commit:", check_output(["git", "describe", "--always"]).strip().decode())
         else:


### PR DESCRIPTION
This is a minor fix that prevents calling out to pacman when the package is installed with snap on arch linux.

It is a minor improvement on #171.
