### PR TITLE
Added missing package Debian based venv

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -106,7 +106,7 @@ function tool_install {
 separator
 if [ -f /etc/debian_version ]; then
 	detected_distro "Debian based"
-	apt install python3-dev python3-pip python3-setuptools dmidecode -y
+	apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode -y
 	completed
 	complete_msg
 elif [ -f /etc/redhat-release ]; then


### PR DESCRIPTION
When install from git using the `auto-cpufreq-installer` I noticed the follow error on a Debian based distro:
```
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.
 
    apt install python3.8-venv
```

Added that package to the debian based installer packages.
