### PR TITLE
Update for ArchLinux's pacman

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -122,7 +122,7 @@ function tool_install {
     separator
     echo -e "\nDetected an Arch Linux based distribution\n"
     echo -e "\nSetting up Python environment\n"
-    pacman -S --noconfirm python python-pip python-setuptools gcc dmidecode
+    pacman -S --noconfirm --needed python python-pip python-setuptools base-devel dmidecode
     echo -e "\nInstalling necessary Python packages\n"
     pip_pkg_install
     separator


### PR DESCRIPTION
Adding "--needed" option to not reinstall installed packages. Replaced "gcc" with metapackage "base-devel" for complete delopment environment.