### PR TITLE
Replaced obsolete "egrep" calls with "grep -E"

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1067,7 +1067,7 @@ def sysinfo():
     """
 
     # processor_info
-    model_name = getoutput("egrep 'model name' /proc/cpuinfo -m 1").split(":")[-1]
+    model_name = getoutput("grep -E 'model name' /proc/cpuinfo -m 1").split(":")[-1]
     print(f"Processor:{model_name}")
 
     # get core count
@@ -1095,7 +1095,7 @@ def sysinfo():
     print(f"CPU min frequency: {min_freq:.0f} MHz\n")
 
     # get coreid's and frequencies of online cpus by parsing /proc/cpuinfo
-    coreid_info = getoutput("egrep 'processor|cpu MHz|core id' /proc/cpuinfo").split("\n")
+    coreid_info = getoutput("grep -E 'processor|cpu MHz|core id' /proc/cpuinfo").split("\n")
     cpu_core = dict()
     freq_per_cpu = []
     for i in range(0, len(coreid_info), 3):


### PR DESCRIPTION
Fixed an issue #434 caused by the recent update to `grep`. Said update results in a `egrep is obsolescent; using grep -E` line to be printed before the actual desired output whenever `egrep` is called.