### PR TITLE
Added a warning when using TLP

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -315,6 +315,9 @@ def deploy_daemon():
     gnome_power_detect_install()
     gnome_power_svc_disable()
 
+    # output warning if TLP service is detected
+    tlp_service_detect()
+
     call("/usr/bin/auto-cpufreq-install", shell=True)
 
 # remove auto-cpufreq daemon

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -30,7 +30,7 @@ bluetoothctl_exists = does_command_exists("bluetoothctl")
 if os.getenv('PKG_MARKER') != "SNAP":
     if systemctl_exists:
         try:
-            gnome_power_stats = call(["systemctl", "is-active", "--quiet", "power-profiles-daemon"])
+            gnome_power_status = call(["systemctl", "is-active", "--quiet", "power-profiles-daemon"])
         except:
             print("\nUnable to determine init system")
             print("If this causes any problems, please submit an issue:")
@@ -39,7 +39,7 @@ if os.getenv('PKG_MARKER') != "SNAP":
 # alert in case gnome power profile service is running
 def gnome_power_detect():
     if systemctl_exists:
-        if gnome_power_stats == 0:
+        if gnome_power_status == 0:
             print("\n----------------------------------- Warning -----------------------------------\n")
             print("Detected running GNOME Power Profiles daemon service!")
             print("This daemon might interfere with auto-cpufreq and should be disabled.")
@@ -52,7 +52,7 @@ def gnome_power_detect():
 # automatically disable gnome power profile service in case it's running during install
 def gnome_power_detect_install():
     if systemctl_exists:
-        if gnome_power_stats == 0:
+        if gnome_power_status == 0:
             print("\n----------------------------------- Warning -----------------------------------\n")
             print("Detected running GNOME Power Profiles daemon service!")
             print("This daemon might interfere with auto-cpufreq and has been disabled.\n")
@@ -72,7 +72,7 @@ def gnome_power_detect_snap():
 
 # disable gnome >= 40 power profiles (live)
 def gnome_power_disable_live():
-    if(gnome_power_stats == 0):
+    if(gnome_power_status == 0):
         call(["systemctl", "stop", "power-profiles-daemon"])
 
 
@@ -175,7 +175,7 @@ def bluetooth_on_notif_snap():
 # gnome power removal reminder
 def gnome_power_rm_reminder():
     if systemctl_exists:
-        if gnome_power_stats != 0:
+        if gnome_power_status != 0:
             print("\n----------------------------------- Warning -----------------------------------\n")
             print("Detected GNOME Power Profiles daemon service is stopped!")
             print("This service will now be enabled and started again.")

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -6,6 +6,7 @@ from subprocess import getoutput, call, run, check_output, DEVNULL
 
 sys.path.append('../')
 from auto_cpufreq.core import *
+from auto_cpufreq.tlp_stat_parser import TLPStatusParser
 
 # app_name var
 if sys.argv[0] == "power_helper.py":
@@ -25,6 +26,7 @@ def does_command_exists(cmd):
 
 systemctl_exists = does_command_exists("systemctl")
 bluetoothctl_exists = does_command_exists("bluetoothctl")
+tlp_stat_exists = does_command_exists("tlp-stat")
 
 # detect if gnome power profile service is running
 if os.getenv('PKG_MARKER') != "SNAP":
@@ -35,6 +37,24 @@ if os.getenv('PKG_MARKER') != "SNAP":
             print("\nUnable to determine init system")
             print("If this causes any problems, please submit an issue:")
             print("https://github.com/AdnanHodzic/auto-cpufreq/issues")
+
+# alert in case TLP service is running
+def tlp_service_detect():
+    if tlp_stat_exists:
+        status_output = getoutput("tlp-stat -s")
+        tlp_status = TLPStatusParser(status_output)
+        if tlp_status.is_enabled():
+            print("\n----------------------------------- Warning -----------------------------------\n")
+            print("Detected you are running a TLP service!")
+            print("This daemon might interfere with auto-cpufreq which can lead to unexpected results.")
+            print("We strongly encourage you to remove TLP unless you really know what you are doing.")
+
+# alert about TLP when using snap
+def tlp_service_detect_snap():
+    print("\n----------------------------------- Warning -----------------------------------\n")
+    print("Unable to detect if you are using a TLP service!")
+    print("This daemon might interfere with auto-cpufreq which can lead to unexpected results.")
+    print("We strongly encourage you not to use TLP unless you really know what you are doing.")
 
 # alert in case gnome power profile service is running
 def gnome_power_detect():

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -19,9 +19,16 @@ def header():
 def helper_opts():
     print("\nFor full list of options run: python3 power_helper.py --help")
 
+# used to check if binary exists on the system
+def does_command_exists(cmd):
+    return which(cmd) is not None
+
+systemctl_exists = does_command_exists("systemctl")
+bluetoothctl_exists = does_command_exists("bluetoothctl")
+
 # detect if gnome power profile service is running
 if os.getenv('PKG_MARKER') != "SNAP":
-    if which("systemctl") is not None:
+    if systemctl_exists:
         try:
             gnome_power_stats = call(["systemctl", "is-active", "--quiet", "power-profiles-daemon"])
         except:
@@ -31,7 +38,7 @@ if os.getenv('PKG_MARKER') != "SNAP":
 
 # alert in case gnome power profile service is running
 def gnome_power_detect():
-    if which("systemctl") is not None:
+    if systemctl_exists:
         if gnome_power_stats == 0:
             print("\n----------------------------------- Warning -----------------------------------\n")
             print("Detected running GNOME Power Profiles daemon service!")
@@ -44,7 +51,7 @@ def gnome_power_detect():
 
 # automatically disable gnome power profile service in case it's running during install
 def gnome_power_detect_install():
-    if which("systemctl") is not None:
+    if systemctl_exists:
         if gnome_power_stats == 0:
             print("\n----------------------------------- Warning -----------------------------------\n")
             print("Detected running GNOME Power Profiles daemon service!")
@@ -71,7 +78,7 @@ def gnome_power_disable_live():
 
 # disable gnome >= 40 power profiles (install)
 def gnome_power_svc_disable():
-    if which("systemctl") is not None:
+    if systemctl_exists:
         try:
             print("\n* Disabling GNOME power profiles")
             call(["systemctl", "stop", "power-profiles-daemon"])
@@ -86,7 +93,7 @@ def gnome_power_svc_disable():
 
 # enable gnome >= 40 power profiles (uninstall)
 def gnome_power_svc_enable():
-    if which("systemctl") is not None:
+    if systemctl_exists:
         try:
             print("\n* Enabling GNOME power profiles")
             call(["systemctl", "unmask", "power-profiles-daemon"])
@@ -101,7 +108,7 @@ def gnome_power_svc_enable():
 
 # gnome power profiles current status
 def gnome_power_svc_status():
-    if which("systemctl") is not None:
+    if systemctl_exists:
         try:
             print("* GNOME power profiles status")
             call(["systemctl", "status", "power-profiles-daemon"])
@@ -115,7 +122,7 @@ def gnome_power_svc_status():
 def bluetooth_disable():
     if os.getenv("PKG_MARKER") == "SNAP":
         bluetooth_notif_snap()
-    elif which("bluetoothctl") is not None:
+    elif bluetoothctl_exists:
         print("* Turn off bluetooth on boot")
         btconf = Path("/etc/bluetooth/main.conf")
         try:
@@ -136,7 +143,7 @@ def bluetooth_disable():
 def bluetooth_enable():
     if os.getenv("PKG_MARKER") == "SNAP":
         bluetooth_on_notif_snap()
-    if which("bluetoothctl") is not None:
+    if bluetoothctl_exists:
         print("* Turn on bluetooth on boot")
         btconf = "/etc/bluetooth/main.conf"
         try:
@@ -167,7 +174,7 @@ def bluetooth_on_notif_snap():
 
 # gnome power removal reminder
 def gnome_power_rm_reminder():
-    if which("systemctl") is not None:
+    if systemctl_exists:
         if gnome_power_stats != 0:
             print("\n----------------------------------- Warning -----------------------------------\n")
             print("Detected GNOME Power Profiles daemon service is stopped!")

--- a/auto_cpufreq/tlp_stat_parser.py
+++ b/auto_cpufreq/tlp_stat_parser.py
@@ -1,0 +1,20 @@
+class TLPStatusParser():
+    def __init__(self, tlp_stat_output):
+        self.data = {}
+        self._parse(tlp_stat_output)
+
+    def _parse(self, data):
+        for line in data.split("\n"):
+            key_val = line.split("=", 1)
+            if len(key_val) > 1:
+                self.data[key_val[0].strip().lower()] = key_val[1].strip()
+
+    def _get_key(self, key):
+        if key in self.data:
+            return self.data[key]
+        else:
+            return ""
+
+    def is_enabled(self):
+        return self._get_key("state") == "enabled"
+

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -48,6 +48,7 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
             file_stats()
             if os.getenv("PKG_MARKER") == "SNAP" and dcheck == "enabled":
                 gnome_power_detect_snap()
+                tlp_service_detect_snap()
                 while True:
                     footer()
                     gov_check()
@@ -58,6 +59,7 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
                     countdown(5)
             elif os.getenv("PKG_MARKER") != "SNAP":
                 gnome_power_detect()
+                tlp_service_detect()
                 while True:
                     footer()
                     gov_check()
@@ -74,8 +76,10 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
             print("\nNote: You can quit monitor mode by pressing \"ctrl+c\"")
             if os.getenv("PKG_MARKER") == "SNAP":
                 gnome_power_detect_snap()
+                tlp_service_detect_snap()
             else:
                 gnome_power_detect()
+                tlp_service_detect()
             while True:
                 time.sleep(1)
                 running_daemon()
@@ -93,8 +97,10 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
             time.sleep(1)
             if os.getenv("PKG_MARKER") == "SNAP":
                 gnome_power_detect_snap()
+                tlp_service_detect_snap()
             else:
                 gnome_power_detect()
+                tlp_service_detect()
             while True:
                 running_daemon()
                 footer()
@@ -109,8 +115,10 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
             print("\nNote: You can quit stats mode by pressing \"ctrl+c\"")
             if os.getenv("PKG_MARKER") == "SNAP":
                 gnome_power_detect_snap()
+                tlp_service_detect_snap()
             else:
                 gnome_power_detect()
+                tlp_service_detect()
             time.sleep(1)
             read_stats()
         elif log:
@@ -154,6 +162,7 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
                 root_check()
                 running_daemon()
                 gnome_power_detect_snap()
+                tlp_service_detect_snap()
                 bluetooth_notif_snap()
                 gov_check()
                 run("snapctl set daemon=enabled", shell=True)


### PR DESCRIPTION
At this moment it recognizes only TLP on systemd systems. Just like power-profiles-daemon. Did not add automaticly disable feature, just a good warning to think about their choice of using TLP together with auto-cpufreq.

I did a small rewrite for the `if which("systemctl") is not None:` and `bluetoothctl` which makes the code more readable and less prone to typing mistakes.

It runs great, but I did not test SNAP. 

I hope that you like it.