### PR TITLE
Stop power-profiles-daemon in live mode

### DIFF
--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -95,7 +95,7 @@ def gnome_power_detect_install():
             )
             print("Detected running GNOME Power Profiles daemon service!")
             print("This daemon might interfere with auto-cpufreq and has been disabled.\n")
-            print('Disabled daemon is not automatically disabled in "live" and "monitor" mode and')
+            print('This daemon is not automatically disabled in "monitor" mode and')
             print("will be enabled after auto-cpufreq is removed.")
 
 

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -31,6 +31,7 @@ def does_command_exists(cmd):
 systemctl_exists = does_command_exists("systemctl")
 bluetoothctl_exists = does_command_exists("bluetoothctl")
 tlp_stat_exists = does_command_exists("tlp-stat")
+powerprofilesctl_exists = does_command_exists("powerprofilesctl")
 
 # detect if gnome power profile service is running
 if os.getenv("PKG_MARKER") != "SNAP":
@@ -109,18 +110,24 @@ def gnome_power_detect_snap():
     print("python3 power_helper.py --gnome_power_disable")
 
 
-# disable gnome >= 40 power profiles (live)
-def gnome_power_disable_live():
-    if gnome_power_status == 0:
-        call(["powerprofilesctl", "set", "balanced"])
-        call(["systemctl", "stop", "power-profiles-daemon"])
+# stops gnome >= 40 power profiles (live)
+def gnome_power_stop_live():
+    if systemctl_exists:
+        if gnome_power_status == 0 and powerprofilesctl_exists:
+            call(["powerprofilesctl", "set", "balanced"])
+            call(["systemctl", "stop", "power-profiles-daemon"])
+
+# starts gnome >= 40 power profiles (live)
+def gnome_power_start_live():
+    if systemctl_exists:
+        call(["systemctl", "start", "power-profiles-daemon"])
 
 
 # disable gnome >= 40 power profiles (install)
 def gnome_power_svc_disable():
     if systemctl_exists:
-        # set balanced profile before disabling it
-        if gnome_power_status == 0:
+        # set balanced profile if its running before disabling it
+        if gnome_power_status == 0 and powerprofilesctl_exists:
             call(["powerprofilesctl", "set", "balanced"])
 
         # always disable power-profiles-daemon

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -109,16 +109,22 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
                 tlp_service_detect_snap()
             else:
                 gnome_power_detect()
+                gnome_power_stop_live()
                 tlp_service_detect()
             while True:
-                running_daemon()
-                footer()
-                gov_check()
-                cpufreqctl()
-                distro_info()
-                sysinfo()
-                set_autofreq()
-                countdown(5)
+                try:
+                    running_daemon()
+                    footer()
+                    gov_check()
+                    cpufreqctl()
+                    distro_info()
+                    sysinfo()
+                    set_autofreq()
+                    countdown(5)
+                except KeyboardInterrupt:
+                    gnome_power_start_live()
+                    print("")
+                    sys.exit()
         elif stats:
             config_info_dialog()
             print('\nNote: You can quit stats mode by pressing "ctrl+c"')

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -108,7 +108,7 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
             else:
-                gnome_power_detect()
+                gnome_power_detect_install()
                 gnome_power_stop_live()
                 tlp_service_detect()
             while True:


### PR DESCRIPTION
When using `auto-cpufreq --live` we did only display a warning about the conflict with `power-profiles-daemon`.
It now actually stops it in live mode, and starts it when live mode is exited.

Also added a check to see if `powerprofilesctl` exists.