### PR TITLE
Introduce initial logging infrastructure

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -54,7 +54,7 @@ function tool_install {
     echo -e "\nDetected Debian based distribution"
     separator
     echo -e "\nSetting up Python environment\n"
-    apt install python3-dev python3-pip python3-setuptools dmidecode -y
+    apt install python3-dev python3-pip python3-setuptools python3-systemd dmidecode -y
     separator
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
@@ -70,10 +70,11 @@ function tool_install {
     echo -e "\nDetected RedHat based distribution\n"
     echo -e "\nSetting up Python environment\n"
     # CentOS exception
-    if [ -f /etc/centos-release ]; then
-      yum install platform-python-devel dmidecode
+    if [ -f /etc/centos-release ];
+    then
+      yum install platform-python-devel python-systemd dmidecode
     else
-      yum install python-devel dmidecode
+      yum install python-devel python-systemd dmidecode
     fi
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
@@ -88,7 +89,7 @@ function tool_install {
     separator
     echo -e "\nDetected Solus distribution\n"
     echo -e "\nSetting up Python environment\n"
-    eopkg install pip python3 python3-devel dmidecode
+    eopkg install pip python3 python3-devel python3-systemd dmidecode
     eopkg install -c system.devel
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
@@ -104,10 +105,11 @@ function tool_install {
     separator
     echo -e "\nDetected an OpenSUSE distribution\n"
     echo -e "\nSetting up Python environment\n"
-    if [[ $ID == "opensuse-leap" ]]; then
-      zypper install -y python3 python3-pip python3-setuptools python3-devel gcc dmidecode
+    if [[ $ID == "opensuse-leap" ]];
+    then
+      zypper install -y python3 python3-pip python3-setuptools python3-devel python3-systemd gcc dmidecode
     else
-      zypper install -y python38 python3-pip python3-setuptools python3-devel gcc dmidecode
+      zypper install -y python38 python3-pip python3-setuptools python3-devel python3-systemd gcc dmidecode
     fi
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
@@ -122,7 +124,7 @@ function tool_install {
     separator
     echo -e "\nDetected an Arch Linux based distribution\n"
     echo -e "\nSetting up Python environment\n"
-    pacman -S --noconfirm python python-pip python-setuptools gcc dmidecode
+    pacman -S --noconfirm python python-pip python-setuptools python-systemd gcc dmidecode
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
     separator
@@ -137,7 +139,7 @@ function tool_install {
     separator
     echo -e "\nDidn't detect Debian or RedHat based distro.\n"
     echo -e "To complete installation, you need to:"
-    echo -e "Install: python3, pip3, python3-setuptools\n"
+    echo -e "Install: python3, pip3, python3-setuptools, python3-systemd\n"
     echo -e "Install necessary Python packages:"
     echo -e "pip3 install psutil click distro power"
     echo -e "\nRun following sequence of lines:"

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -14,7 +14,19 @@ import warnings
 from math import isclose
 from pathlib import Path
 from subprocess import getoutput, call, run, check_output, DEVNULL
+import logging
+import random
+import time
+from systemd.journal import JournalHandler
 
+# setup logging
+logger = logging.getLogger(__name__)
+journald_handler = JournalHandler()
+journald_handler.setFormatter(
+    logging.Formatter('[%(levelname)s] auto-cpufreq: %(message)s')
+)
+logger.addHandler(journald_handler)
+logger.setLevel(logging.INFO)
 
 warnings.filterwarnings("ignore")
 
@@ -119,6 +131,7 @@ def turbo(value: bool = None):
         inverse = False
     else:
         print("Warning: CPU turbo is not available")
+        logger.warning('cpu turbo is not available on this system')
         return False
 
     if value is not None:
@@ -127,8 +140,10 @@ def turbo(value: bool = None):
 
         try:
             f.write_text(str(int(value)) + "\n")
+            logger.info('setting turbo to %s', value)
         except PermissionError:
             print("Warning: Changing CPU turbo is not supported. Skipping.")
+            logger.warning('cannot set cpu turbo, operation not supported')
             return False
 
     value = bool(int(f.read_text().strip()))

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,9 +21,11 @@ parts:
     build-packages:
        - gcc
        - python3-dev
+       - python3-systemd
     stage-packages:
        - coreutils
        - dmidecode
+       - python3-systemd
     source: .
 
   deploy-scripts:


### PR DESCRIPTION
This PR is part of #156 and performs the following:

* Install `python-systemd` at system level (not installed by `pip`, as the `systemd` package is borked)
* Set up and configure `logger` and journald logging handler
* Introduce first snippets of logging when turbo mode is set, or can't be set