### PR TITLE
Add temperature readings in thinkpad

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -942,6 +942,8 @@ def sysinfo():
             temp_per_cpu = [core_temp["zenpower"][0].current] * online_cpu_count
         elif "acpitz" in core_temp:
             temp_per_cpu = [core_temp["acpitz"][0].current] * online_cpu_count
+        elif "thinkpad" in core_temp:
+            temp_per_cpu = [core_temp["thinkpad"][0].current] * online_cpu_count
     except Exception as e:
         print(repr(e))
         pass


### PR DESCRIPTION
Great utility! Found temperature readings became NaN in thinkpad (P14s Gen 2, Ryzen 7 Pro 5850u), so I have added a new case to read the CPU temperatures in thinkpads.

Sample psutil.sensors_temperatures() below:
```
>>> psutil.sensors_temperatures()
{
    "nvme": [
        shwtemp(label="Composite", current=37.85, high=81.85, critical=84.85),
        shwtemp(label="Sensor 1", current=37.85, high=65261.85, critical=65261.85),
        shwtemp(label="Sensor 2", current=40.85, high=65261.85, critical=65261.85),
    ],
    "amdgpu": [shwtemp(label="edge", current=41.0, high=None, critical=None)],
    "thinkpad": [
        shwtemp(label="CPU", current=42.0, high=None, critical=None),
        shwtemp(label="GPU", current=0.0, high=None, critical=None),
        shwtemp(label="", current=0.0, high=None, critical=None),
        shwtemp(label="", current=0.0, high=None, critical=None),
        shwtemp(label="", current=0.0, high=None, critical=None),
        shwtemp(label="", current=0.0, high=None, critical=None),
        shwtemp(label="", current=0.0, high=None, critical=None),
    ],
}

```