### PR TITLE
Disable turbo when config is "never"

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -470,7 +470,7 @@ def set_powersave():
     elif auto == "never":
         print("Configuration file disables turbo boost")
         print("setting turbo boost: off")
-        turbo(True)
+        turbo(False)
     else:
         if psutil.cpu_percent(percpu=False, interval=0.01) >= 30.0 or isclose(
             max(psutil.cpu_percent(percpu=True, interval=0.01)), 100


### PR DESCRIPTION
I suspect that this is a copy-paste error.
