### PR TITLE
Fixed where average all core temp is displayed with too many decimals.

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -491,7 +491,7 @@ def display_load():
 
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m)
-    print("Average temp. of all cores:", avg_all_core_temp, "°C", "\n")
+    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C", "\n")
 
 
 # set minimum and maximum CPU frequencies
@@ -594,7 +594,7 @@ def set_powersave():
 
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m)
-    print("Average temp. of all cores:", avg_all_core_temp, "°C")
+    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
 
     # conditions for setting turbo in powersave
     if conf.has_option("battery", "turbo"):
@@ -696,7 +696,7 @@ def mon_powersave():
 
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m)
-    print("Average temp. of all cores:", avg_all_core_temp, "°C")
+    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
 
     if psutil.cpu_percent(percpu=False, interval=0.01) >= 30.0 or isclose(
         max(psutil.cpu_percent(percpu=True, interval=0.01)), 100
@@ -803,7 +803,7 @@ def set_performance():
 
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m)
-    print("Average temp. of all cores:", avg_all_core_temp, "°C")
+    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
 
     if conf.has_option("charger", "turbo"):
         auto = conf["charger"]["turbo"]
@@ -905,7 +905,7 @@ def mon_performance():
 
     print("\nTotal CPU usage:", cpuload, "%")
     print("Total system load:", load1m)
-    print("Average temp. of all cores:", avg_all_core_temp, "°C")
+    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
 
     # get system/CPU load
     load1m, _, _ = os.getloadavg()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -490,8 +490,8 @@ def display_load():
     load1m, _, _ = os.getloadavg()
 
     print("\nTotal CPU usage:", cpuload, "%")
-    print("Total system load:", load1m)
-    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C", "\n")
+    print("Total system load: {:.2f}".format(load1m))
+    print("Average temp. of all cores: {:.2f} °C \n".format(avg_all_core_temp))
 
 
 # set minimum and maximum CPU frequencies
@@ -593,8 +593,8 @@ def set_powersave():
     load1m, _, _ = os.getloadavg()
 
     print("\nTotal CPU usage:", cpuload, "%")
-    print("Total system load:", load1m)
-    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
+    print("Total system load: {:.2f}".format(load1m))
+    print("Average temp. of all cores: {:.2f} °C \n".format(avg_all_core_temp))
 
     # conditions for setting turbo in powersave
     if conf.has_option("battery", "turbo"):
@@ -695,8 +695,8 @@ def mon_powersave():
     load1m, _, _ = os.getloadavg()
 
     print("\nTotal CPU usage:", cpuload, "%")
-    print("Total system load:", load1m)
-    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
+    print("Total system load: {:.2f}".format(load1m))
+    print("Average temp. of all cores: {:.2f} °C \n".format(avg_all_core_temp))
 
     if psutil.cpu_percent(percpu=False, interval=0.01) >= 30.0 or isclose(
         max(psutil.cpu_percent(percpu=True, interval=0.01)), 100
@@ -802,8 +802,8 @@ def set_performance():
     load1m, _, _ = os.getloadavg()
 
     print("\nTotal CPU usage:", cpuload, "%")
-    print("Total system load:", load1m)
-    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
+    print("Total system load: {:.2f}".format(load1m))
+    print("Average temp. of all cores: {:.2f} °C \n".format(avg_all_core_temp))
 
     if conf.has_option("charger", "turbo"):
         auto = conf["charger"]["turbo"]
@@ -904,8 +904,8 @@ def mon_performance():
     load1m, _, _ = os.getloadavg()
 
     print("\nTotal CPU usage:", cpuload, "%")
-    print("Total system load:", load1m)
-    print("Average temp. of all cores:", "{:.2f}".format(avg_all_core_temp), "°C")
+    print("Total system load: {:.2f}".format(load1m))
+    print("Average temp. of all cores: {:.2f} °C \n".format(avg_all_core_temp))
 
     # get system/CPU load
     load1m, _, _ = os.getloadavg()


### PR DESCRIPTION
I changed the monitoring display of `Average temp. of all cores:`.

Before:

![image](https://user-images.githubusercontent.com/10132938/166450124-45c4def7-dcce-478a-85b5-ba6f6569e563.png)

After:

![image](https://user-images.githubusercontent.com/10132938/166450170-1835b492-0662-483a-9d9e-25159c589ef4.png)
