### PR TITLE
Running "auto-cpufreq" itself returns an error

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -74,7 +74,7 @@ function completed () {
 function complete_msg() {
   separator
   echo -e "\nauto-cpufreq tool successfully installed.\n"
-  echo -e "For list of options, run:\nauto-cpufreq"
+  echo -e "For list of options, run:\nauto-cpufreq --help"
   separator
 }
 


### PR DESCRIPTION
Running "auto-cpufreq" itself returns an error so I added the "--help" flag so the user know how to see the available options.