### PR TITLE
Fixed typo for "auto-cpufeq"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In case you encounter any problems with `auto-cpufreq-installer`, please [submit
 
 [AUR package is available](https://aur.archlinux.org/packages/auto-cpufreq-git/) for install. After which `auto-cpufreq` will be available as a binary and you can refer to [auto-cpufreq modes and options](https://github.com/AdnanHodzic/auto-cpufreq#auto-cpufreq-modes-and-options).
 
-**Please note:** If you want to install auto-cpufreq daemon, do not run `auto-cpufeq --install` otherwise you'll run into an issue: [#91](https://github.com/AdnanHodzic/auto-cpufreq/issues/91), [#96](https://github.com/AdnanHodzic/auto-cpufreq/issues/96).
+**Please note:** If you want to install auto-cpufreq daemon, do not run `auto-cpufreq --install` otherwise you'll run into an issue: [#91](https://github.com/AdnanHodzic/auto-cpufreq/issues/91), [#96](https://github.com/AdnanHodzic/auto-cpufreq/issues/96).
 
 Instead run `systemctl start auto-cpufreq` to start the service. Run `systemctl status auto-cpufreq` to see the status of service, and `systemctl enable auto-cpufreq` for service to persist running accross reboots. 
 


### PR DESCRIPTION
The word has been corrected to "auto-cpufreq".
Have a nice day!