### PR TITLE
Fixed the --version command when installed from source

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -12,6 +12,7 @@ import time
 import click
 import warnings
 import configparser
+import pkg_resources
 from math import isclose
 from pathlib import Path
 from shutil import which
@@ -111,7 +112,7 @@ except PermissionError:
 # display running version of auto-cpufreq
 def app_version():
 
-    print("auto-cpufreq version:")
+    print("auto-cpufreq version: ", end="")
 
     # snap package
     if os.getenv("PKG_MARKER") == "SNAP":
@@ -120,19 +121,13 @@ def app_version():
     elif dist_name in ["arch", "manjaro", "garuda"]:
         aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
         if aur_pkg_check == 1:
-            print(
-                "Git commit:",
-                check_output(["git", "describe", "--always"]).strip().decode(),
-            )
+            print(pkg_resources.require("auto-cpufreq")[0].version)
         else:
             print(getoutput("pacman -Qi auto-cpufreq | grep Version"))
     else:
         # source code (auto-cpufreq-installer)
         try:
-            print(
-                "Git commit:",
-                check_output(["git", "describe", "--always"]).strip().decode(),
-            )
+            print(pkg_resources.require("auto-cpufreq")[0].version)
         except Exception as e:
             print(repr(e))
             pass

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -121,17 +121,27 @@ def app_version():
     elif dist_name in ["arch", "manjaro", "garuda"]:
         aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
         if aur_pkg_check == 1:
-            print(pkg_resources.require("auto-cpufreq")[0].version)
+            print(get_formatted_version())
         else:
             print(getoutput("pacman -Qi auto-cpufreq | grep Version"))
     else:
         # source code (auto-cpufreq-installer)
         try:
-            print(pkg_resources.require("auto-cpufreq")[0].version)
+            print(get_formatted_version())
         except Exception as e:
             print(repr(e))
             pass
 
+# return formatted version for a better readability
+def get_formatted_version():
+    literal_version = pkg_resources.require("auto-cpufreq")[0].version
+    splitted_version = literal_version.split("+")
+    formatted_version = splitted_version[0]
+    
+    if len(splitted_version) > 1:
+        formatted_version += " (git: " + splitted_version[1] + ")"
+
+    return formatted_version
 
 def app_res_use():
     p = psutil.Process()

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,16 @@ def read(name):
     with open(os.path.join(this, name)) as f:
         return f.read()
 
+# Used for the tar.gz/snap releases
+VERSION = "1.9.0"
 
 setup(
     name="auto-cpufreq",
-    version_config={
-        "template": "{tag}.{sha}",
-        "dev_template": "{tag}.{sha}"
+    setuptools_git_versioning={
+        "starting_version": VERSION,
+        "template": "{tag}+{sha}",
+        "dev_template": "{tag}+{sha}",
+        "dirty_template": "{tag}+{sha}.post{ccount}.dirty"
     },
     setup_requires=["setuptools-git-versioning"],
     description="Automatic CPU speed & power optimizer for Linux",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ def read(name):
 
 setup(
     name="auto-cpufreq",
-    version="1.0",
+    version_config={
+        "template": "{tag}.{sha}",
+        "dev_template": "{tag}.{sha}"
+    },
+    setup_requires=["setuptools-git-versioning"],
     description="Automatic CPU speed & power optimizer for Linux",
     long_description=readme,
     author="Adnan Hodzic",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: auto-cpufreq
 base: core20
-version: '1.9.0'
 summary: Automatic CPU speed & power optimizer for Linux
 description: |
   Automatic CPU speed & power optimizer for Linux based on active
@@ -11,6 +10,7 @@ description: |
 license: LGPL-3.0
 grade: stable
 confinement: strict
+adopt-info: auto-cpufreq
 
 compression: lzo
 
@@ -27,6 +27,9 @@ parts:
        - coreutils
        - dmidecode
     source: .
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version `grep ^VERSION $SNAPCRAFT_PART_SRC/setup.py | sed 's/.*"\(.*\)"/\1/'`
 
   deploy-scripts:
     plugin: dump


### PR DESCRIPTION
Closes #344

The command only worked when running it inside the git repository.

Now, it works from everywhere, and the version is constructed using the latest git tag and the SHA (8 first symbols) of the latest commit, which may help with further debugging in future issues (since when installing from source you don't install a fixed version).

To do so, I have included [this setuptools plugin](https://github.com/dolfinus/setuptools-git-versioning). The template for the versioning [can be changed](https://setuptools-git-versioning.readthedocs.io/en/latest/schemas/index.html) by modifying the options in `setup.py`, but IMO this is a good approach, since, as I previously said, the version is constructed with the latest Git tag as well as the SHA of the latest commit, which may come in handy for debugging future specific issues.

Waiting for your feedback!