### PR TITLE
[BUG-FIX] Adding root_check before set_override method execution

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -96,6 +96,7 @@ def get_override():
         return "default"
 
 def set_override(override):
+    root_check() # Calling root_check inside if and elif might be too verbose and is susceptible to bugs in future
     if override in ["powersave", "performance"]:
         with open(governor_override_state, "wb") as store:
             pickle.dump(override, store)


### PR DESCRIPTION
Fixes permission issue prompt when calling `--force` flag in non root mode.

This PR, basically calls pre-defined `root_check()` function before accessing `set_override` method aimed at implementing the force feature.
And hence ensuring `set_override` calls are always in su mode. 
So, in effect all override using 'force' can clearly access the `governer_override_state` path file, and write changes to it, without externally tinkering the environment.


<details open>
    <summary>Current output</summary>
<img src="https://github.com/AdnanHodzic/auto-cpufreq/assets/35325046/57402a46-6205-43ac-a520-6ea46fed0b3d" alt="Now">
</details>

<details>
    <summary>Past output</summary>
<img src="https://github.com/AdnanHodzic/auto-cpufreq/assets/35325046/073dfb12-8919-457c-b71c-8b0d709c444d" alt="Past">
</details>



Fixes #523 