### PR TITLE
On laptops and notebooks, check if charging via BAT* status

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -168,10 +168,10 @@ def charging():
 
     computer_type = getoutput("dmidecode --string chassis-type")
     if computer_type in ["Notebook", "Laptop", "Convertible", "Portable"]:
-        # AC adapter states: 0, 1, unknown
-        ac_info = getoutput(f"grep . {power_dir}A*/online").splitlines()
-        # if there's one ac-adapter on-line, ac_state is True
-        ac_state = any(["1" in ac.split(":")[-1] for ac in ac_info])
+        # Battery statuses: Full, Charging, Discharging, Unknown
+        battery_status = getoutput(f"grep . {power_dir}B*/status").splitlines()
+        # if there's one battery charging, ac_state is True
+        ac_state = any(["Full" in ac or "Charging" in ac for ac in battery_status])
     else:
         has_battery = psutil.sensors_battery() is not None
         if has_battery:


### PR DESCRIPTION
Hi,
For some time now auto-cpufreq got stuck on the powersave governor for me.
This happens because Linux does not recognize my power adapter for some reason, thus using `grep . /sys/class/power_supply/A*/online` doesn't work for me.

I discussed this further in #234.

So, I changed `charging()` to read from `/sys/class/power_supply/BAT*/status` instead, which will greatly improve my experience.