### PR TITLE
Ignore hidpp_battery

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -198,6 +198,9 @@ def charging():
     # we found some power supplies, lets check their state
     else:
         for supply in power_supplies:
+            if supply == "hidpp_battery":
+                # disregard from wireless mice
+                continue
             try:
                 with open(Path(power_supply_path + supply + "/type")) as f:
                     supply_type = f.read()[:-1]


### PR DESCRIPTION
When looping through the power supply class, ignore `hidpp_battery`.
A connected wireless mouse will report itself as a type = "battery"
which may trick auto_cpufreq into thinking that the system is running on
batteries.

The issue above was discovered on a ThinkPad P15 running Ubuntu 20.04.