### PR TITLE
Fix for Regression in #460

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -167,7 +167,7 @@ function tool_remove {
   srv_install="/usr/local/bin/auto-cpufreq-install"
   srv_install_old="/usr/bin/auto-cpufreq-install"
 
-  srv_remove="/usr/bin/auto-cpufreq-remove"
+  srv_remove="/usr/local/bin/auto-cpufreq-remove"
   srv_remove_old="/usr/bin/auto-cpufreq-remove"
 
   stats_file="/var/run/auto-cpufreq.stats"
@@ -189,7 +189,7 @@ function tool_remove {
   done
 
   # run uninstall in case of installed daemon
-  if [ -f $srv_remove -o -f $srv_remove_old]; then
+  if [ -f $srv_remove -o -f $srv_remove_old ]; then
     eval $tool_proc_rm
   else
 	separator

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -193,7 +193,8 @@ function tool_remove {
     eval $tool_proc_rm
   else
 	separator
-	printf "Couldn't remove auto-cpufreq\n$srv_remove or $srv_remove_old do not exist.\n"
+	printf "Couldn't remove the auto-cpufreq daemon\n$srv_remove or $srv_remove_old do not exist.\n"
+	exit 1;
 	separator
   fi
 

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -183,6 +183,10 @@ function tool_remove {
   # run uninstall in case of installed daemon
   if [ -f $srv_remove ]; then
     eval $tool_proc_rm
+  else
+	separator
+	printf "Couldn't remove auto-cpufreq\n"
+	separator
   fi
 
   # remove auto-cpufreq and all its supporting files

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -163,14 +163,22 @@ fi
 function tool_remove {
   files="files.txt"
   share_dir="/usr/local/share/auto-cpufreq/"
-  srv_install="/usr/bin/auto-cpufreq-install"
+
+  srv_install="/usr/local/bin/auto-cpufreq-install"
+  srv_install_old="/usr/bin/auto-cpufreq-install"
+
   srv_remove="/usr/bin/auto-cpufreq-remove"
+  srv_remove_old="/usr/bin/auto-cpufreq-remove"
+
   stats_file="/var/run/auto-cpufreq.stats"
+
   tool_proc_rm="/usr/local/bin/auto-cpufreq --remove"
   wrapper_script="/usr/local/bin/auto-cpufreq"
   unit_file="/etc/systemd/system/auto-cpufreq.service"
   venv_path="/opt/auto-cpufreq"
-  cpufreqctl="/usr/bin/cpufreqctl.auto-cpufreq"
+
+  cpufreqctl="/usr/local/bin/cpufreqctl.auto-cpufreq"
+  cpufreqctl_old="/usr/bin/cpufreqctl.auto-cpufreq"
 
   # stop any running auto-cpufreq argument (daemon/live/monitor)
   tool_arg_pids=($(pgrep -f "auto-cpufreq --"))
@@ -181,11 +189,11 @@ function tool_remove {
   done
 
   # run uninstall in case of installed daemon
-  if [ -f $srv_remove ]; then
+  if [ -f $srv_remove -o -f $srv_remove_old]; then
     eval $tool_proc_rm
   else
 	separator
-	printf "Couldn't remove auto-cpufreq\n"
+	printf "Couldn't remove auto-cpufreq\n$srv_remove or $srv_remove_old do not exist.\n"
 	separator
   fi
 
@@ -195,11 +203,17 @@ function tool_remove {
 
   # files cleanup
   [ -f $srv_install ] && rm $srv_install
+  [ -f $srv_install_old ] && rm $srv_install_old
+
   [ -f $srv_remove ] && rm $srv_remove
+  [ -f $srv_remove_old ] && rm $srv_remove_old
+
   [ -f $stats_file ] && rm $stats_file
   [ -f $unit_file ] && rm $unit_file
   [ -f $wrapper_script ] && rm $wrapper_script
+
   [ -f $cpufreqctl ] && rm $cpufreqctl
+  [ -f $cpufreqctl_old ] && rm $cpufreqctl_old
 
   # remove python virtual environment
   rm -rf "${venv_path}"


### PR DESCRIPTION
The uninstall script was checking old locations (`/usr/bin/<file>`) that were changed by @gimbles

When the check to see if `/usr/bin/auto-cpufreq-remove` existed failed (since it's now at `/usr/local/bin/auto-cpufreq-remove`), the removal didn't occur fully and the installer silently goes on until the  success message is wrongly printed.

Just adding  a check for this should make it work now

However, people who downloaded older versions of `auto-cpufreq` will still have those scripts at the old locations (in `/usr/bin`), so I added some variables with an `_old` suffix so people cloning a new repo and running the script can still uninstall their old versions of `auto-cpufreq`.

We could also use `/usr/local/bin` for only Silverblue, which is something I can work on later, but this should fix the script for now.