### PR TITLE
Set Balanced mode on power-profiles-daemon

### DIFF
--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -112,12 +112,18 @@ def gnome_power_detect_snap():
 # disable gnome >= 40 power profiles (live)
 def gnome_power_disable_live():
     if gnome_power_status == 0:
+        call(["powerprofilesctl", "set", "balanced"])
         call(["systemctl", "stop", "power-profiles-daemon"])
 
 
 # disable gnome >= 40 power profiles (install)
 def gnome_power_svc_disable():
     if systemctl_exists:
+        # set balanced profile before disabling it
+        if gnome_power_status == 0:
+            call(["powerprofilesctl", "set", "balanced"])
+
+        # always disable power-profiles-daemon
         try:
             print("\n* Disabling GNOME power profiles")
             call(["systemctl", "stop", "power-profiles-daemon"])


### PR DESCRIPTION
When we disable the `power-profiles-daemon` if it's in "Power saver" mode, we can loose some performance. As it will not max out the turbo. As seen in the following tests below. 

We can only set this mode when the `power-profiles-daemon` is actually running. We always disable `power-profiles-daemon` on installation, and if it's running before we disable it, we first set it to "Balanced".

```stress --cpu 16 --io 4 --vm 4 --timeout 60``` after I installed `auto-cpufreq` when `power-profiles-daemon` was first set to "Power saver"
```
Linux distro: Fedora Linux 35 
Linux kernel: 5.15.12-200.fc35.x86_64
Processor: AMD Ryzen 7 4800U with Radeon Graphics
Cores: 16
Architecture: x86_64
Driver: acpi-cpufreq

------------------------------ Current CPU stats ------------------------------

CPU max frequency: 1800 MHz
CPU min frequency: 1400 MHz

Core	Usage	Temperature	Frequency
CPU0:	100.0%     69 °C     2226 MHz
CPU1:	100.0%     69 °C     2226 MHz
CPU2:	100.0%     69 °C     2216 MHz
CPU3:	100.0%     69 °C     2226 MHz
CPU4:	 99.0%     69 °C     2227 MHz
CPU5:	100.0%     69 °C     2227 MHz
CPU6:	100.0%     69 °C     2227 MHz
CPU7:	 99.0%     69 °C     2227 MHz
CPU8:	100.0%     69 °C     2227 MHz
CPU9:	100.0%     69 °C     2227 MHz
CPU10:	100.0%     69 °C     2227 MHz
CPU11:	100.0%     69 °C     2227 MHz
CPU12:	100.0%     69 °C     2227 MHz
CPU13:	100.0%     69 °C     2227 MHz
CPU14:	100.0%     69 °C     2227 MHz
CPU15:	100.0%     69 °C     2227 MHz

---------------------------- CPU frequency scaling ----------------------------

Battery is: charging

Setting to use: "performance" governor

Total CPU usage: 99.9 %
Total system load: 17.19
Average temp. of all cores: 68.875 °C

High CPU load
setting turbo boost: on
```


```stress --cpu 16 --io 4 --vm 4 --timeout 60``` after I installed `auto-cpufreq` when `power-profiles-daemon` was first set to "Balanced"
```
Linux distro: Fedora Linux 35 
Linux kernel: 5.15.12-200.fc35.x86_64
Processor: AMD Ryzen 7 4800U with Radeon Graphics
Cores: 16
Architecture: x86_64
Driver: acpi-cpufreq

------------------------------ Current CPU stats ------------------------------

CPU max frequency: 1800 MHz
CPU min frequency: 1400 MHz

Core	Usage	Temperature	Frequency
CPU0:	100.0%     99 °C     3219 MHz
CPU1:	100.0%     99 °C     3219 MHz
CPU2:	100.0%     99 °C     3219 MHz
CPU3:	100.0%     99 °C     3219 MHz
CPU4:	100.0%     99 °C     3219 MHz
CPU5:	100.0%     99 °C     3219 MHz
CPU6:	100.0%     99 °C     3219 MHz
CPU7:	100.0%     99 °C     3219 MHz
CPU8:	100.0%     99 °C     3218 MHz
CPU9:	100.0%     99 °C     3218 MHz
CPU10:	100.0%     99 °C     3218 MHz
CPU11:	100.0%     99 °C     3218 MHz
CPU12:	 97.0%     99 °C     3218 MHz
CPU13:	100.0%     99 °C     3218 MHz
CPU14:	100.0%     99 °C     3218 MHz
CPU15:	100.0%     99 °C     3218 MHz

---------------------------- CPU frequency scaling ----------------------------

Battery is: charging

Setting to use: "performance" governor

Total CPU usage: 99.8 %
Total system load: 17.88
Average temp. of all cores: 99.0 °C

High CPU load
setting turbo boost: on
```

I did add the change to ```gnome_power_disable_live()``` but we don't actually use that at the moment. We currently only throw a warning to the user when in live mode.