### PR TITLE
warn user, rather than stop them: #196

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -3,6 +3,18 @@
 # auto-cpufreq-installer:
 # auto-cpufreq source code based installer
 
+# TODO(github.com/AdnanHodzic/auto-cpufreq/issues/196) fix
+echo 'WARNING: this installer is temporarily NOT recommended' >&2
+echo "Instead please use our Snap package (or AUR if you're on Arch)" >&2
+echo 'For more context, see: https://github.com/AdnanHodzic/auto-cpufreq/issues/196' >&2
+echo >&2
+read -p 'Continue anyway? [N/y] ' warning_response
+if [[ "${warning_response,,}" =~ ^y ]]; then
+  echo "Continuing with this installer." >&2
+else
+  exit
+fi
+
 SCRIPT_PATH=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 cd "${SCRIPT_DIR}"


### PR DESCRIPTION
Output from manual testing _(with an `exit 99` a few lines down after
this patch, so the script wouldn't actually continue for my testing -
see exit codes included in my $PS1)_

```sh
$ ./auto-cpufreq-installer
WARNING: this installer is temporarily NOT recommended
Instead please use our Snap package (or AUR if you're on Arch)
For more context, see:
https://github.com/AdnanHodzic/auto-cpufreq/issues/196

Continue anyway? [N/y]
1:$ ./auto-cpufreq-installer
WARNING: this installer is temporarily NOT recommended
Instead please use our Snap package (or AUR if you're on Arch)
For more context, see:
https://github.com/AdnanHodzic/auto-cpufreq/issues/196

Continue anyway? [N/y] y
Continuing with this installer.
99:$ ./auto-cpufreq-installer
WARNING: this installer is temporarily NOT recommended
Instead please use our Snap package (or AUR if you're on Arch)
For more context, see:
https://github.com/AdnanHodzic/auto-cpufreq/issues/196

Continue anyway? [N/y] noy
1:$ ./auto-cpufreq-installer
WARNING: this installer is temporarily NOT recommended
Instead please use our Snap package (or AUR if you're on Arch)
For more context, see:
https://github.com/AdnanHodzic/auto-cpufreq/issues/196

Continue anyway? [N/y] YES
Continuing with this installer.
```