### PR TITLE
Omit the --all flag from calling nproc to get actual number of cores

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1072,7 +1072,7 @@ def sysinfo():
     print(f"Processor:{model_name}")
 
     # get core count
-    total_cpu_count = int(getoutput("nproc --all"))
+    total_cpu_count = int(getoutput("nproc"))
     print("Cores:", total_cpu_count)
 
     # get architecture


### PR DESCRIPTION
--all seems to return the number of threads for processor units on some systems.