### PR TITLE
updating grub for fedora (noob friendly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,12 @@ If daemon has been installed, live stats of CPU/system load monitoring and optim
 
 **A:** If you're using `intel_pstate/amd-pstate` CPU management driver, consider changing it to `acpi-cpufreq`.
 
-This can be done by editing the `GRUB_CMDLINE_LINUX_DEFAULT` params in `/etc/default/grub`.
+This can be done by editing the `GRUB_CMDLINE_LINUX_DEFAULT` params in `/etc/default/grub`. For instance:
+
+```
+    sudo nano /etc/default/grub
+    # make sure you have nano installed, or you can use your favorite text editor.
+```
 
 For Intel users:
 
@@ -316,7 +321,20 @@ For AMD users:
 GRUB_CMDLINE_LINUX_DEFAULT="quiet splash initcall_blacklist=amd_pstate_init amd_pstate.enable=0"
 ```
 
-After you are done, run `sudo update-grub` or `sudo grub-mkconfig -o /boot/grub/grub.cfg`, if you are using Arch.
+Once you have made the necessary changes to the GRUB configuration file, you can update it by running `sudo update-grub` or `sudo grub-mkconfig -o /boot/grub/grub.cfg` on Arch Linux. On the other hand, for Fedora, you can update the configuration file by running one of the following commands: 
+
+```
+    sudo grub2-mkconfig -o /etc/grub2.cfg
+```
+
+```
+    sudo grub2-mkconfig -o /etc/grub2-efi.cfg
+```
+
+```
+    sudo grub2-mkconfig -o /boot/grub2/grub.cfg  
+    # Legacy boot method for grub update. 
+```
 
 ### AUR
 


### PR DESCRIPTION
This pull request offers a comprehensive guide on how to update and modify the GRUB in Fedora. As Fedora uses GRUB2, this guide is especially useful for beginners who may require assistance in configuring their system. The guide outlines the necessary steps for updating the GRUB, as well as providing instructions on how to modify it in the first place.  