### PR TITLE
fixup(runit): allow daemon to search for the executable in /usr/local/bin

### DIFF
--- a/scripts/auto-cpufreq-runit
+++ b/scripts/auto-cpufreq-runit
@@ -1,2 +1,3 @@
 #!/bin/sh
+export PATH="$PATH:/usr/local/bin"
 exec /usr/local/bin/auto-cpufreq --daemon


### PR DESCRIPTION
Fixes #474, caused due to change of installation path from /usr to /usr/local in #460.