### PR TITLE
Minor fixes for Void Linux

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -130,7 +130,7 @@ elif [ -f /etc/os-release ];then
 		;;
 	void)
 		detected_distro "Void Linux"
-    		xbps-install -Suy python3 python3-pip python3-devel python3-setuptools base-devel dmidecode
+    		xbps-install -Sy python3 python3-pip python3-devel python3-setuptools base-devel dmidecode
 		;;
 	*) #Any other distro
 	manual_install

--- a/scripts/auto-cpufreq-install.sh
+++ b/scripts/auto-cpufreq-install.sh
@@ -37,7 +37,6 @@ sv_cmd() {
 if [ "$(ps h -o comm 1)" = "runit" ];then
 	if [ -f /etc/os-release ];then
 		eval "$(cat /etc/os-release)"
-		separator
 		case $ID in
 			void)
 				runit_ln /etc /var

--- a/scripts/auto-cpufreq-remove.sh
+++ b/scripts/auto-cpufreq-remove.sh
@@ -25,7 +25,6 @@ rm_sv() {
 if [ "$(ps h -o comm 1)" = "runit" ];then
 	if [ -f /etc/os-release ];then
 		eval "$(cat /etc/os-release)"
-		separator
 		case $ID in
 			void)
 				rm_sv /etc /var ;;


### PR DESCRIPTION
Closes #265. (summary: commit msg).

Edit: `bluez` package provides bluetooth access using traditional `bluetoothctl` and installs the `/etc/bluetooth/main.conf` file, which is not present in the base installation. So did a check if it is present, and try to change if its present.