### PR TITLE
WIP: Implement python virtual environment 

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -35,6 +35,7 @@ function setup_venv {
     python3 -m venv "${venv_dir}"
 
     source "${venv_dir}/bin/activate"
+    python3 -m pip install --upgrade pip
     python3 -m pip install -r requirements.txt
 }
 
@@ -44,7 +45,8 @@ function install {
   mkdir -p /usr/local/share/auto-cpufreq/
   cp -r scripts/ /usr/local/share/auto-cpufreq/
 
-  cp /usr/local/share/auto-cpufreq/scripts/auto-cpufreq /usr/local/bin
+  # this is necessary since we need this script before we can run auto-cpufreq itself
+  cp scripts/auto-cpufreq /usr/local/bin
   chmod u+x /usr/local/bin/auto-cpufreq
 }
 

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -48,12 +48,6 @@ function install {
   chmod u+x /usr/local/bin/auto-cpufreq
 }
 
-function update_service_file {
-  echo -e "\nUpdating service file (/usr/local/bin/auto-cpufreq -> /usr/bin/auto-cpu-freq)"
-  sed -i 's|ExecStart=/usr/local/bin/auto-cpufreq|ExecStart=/usr/bin/auto-cpufreq|' \
-	  /usr/local/share/auto-cpufreq/scripts/auto-cpufreq.service
-}
-
 # First argument is the distro
 function detected_distro() {
   echo -e "\nDetected $1 distribution"
@@ -116,7 +110,6 @@ elif [ -f /etc/solus-release ]; then
 	detected_distro "Solus"
 	eopkg install pip python3 python3-devel dmidecode
 	eopkg install -c system.devel
-	update_service_file
 	completed
 elif [ -f /etc/os-release ];then
 	eval "$(cat /etc/os-release)"
@@ -134,7 +127,6 @@ elif [ -f /etc/os-release ];then
 	arch|manjaro|endeavouros|garuda|artix)
 		detected_distro "Arch Linux based"
 		pacman -S --noconfirm --needed python python-pip python-setuptools base-devel dmidecode
-		[ $ID != "artix" ] && update_service_file
 		;;
 	void)
 		detected_distro "Void Linux"

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -29,8 +29,13 @@ function root_check {
 }
 
 # python packages install
-function pip_pkg_install {
-  python3 -m pip install -r requirements.txt
+function setup_venv {
+    venv_dir=/opt/auto-cpufreq/venv
+    mkdir -p "${venv_dir}"
+    python3 -m venv "${venv_dir}"
+
+    source "${venv_dir}/bin/activate"
+    python3 -m pip install -r requirements.txt
 }
 
 # tool install
@@ -38,6 +43,9 @@ function install {
   python3 setup.py install --record files.txt
   mkdir -p /usr/local/share/auto-cpufreq/
   cp -r scripts/ /usr/local/share/auto-cpufreq/
+
+  cp /usr/local/share/auto-cpufreq/scripts/auto-cpufreq /usr/local/bin
+  chmod u+x /usr/local/bin/auto-cpufreq
 }
 
 function update_service_file {
@@ -56,7 +64,7 @@ function detected_distro() {
 # merged functions pip - install - complete_msg, since it repeats
 function completed () {
   echo -e "\nInstalling necessary Python packages\n"
-  pip_pkg_install
+  setup_venv
   separator
   echo -e "\ninstalling auto-cpufreq tool\n"
   install
@@ -148,7 +156,10 @@ function tool_remove {
   srv_install="/usr/bin/auto-cpufreq-install"
   srv_remove="/usr/bin/auto-cpufreq-remove"
   stats_file="/var/run/auto-cpufreq.stats"
-  tool_proc_rm="auto-cpufreq --remove"
+  tool_proc_rm="/usr/local/bin/auto-cpufreq --remove"
+  wrapper_script="/usr/local/bin/auto-cpufreq"
+  unit_file="/etc/systemd/system/auto-cpufreq.service"
+  venv_path="/opt/auto-cpufreq"
 
   # stop any running auto-cpufreq argument (daemon/live/monitor)
   tool_arg_pids=($(pgrep -f "auto-cpufreq --"))
@@ -171,6 +182,11 @@ function tool_remove {
   [ -f $srv_install ] && rm $srv_install
   [ -f $srv_remove ] && rm $srv_remove
   [ -f $stats_file ] && rm $stats_file
+  [ -f $unit_file ] && rm $unit_file
+  [ -f $wrapper_script ] && rm $wrapper_script
+
+  # remove python virtual environment
+  rm -rf "${venv_path}"
 
   separator
   echo -e "\nauto-cpufreq tool and all its supporting files successfully removed."

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1042,22 +1042,12 @@ def read_stats():
 
 # check if program (argument) is running
 def is_running(program, argument):
-    # iterate over all process id's found by psutil
-    for pid in psutil.pids():
-        try:
-            # requests the process information corresponding to each process id
-            proc = psutil.Process(pid)
-            # check if value of program-variable that was used to call the function
-            # matches the name field of the plutil.Process(pid) output
-            if program in proc.name():
-                # check output of p.name(), output name of program
-                # p.cmdline() - echo the exact command line via which p was called.
-                for arg in proc.cmdline():
-                    if argument in str(arg):
-                        return True
-        except Exception as e:
-            print(repr(e))
-            continue
+    # iterate over all processes found by psutil
+    # and find the one with name and args passed to the function
+    for p in psutil.process_iter():
+        for s in filter(lambda x: program in x, p.cmdline()):
+            if argument in p.cmdline():
+                return True
 
 def daemon_running_msg():
     print("\n" + "-" * 24 + " auto-cpufreq running " + "-" * 30 + "\n")

--- a/scripts/auto-cpufreq
+++ b/scripts/auto-cpufreq
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+# get script name
+PROGNAME=$(basename "${0}")
+
+err_exit()
+{
+    echo "${PROGNAME}: ${1:-wrong invocation. try --help for help.}" 1>&2
+    exit 1
+}
+
+# invocation handling
+#
+param=""
+if [ "${#}" -eq 1 ];
+then
+    param="${1}"
+fi
+
+venv_dir=/opt/auto-cpufreq/venv
+. "${venv_dir}/bin/activate"
+PYTHONPATH=/opt/auto-cpufreq \
+            /opt/auto-cpufreq/venv/bin/python \
+            /opt/auto-cpufreq/venv/bin/auto-cpufreq \
+            "${param}"

--- a/scripts/auto-cpufreq
+++ b/scripts/auto-cpufreq
@@ -5,6 +5,7 @@ set -eu
 # get script name
 PROGNAME=$(basename "${0}")
 
+# bailout function
 err_exit()
 {
     echo "${PROGNAME}: ${1:-wrong invocation. try --help for help.}" 1>&2
@@ -14,13 +15,18 @@ err_exit()
 # invocation handling
 #
 param=""
-if [ "${#}" -eq 1 ];
+if [ "${#}" -ne 1 ];
 then
+    err_exit()
+else
     param="${1}"
 fi
 
+# load python virtual environment
 venv_dir=/opt/auto-cpufreq/venv
 . "${venv_dir}/bin/activate"
+
+# run python code with venv loaded
 PYTHONPATH=/opt/auto-cpufreq \
             /opt/auto-cpufreq/venv/bin/python \
             /opt/auto-cpufreq/venv/bin/auto-cpufreq \

--- a/scripts/auto-cpufreq
+++ b/scripts/auto-cpufreq
@@ -17,7 +17,7 @@ err_exit()
 param=""
 if [ "${#}" -ne 1 ];
 then
-    err_exit()
+    err_exit
 else
     param="${1}"
 fi

--- a/scripts/auto-cpufreq.service
+++ b/scripts/auto-cpufreq.service
@@ -5,6 +5,10 @@ After=network.target network-online.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/local/bin/auto-cpufreq --daemon
+WorkingDirectory=/opt/auto-cpufreq/venv
+Environment=PYTHONPATH=/opt/auto-cpufreq
+ExecStart=/opt/auto-cpufreq/venv/bin/python /opt/auto-cpufreq/venv/bin/auto-cpufreq --daemon
+Restart=on-failure
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
  * added venv instead of using system env pip
  * adjusted the unit file to startup the app from the venv
  * created a wrapper script to call the app from the venv
  * extended cleanup for venv and additional scripts
  * refactored the is_running() function to find the process now that it
    is called from a venv


I tested this on Fedora 35. It worked fine (TM).
Please test on other platforms before merging. I am especially not sure how this change reflects on SNAP and other packaging systems.