### PR TITLE
Check if lsb_release exists before using it

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -7,9 +7,14 @@ SCRIPT_PATH=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 cd "${SCRIPT_DIR}"
 
-distro="$(lsb_release -is)"
-release="$(lsb_release -rs)"
-codename="$(lsb_release -cs)"
+# check if lsb_release exists on the system before using it
+if command -v lsb_release > /dev/null
+then
+  distro="$(lsb_release -is)"
+  release="$(lsb_release -rs)"
+  codename="$(lsb_release -cs)"
+fi
+
 sep="\n-------------------------------------------------------------------------------"
 
 # functions


### PR DESCRIPTION
When installing auto-cpufreq using the auto-cpufreq-installer on my Fedora 35 system it shows me some errors. 

```
./auto-cpufreq-installer: line 10: lsb_release: command not found
./auto-cpufreq-installer: line 11: lsb_release: command not found
./auto-cpufreq-installer: line 12: lsb_release: command not found
```
lsb_release is not installed by default on my system, and that is why it's not found.

This small change will first check if lsb_release is on the system before using it. In the end it behaves the same, but without the command not found messages.