### PR TITLE
Fix #321, skip hid devices with battery

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -198,6 +198,10 @@ def charging():
     # we found some power supplies, lets check their state
     else:
         for supply in power_supplies:
+            # skip battery of hid devices
+            # see issue #321
+            if "hid" in supply.lower():
+                continue
             try:
                 with open(Path(power_supply_path + supply + "/type")) as f:
                     supply_type = f.read()[:-1]


### PR DESCRIPTION
Fix for issue #321 

HID device with battery show up under `/sys/class/power_supply`

`hidpp_battery_0`
`hidpp_battery_1`

skip devices contain "hid", tested by user and fixes the issue.

I'm not sure if "hid" is too broad match. that's why I will add those names to the list if future errors come up with this, I can refine if needed.