### PR TITLE
Verify the use of supported init systems.

### DIFF
--- a/scripts/auto-cpufreq-install.sh
+++ b/scripts/auto-cpufreq-install.sh
@@ -55,7 +55,7 @@ if [ "$(ps h -o comm 1)" = "runit" ];then
 		esac
 	fi
 # Install script for systemd
-else
+elif [ "$(ps h -o comm 1)" = "systemd" ];then
     echo -e "\n* Deploy auto-cpufreq systemd unit file"
     cp /usr/local/share/auto-cpufreq/scripts/auto-cpufreq.service /etc/systemd/system/auto-cpufreq.service
 
@@ -70,4 +70,7 @@ else
 
     echo -e "\n* Enabling auto-cpufreq daemon (systemd) service at boot"
     systemctl enable auto-cpufreq
+else
+  echo -e "\n* Unsupported init system detected, could not install the daemon\n"
+  echo -e "\n* Please open an issue on https://github.com/AdnanHodzic/auto-cpufreq\n"
 fi

--- a/scripts/auto-cpufreq-remove.sh
+++ b/scripts/auto-cpufreq-remove.sh
@@ -36,7 +36,8 @@ if [ "$(ps h -o comm 1)" = "runit" ];then
 
 		esac
 	fi
-else
+# Remove service for systemd
+elif [ "$(ps h -o comm 1)" = "systemd" ];then
     echo -e "\n* Stopping auto-cpufreq daemon (systemd) service"
     systemctl stop auto-cpufreq
 
@@ -51,4 +52,7 @@ else
 
     echo -e "reset failed"
     systemctl reset-failed
+else
+  echo -e "\n* Unsupported init system detected, could not remove the daemon\n"
+  echo -e "\n* Please open an issue on https://github.com/AdnanHodzic/auto-cpufreq\n"
 fi


### PR DESCRIPTION
When installing on a old Gentoo machine, I found the following issue. Gentoo doesn't use runit, so it would assume it's systemd. Which was not correct. Added an extra check to see if its actually systemd instead of runit, otherwise give unsupported message. 

```
sudo auto-cpufreq --install

--------------------- Deploying auto-cpufreq as a daemon ----------------------

* Turn off bluetooth on boot [skipping] (package providing bluetooth access is not present)

* Deploy auto-cpufreq install script

* Deploy auto-cpufreq remove script

------------------ Running auto-cpufreq daemon install script ------------------

* Unsupported init system detected, could not install the daemon


* Please open an issue on https://github.com/AdnanHodzic/auto-cpufreq


----------------- auto-cpufreq daemon installed and running -----------------

To view live stats, run:
auto-cpufreq --stats

To disable and remove auto-cpufreq daemon, run:
sudo auto-cpufreq --remove

-------------------------------------------------------------------------------


```
The message is maybe not really nice, because it still says it's installed and running afterwards. 

I tested this change on the `non-systemd-gnome-power` branch otherwise it didn't run at all. So I think that is good to go!