### PR TITLE
add wheel to dependencies (should speed up install)

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -40,7 +40,7 @@ function setup_venv {
     python3 -m venv "${venv_dir}"
 
     source "${venv_dir}/bin/activate"
-    python3 -m pip install --upgrade pip
+    python3 -m pip install --upgrade pip wheel
     python3 -m pip install -r requirements.txt
 }
 


### PR DESCRIPTION
Signed-off-by: John Seekins <john@civiceagle.com>

`wheel` lets `pip` download pre-compiled binary packages, which should make the actual install process a little smoother for people.