### PR TITLE
[Feature] Force use of powersave or performance governors

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ auto-cpufreq should be run with with one of the following options:
 * force TEXT
     - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
 
+* state
+    - Show if the governor has been overriden with --force. Returns 'default' if there's no override
+
 * config TEXT
     - Use config file at defined path
 

--- a/README.md
+++ b/README.md
@@ -206,13 +206,13 @@ auto-cpufreq should be run with with one of the following options:
 * [stats](https://github.com/AdnanHodzic/auto-cpufreq/#stats)
     - View live stats of CPU optimizations made by daemon
 
-* force TEXT
+* force=TEXT
     - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
 
 * state
     - Show if the governor has been overriden with --force. Returns 'default' if there's no override
 
-* config TEXT
+* config=TEXT
     - Use config file at defined path
 
 * debug
@@ -242,6 +242,12 @@ No changes are made to the system, and is solely made for demonstration purposes
 `sudo auto-cpufreq --live`
 
 Necessary changes are temporarily made to the system which are lost with system reboot. This mode is made to evaluate what the system would behave with auto-cpufreq permanently running on the system.
+
+### Overriding governor
+
+`sudo auto-cpufreq --force=governor`
+
+The system will be forced to use the governor of choice. The only governor options are "powersave" and "performance". Setting force to "reset" will disable any override. Please note that any set override will persist even after reboot.
 
 ### Install - auto-cpufreq daemon
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ auto-cpufreq should be run with with one of the following options:
 
 * [force=TEXT](https://github.com/AdnanHodzic/auto-cpufreq/#overriding-governor)
     - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
-
 * state
     - Show if the governor has been overriden with --force. Returns 'default' if there's no override
 
@@ -248,7 +247,8 @@ Necessary changes are temporarily made to the system which are lost with system 
 
 `sudo auto-cpufreq --force=governor`
 
-The system will be forced to use the governor of choice. The only governor options are "powersave" and "performance". Setting force to "reset" will disable any override. Please note that any set override will persist even after reboot.
+Force use of either "powersave" or "performance" governors. Setting to "reset" will go back to normal mode
+Please note that any set override will persist even after reboot.
 
 ### Install - auto-cpufreq daemon
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ auto-cpufreq is looking for [co-maintainers & open source developers to help sha
 * [auto-cpufreq modes and options](https://github.com/AdnanHodzic/auto-cpufreq/#auto-cpufreq-modes-and-options)
     * [monitor](https://github.com/AdnanHodzic/auto-cpufreq/#monitor)
     * [live](https://github.com/AdnanHodzic/auto-cpufreq/#live)
+    * [overriding governor](https://github.com/AdnanHodzic/auto-cpufreq/#overriding-governor)
     * [Install - auto-cpufreq daemon](https://github.com/AdnanHodzic/auto-cpufreq/#install---auto-cpufreq-daemon)
     * [Remove - auto-cpufreq daemon](https://github.com/AdnanHodzic/auto-cpufreq/#remove---auto-cpufreq-daemon)
     * [stats](https://github.com/AdnanHodzic/auto-cpufreq/#stats)
@@ -206,7 +207,7 @@ auto-cpufreq should be run with with one of the following options:
 * [stats](https://github.com/AdnanHodzic/auto-cpufreq/#stats)
     - View live stats of CPU optimizations made by daemon
 
-* force=TEXT
+* [force=TEXT](https://github.com/AdnanHodzic/auto-cpufreq/#overriding-governor)
     - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
 
 * state

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ auto-cpufreq should be run with with one of the following options:
     - View live stats of CPU optimizations made by daemon
 
 * [force=TEXT](https://github.com/AdnanHodzic/auto-cpufreq/#overriding-governor)
-    - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
+    - Force use of either the "powersave" or "performance" governor. Setting to "reset" goes back to normal mode
 
 * config=TEXT
     - Use config file at defined path

--- a/README.md
+++ b/README.md
@@ -210,8 +210,6 @@ auto-cpufreq should be run with with one of the following options:
 
 * [force=TEXT](https://github.com/AdnanHodzic/auto-cpufreq/#overriding-governor)
     - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
-* state
-    - Show if the governor has been overriden with --force. Returns 'default' if there's no override
 
 * config=TEXT
     - Use config file at defined path

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ auto-cpufreq should be run with with one of the following options:
 * [stats](https://github.com/AdnanHodzic/auto-cpufreq/#stats)
     - View live stats of CPU optimizations made by daemon
 
+* force TEXT
+    - Force use of either the powersave or performance governor. Setting to 'reset' goes back to normal mode
+
 * config TEXT
     - Use config file at defined path
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -90,16 +90,19 @@ def get_override():
     if os.path.isfile(STORE):
         with open(STORE, "rb") as store:
             return pickle.load(store)
+    else:
+        return "default"
 
-def set_override(override=False):
+def set_override(override):
     if override in ["powersave", "performance"]:
         with open(STORE, "wb") as store:
             pickle.dump(override, store)
         print(f"Set governor override to {override}")
     elif override == "reset":
-        os.remove(STORE)
+        if os.path.isfile(STORE):
+            os.remove(STORE)
         print("Governor override removed")
-    else:
+    elif override is not None:
         print("Invalid option.\nUse force=performance, force=powersave, or force=reset")
 
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -337,14 +337,6 @@ def footer(l=79):
     print("\n" + "-" * l + "\n")
 
 
-def daemon_not_found():
-    print("\n" + "-" * 32 + " Daemon check " + "-" * 33 + "\n")
-    print(
-        "ERROR:\n\nDaemon not enabled, must run install first, i.e: \nsudo auto-cpufreq --install"
-    )
-    footer()
-
-
 def deploy_complete_msg():
     print("\n" + "-" * 17 + " auto-cpufreq daemon installed and running " + "-" * 17 + "\n")
     print("To view live stats, run:\nauto-cpufreq --stats")
@@ -1185,20 +1177,12 @@ def sysinfo():
         print("\nCPU fan speed:", psutil.sensors_fans()[current_fan][0].current, "RPM")
 
 
-def no_stats_msg():
-    print("\n" + "-" * 29 + " auto-cpufreq stats " + "-" * 30 + "\n")
-    print(
-        'ERROR: auto-cpufreq stats are missing.\n\nMake sure to run: "auto-cpufreq --install" first'
-    )
-
 
 # read stats func
 def read_stats():
     # read stats
     if os.path.isfile(auto_cpufreq_stats_path):
         call(["tail", "-n 50", "-f", str(auto_cpufreq_stats_path)], stderr=DEVNULL)
-    else:
-        no_stats_msg()
     footer()
 
 
@@ -1226,13 +1210,12 @@ def daemon_running_msg():
 def daemon_not_running_msg():
     print("\n" + "-" * 24 + " auto-cpufreq not running " + "-" * 30 + "\n")
     print(
-        "ERROR: auto-cpufreq is not running in daemon mode.\n\nMake sure to start the daemon with --install before running with --force option"
+        "ERROR: auto-cpufreq is not running in daemon mode.\n\nMake sure to run \"sudo auto-cpufreq --install\" first"
     )
     footer()
 
-
 # check if auto-cpufreq --daemon is running
-def running_daemon():
+def running_daemon_check():
     if is_running("auto-cpufreq", "--daemon"):
         daemon_running_msg()
         exit(1)
@@ -1241,7 +1224,7 @@ def running_daemon():
         exit(1)
 
 # check if auto-cpufreq --daemon is not running
-def not_running_daemon():
+def not_running_daemon_check():
     if not is_running("auto-cpufreq", "--daemon"):
         daemon_not_running_msg()
         exit(1)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -75,7 +75,6 @@ def file_stats():
     auto_cpufreq_stats_file = open(auto_cpufreq_stats_path, "w")
     sys.stdout = auto_cpufreq_stats_file
 
-
 def get_config(config_file=""):
     if not hasattr(get_config, "config"):
         get_config.config = configparser.ConfigParser()
@@ -608,6 +607,8 @@ def set_powersave():
     else:
         gov = get_avail_powersave()
     print(f'Setting to use: "{gov}" governor')
+    if get_override() != "default":
+        print("Warning: governor overwritten using `--force` flag.")
     run(f"cpufreqctl.auto-cpufreq --governor --set={gov}", shell=True)
     if (
         Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists()
@@ -814,6 +815,8 @@ def set_performance():
         gov = get_avail_performance()
 
     print(f'Setting to use: "{gov}" governor')
+    if get_override() != "default":
+        print("Warning: governor overwritten using `--force` flag.")
     run(
         f"cpufreqctl.auto-cpufreq --governor --set={gov}",
         shell=True,

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -428,7 +428,7 @@ def deploy_daemon_performance():
 
 
 # remove auto-cpufreq daemon
-def remove():
+def remove_daemon():
 
     # check if auto-cpufreq is installed
     if not os.path.exists("/usr/local/bin/auto-cpufreq-remove"):
@@ -449,6 +449,10 @@ def remove():
 
     # remove auto-cpufreq-remove
     os.remove("/usr/local/bin/auto-cpufreq-remove")
+
+    # delete override pickle if it exists
+    if os.path.exists(STORE):
+        os.remove(STORE)
 
     # delete stats file
     if auto_cpufreq_stats_path.exists():
@@ -1216,6 +1220,13 @@ def daemon_running_msg():
     )
     footer()
 
+def daemon_not_running_msg():
+    print("\n" + "-" * 24 + " auto-cpufreq not running " + "-" * 30 + "\n")
+    print(
+        "ERROR: auto-cpufreq is not running in daemon mode.\n\nMake sure to start the daemon with --install before running with --force option"
+    )
+    footer()
+
 
 # check if auto-cpufreq --daemon is running
 def running_daemon():
@@ -1224,4 +1235,13 @@ def running_daemon():
         exit(1)
     elif os.getenv("PKG_MARKER") == "SNAP" and dcheck == "enabled":
         daemon_running_msg()
+        exit(1)
+
+# check if auto-cpufreq --daemon is not running
+def not_running_daemon():
+    if not is_running("auto-cpufreq", "--daemon"):
+        daemon_not_running_msg()
+        exit(1)
+    elif os.getenv("PKG_MARKER") == "SNAP" and dcheck == "disabled":
+        daemon_not_running_msg()
         exit(1)

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -18,15 +18,13 @@ from auto_cpufreq.power_helper import *
 @click.command()
 @click.option("--monitor", is_flag=True, help="Monitor and see suggestions for CPU optimizations")
 @click.option("--live", is_flag=True, help="Monitor and make (temp.) suggested CPU optimizations")
-@click.option(
-    "--install/--remove",
-    default=True,
-    help="Install/remove daemon for (permanent) automatic CPU optimizations",
-)
+@click.option("--install", is_flag=True, help="Install daemon for (permanent) automatic CPU optimizations")
+@click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
+
 @click.option("--install_performance", is_flag=True, help="Install daemon in \"performance\" mode, reference:\n https://bit.ly/3bjVZW1")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--force", is_flag=False, help="Force use of either powersave or performance governors. Setting to 'reset' will go back to normal mode")
-@click.option("--state", is_flag=True, help="Show if the governor has been overriden with --force. Returns 'default' if there's no override")
+@click.option("--get-state", is_flag=True, help="Show if the governor has been overriden with --force. Returns 'default' if there's no override")
 @click.option(
     "--config",
     is_flag=False,
@@ -38,7 +36,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--donate", is_flag=True, help="Support the project")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
-def main(config, daemon, debug, install, install_performance, live, log, monitor, stats, version, donate, force, state):
+def main(config, daemon, debug, install, remove, install_performance, live, log, monitor, stats, version, donate, force, get_state):
 
     # display info if config file is used
     def config_info_dialog():
@@ -46,11 +44,15 @@ def main(config, daemon, debug, install, install_performance, live, log, monitor
             print("\nUsing settings defined in " + config + " file")
 
     # set governor override unless None or invalid
+    if force is not None:
+        not_running_daemon()
     set_override(force)
 
     if len(sys.argv) == 1:
+ 
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
+ 
         print("\nExample usage:\nauto-cpufreq --monitor")
         print("\n-----\n")
 
@@ -143,7 +145,7 @@ def main(config, daemon, debug, install, install_performance, live, log, monitor
             read_stats()
         elif log:
             deprecated_log_msg()
-        elif state:
+        elif get_state:
             override = get_override()
             print(override)
         elif debug:
@@ -226,7 +228,7 @@ def main(config, daemon, debug, install, install_performance, live, log, monitor
                 remove_complete_msg()
             else:
                 root_check()
-                remove()
+                remove_daemon()
                 remove_complete_msg()
 
 

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -25,6 +25,7 @@ from auto_cpufreq.power_helper import *
 )
 @click.option("--install_performance", is_flag=True, help="Install daemon in \"performance\" mode, reference:\n https://bit.ly/3bjVZW1")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
+@click.option("--force", is_flag=False, help="Force use of either powersave or performance governors. Setting to 'reset' will go back to normal mode")
 @click.option(
     "--config",
     is_flag=False,
@@ -36,12 +37,15 @@ from auto_cpufreq.power_helper import *
 @click.option("--donate", is_flag=True, help="Support the project")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
-def main(config, daemon, debug, install, install_performance, live, log, monitor, stats, version, donate):
+def main(config, daemon, debug, install, install_performance, live, log, monitor, stats, version, donate, force):
 
     # display info if config file is used
     def config_info_dialog():
         if get_config(config) and hasattr(get_config, "using_cfg_file"):
             print("\nUsing settings defined in " + config + " file")
+
+    # set governor override unless None or invalid
+    set_override(force)
 
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -23,7 +23,7 @@ from auto_cpufreq.power_helper import *
 
 @click.option("--install_performance", is_flag=True, help="Install daemon in \"performance\" mode, reference:\n https://bit.ly/3bjVZW1")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
-@click.option("--force", is_flag=False, help="Force use of either powersave or performance governors. Setting to 'reset' will go back to normal mode")
+@click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
 @click.option("--get-state", is_flag=True, help="Show if the governor has been overriden with --force. Returns 'default' if there's no override")
 @click.option(
     "--config",

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -24,7 +24,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--install_performance", is_flag=True, help="Install daemon in \"performance\" mode, reference:\n https://bit.ly/3bjVZW1")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
-@click.option("--get-state", is_flag=True, help="Show if the governor has been overriden with --force. Returns 'default' if there's no override")
+@click.option("--get-state", is_flag=True, hidden=True)
 @click.option(
     "--config",
     is_flag=False,

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -45,7 +45,7 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
 
     # set governor override unless None or invalid
     if force is not None:
-        not_running_daemon()
+        not_running_daemon_check()
     set_override(force)
 
     if len(sys.argv) == 1:
@@ -99,7 +99,7 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
                 tlp_service_detect()
             while True:
                 time.sleep(1)
-                running_daemon()
+                running_daemon_check()
                 footer()
                 gov_check()
                 cpufreqctl()
@@ -121,7 +121,7 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
                 tlp_service_detect()
             while True:
                 try:
-                    running_daemon()
+                    running_daemon_check()
                     footer()
                     gov_check()
                     cpufreqctl()
@@ -134,6 +134,7 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
                     print("")
                     sys.exit()
         elif stats:
+            not_running_daemon_check()
             config_info_dialog()
             print('\nNote: You can quit stats mode by pressing "ctrl+c"')
             if os.getenv("PKG_MARKER") == "SNAP":
@@ -146,6 +147,7 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
         elif log:
             deprecated_log_msg()
         elif get_state:
+            not_running_daemon_check()
             override = get_override()
             print(override)
         elif debug:
@@ -191,14 +193,14 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
                     "Reference: https://github.com/AdnanHodzic/auto-cpufreq#configuring-auto-cpufreq\n")
             else:
                 root_check()
-                running_daemon()
+                running_daemon_check()
                 gov_check()
                 deploy_daemon_performance()
                 deploy_complete_msg()
         elif install:
             if os.getenv("PKG_MARKER") == "SNAP":
                 root_check()
-                running_daemon()
+                running_daemon_check()
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
                 bluetooth_notif_snap()
@@ -208,7 +210,7 @@ def main(config, daemon, debug, install, remove, install_performance, live, log,
                 deploy_complete_msg()
             else:
                 root_check()
-                running_daemon()
+                running_daemon_check()
                 gov_check()
                 deploy_daemon()
                 deploy_complete_msg()

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -26,6 +26,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--install_performance", is_flag=True, help="Install daemon in \"performance\" mode, reference:\n https://bit.ly/3bjVZW1")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--force", is_flag=False, help="Force use of either powersave or performance governors. Setting to 'reset' will go back to normal mode")
+@click.option("--state", is_flag=True, help="Show if the governor has been overriden with --force. Returns 'default' if there's no override")
 @click.option(
     "--config",
     is_flag=False,
@@ -37,7 +38,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--donate", is_flag=True, help="Support the project")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
-def main(config, daemon, debug, install, install_performance, live, log, monitor, stats, version, donate, force):
+def main(config, daemon, debug, install, install_performance, live, log, monitor, stats, version, donate, force, state):
 
     # display info if config file is used
     def config_info_dialog():
@@ -142,6 +143,9 @@ def main(config, daemon, debug, install, install_performance, live, log, monitor
             read_stats()
         elif log:
             deprecated_log_msg()
+        elif state:
+            override = get_override()
+            print(override)
         elif debug:
             # ToDo: add status of GNOME Power Profile service status
             config_info_dialog()


### PR DESCRIPTION
I noticed a couple of people had requested this and I wanted the feature myself, so I took the initiative. I threw this together, but I tested it well and it works flawlessly so far.

This adds two new options.

`--force TEXT` allows the user to force a governor into use until the user disables it.
For example, if I do `sudo auto-cpufreq --force=powersave` this will force the use of the powersave governor under any circumstance. If you plug in your laptop it will still use powersave mode, and changing the config file will not do anything. This will even persist after a reboot because it's stored to disk. 

Using `sudo auto-cpufreq --force=reset` will reset the override and return to using the config file or default governors

the `--state` options returns the status of the override. if there's no override it simply returns `default`

Hopefully, this is a welcome change. You're welcome to change any of the help messages or updates I made to the README as I made them on the fly and didn't put a ton of thought into the wording.