### PR TITLE
Artix runnit support

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -128,7 +128,7 @@ function tool_install {
     separator
     echo -e "\ninstalling auto-cpufreq tool\n"
     install
-    if [[ ! $ID == "artix" ]]; then
+    if [[ $ID != "artix" ]]; then
     	update_service_file
     fi
     separator

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -118,7 +118,7 @@ function tool_install {
     complete_msg
     separator
   # Manjaro/Arch
-  elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [[ $ID == "manjaro" || $ID == "arch" || $ID == "endeavouros" || $ID == "garuda" ]]; then
+  elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [[ $ID == "manjaro" || $ID == "arch" || $ID == "endeavouros" || $ID == "garuda" || $ID == "artix" ]]; then
     separator
     echo -e "\nDetected an Arch Linux based distribution\n"
     echo -e "\nSetting up Python environment\n"
@@ -128,7 +128,9 @@ function tool_install {
     separator
     echo -e "\ninstalling auto-cpufreq tool\n"
     install
-    update_service_file
+    if [[ ! $ID == "artix" ]]; then
+    	update_service_file
+    fi
     separator
     complete_msg
     separator

--- a/scripts/auto-cpufreq-install.sh
+++ b/scripts/auto-cpufreq-install.sh
@@ -5,7 +5,7 @@
 
 echo -e "\n------------------ Running auto-cpufreq daemon install script ------------------"
 
-if [[ $EUID != 0 ]]; 
+if [[ $EUID != 0 ]];
 then
 	echo -e "\nERROR\nMust be run as root (i.e: 'sudo $0')\n"
 	exit 1
@@ -29,6 +29,21 @@ if [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [[ $ID == "void"* 
     sv start auto-cpufreq
     sv up auto-cpufreq
 
+elif [ -f /etc/os-release ] && eval "$(cat /etc/os-release)" && [[ $ID == "artix"* ]]; then
+    echo -e "\n* Deploy auto-cpufreq runit unit file"
+    mkdir /etc/runit/sv/auto-cpufreq
+    cp /usr/local/share/auto-cpufreq/scripts/run /etc/runit/sv/auto-cpufreq
+    chmod +x /etc/runit/sv/auto-cpufreq/run
+
+    echo -e "\n* Creating symbolic link (/run/runit/service/auto-cpufreq -> /etc/runit/sv/auto-cpufreq)"
+    ln -s /etc/runit/sv/auto-cpufreq /run/runit/service
+
+    echo -e "\n* Stopping auto-cpufreq daemon (runit) service"
+    sv stop auto-cpufreq
+
+    echo -e "\n* Starting auto-cpufreq daemon (runit) service"
+    sv start auto-cpufreq
+    sv up auto-cpufreq
 
 # Install script for systemd
 else


### PR DESCRIPTION
seemed easy enough to add it thanks to void linux steps. Although artix supports other inits which I haven't tried it. Maybe checking if the `runnit` directory exist before installing the daemon, else print manual installations..
```bash
if [ -d /etc/runit ] && [ -d /run/runnit ]; then
...
```