### PR TITLE
Fix location of auto-cpufreq in service descriptor.

### DIFF
--- a/scripts/auto-cpufreq.service
+++ b/scripts/auto-cpufreq.service
@@ -5,6 +5,6 @@ After=network.target network-online.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/local/bin/auto-cpufreq --daemon
+ExecStart=/usr/bin/auto-cpufreq --daemon
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This fixes a bug that causes the systemd service to go into a failed state because the `auto-cpufreq` script can't be found.