### PR TITLE
Catch exception in call to psutil .cmdline()

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1175,8 +1175,12 @@ def is_running(program, argument):
     # iterate over all processes found by psutil
     # and find the one with name and args passed to the function
     for p in psutil.process_iter():
-        for s in filter(lambda x: program in x, p.cmdline()):
-            if argument in p.cmdline():
+        try:
+            cmd = p.cmdline();
+        except:
+            continue
+        for s in filter(lambda x: program in x, cmd):
+            if argument in cmd:
                 return True
 
 


### PR DESCRIPTION
There's a race condition where processes might disappear while filtering. The uncaught exception causes a crash.

See the following stack trace:
Traceback (most recent call last):
  File "/usr/bin/auto-cpufreq", line 226, in <module>
    main()
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/bin/auto-cpufreq", line 117, in main
    running_daemon()
  File "/usr/lib/python3.10/site-packages/auto_cpufreq/core.py", line 1190, in running_daemon
    if is_running("auto-cpufreq", "--daemon"):
  File "/usr/lib/python3.10/site-packages/auto_cpufreq/core.py", line 1175, in is_running
    for s in filter(lambda x: program in x, p.cmdline()):
  File "/usr/lib/python3.10/site-packages/psutil/__init__.py", line 684, in cmdline
    return self._proc.cmdline()
  File "/usr/lib/python3.10/site-packages/psutil/_pslinux.py", line 1668, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: process no longer exists (pid=669342)
