### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Navigate to repo location where `power_helper.py` resides, i.e:
 
 Make sure to have `psutil` Python library installed before next step, i.e: `sudo python3 -m pip install psutil`
 
-Then disable GNOME Power Profiles Daemon by runing:
+Then disable GNOME Power Profiles Daemon by running:
 
 `sudo python3 power_helper.py --gnome_power_disable`
 
@@ -150,7 +150,7 @@ See [`--force` flag](#overriding-governor) for more info.
 
 ### 3: auto-cpufreq config file
 
-You can configure seperate profiles for the battery and power supply. These profiles will let you pick which governor to use, and how and when turbo boost is enabled. The possible values for turbo boost behavior are `always`, `auto` and `never`. The default behavior is `auto`, which only kicks in during high load.
+You can configure separate profiles for the battery and power supply. These profiles will let you pick which governor to use, and how and when turbo boost is enabled. The possible values for turbo boost behavior are `always`, `auto` and `never`. The default behavior is `auto`, which only kicks in during high load.
 
 By default, auto-cpufreq does not use the config file! If you wish to use it, the location where config needs to be placed for it to be read automatically is: `/etc/auto-cpufreq.conf`
 

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -20,9 +20,9 @@ fi
 
 #separator
 function separator {
-  local COLOUMNS="`tput cols`"
+  local COLUMNS="`tput cols`"
   echo -e "\n"
-  printf "%0.s─" $(seq $COLOUMNS)
+  printf "%0.s─" $(seq $COLUMNS)
   echo -e "\n"
 }
 
@@ -37,8 +37,8 @@ function root_check {
 }
 
 function header {
-	local COLOUMNS="`tput cols`"
-	MID="$((COLOUMNS / 2))"
+	local COLUMNS="`tput cols`"
+	MID="$((COLUMNS / 2))"
 	HEADER="$1"
 	printf "%0.s─" $(seq $((MID-(${#HEADER}/2)- 1)))
 	echo -n " $HEADER "


### PR DESCRIPTION
Found via `codespell -L nstall`