### PR TITLE
Deploy cpufreqctl on --debug and remove via installer

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -170,6 +170,7 @@ function tool_remove {
   wrapper_script="/usr/local/bin/auto-cpufreq"
   unit_file="/etc/systemd/system/auto-cpufreq.service"
   venv_path="/opt/auto-cpufreq"
+  cpufreqctl="/usr/bin/cpufreqctl.auto-cpufreq"
 
   # stop any running auto-cpufreq argument (daemon/live/monitor)
   tool_arg_pids=($(pgrep -f "auto-cpufreq --"))
@@ -194,6 +195,7 @@ function tool_remove {
   [ -f $stats_file ] && rm $stats_file
   [ -f $unit_file ] && rm $unit_file
   [ -f $wrapper_script ] && rm $wrapper_script
+  [ -f $cpufreqctl ] && rm $cpufreqctl
 
   # remove python virtual environment
   rm -rf "${venv_path}"

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -142,6 +142,7 @@ def main(config, daemon, debug, install, live, log, monitor, stats, version, don
             # ToDo: add status of GNOME Power Profile servie status
             config_info_dialog()
             root_check()
+            cpufreqctl()
             footer()
             distro_info()
             sysinfo()


### PR DESCRIPTION
`cpufreqctl.auto-cpufreq` was deployed everywhere except on `auto-cpufreq --debug`. 

It was only removed when it was deployed as part of the daemon install. 

Now it's always removed when using the `auto-cpufreq-install --remove` option.