### PR TITLE
Don't overwrite /usr/bin/cpufreqctl.auto-cpufreq excessively.

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -296,9 +296,7 @@ def cpufreqctl():
         pass
     else:
         # deploy cpufreqctl.auto-cpufreq script
-        if os.path.isfile("/usr/bin/cpufreqctl"):
-            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
-        else:
+        if not os.path.isfile("/usr/bin/cpufreqctl.auto-cpufreq"):
             shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl.auto-cpufreq")
 
 


### PR DESCRIPTION
Looks like the behavior of constantly overwriting it was not intended,
but introduced inadvertently in a91d4ba36e5f42d025b3978ee1178441b52a372f

This should solve #381