### PR TITLE
[BUG-FIX] Fixed bug related to recurring sudo prompt for functions that even don't require it

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -96,7 +96,6 @@ def get_override():
         return "default"
 
 def set_override(override):
-    root_check() # Calling root_check inside if and elif might be too verbose and is susceptible to bugs in future
     if override in ["powersave", "performance"]:
         with open(governor_override_state, "wb") as store:
             pickle.dump(override, store)

--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -45,7 +45,8 @@ def main(config, daemon, debug, install, remove, live, log, monitor, stats, vers
     # set governor override unless None or invalid
     if force is not None:
         not_running_daemon_check()
-    set_override(force)
+        root_check() # Calling root_check before set_override as it will require sudo access
+        set_override(force) # Calling set override, only if force has some values
 
     if len(sys.argv) == 1:
  


### PR DESCRIPTION
The `set_override` function is always called irrespective of the force flag is called or not. This in turn, required root checks for every flag calls, even for `auto-cpufreq --version`.

To fix it, now `set_override` method is now called only if force flag is invoked.
Also root_check is moved from core.py to the main file, to ensure consistency with previous usage of root_check in the code used earlier.

Here are the specific code changes made:

In auto_cpufreq/core.py:
- Line 96: Removed the root_check call from the set_override function. This was intended to be done to comply with code template, i.e. to use root_check in the main file.

In bin/auto-cpufreq:
- Line 45: Added a root_check call before calling set_override in main program. Also, set_override is only called if force option is invoked, saving us from precious extra overheads.

Fixes #530