### PR TITLE
Fix issue #544: missing dependencies

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -111,10 +111,10 @@ function manual_install {
 	Didn't detect Debian or RedHat based distro.
 
 	To complete installation, you need to:
-	Install: python3, pip3, python3-setuptools
+	Install: python3, pip3, python3-setuptools, gobject-introspection, cairo (or cairo-devel), gcc, and gtk3
 
 	Install necessary Python packages:
-	pip3 install psutil click distro power
+	pip3 install psutil click distro power requests PyGObject
 	Run following sequence of lines:
 
 	-----
@@ -148,21 +148,21 @@ function tool_install {
 separator
 if [ -f /etc/debian_version ]; then
 	detected_distro "Debian based"
-	apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libcairo2-dev -y
+	apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libcairo2-dev libgtk-3 gcc -y
 	completed
 	complete_msg
 elif [ -f /etc/redhat-release ]; then
 	detected_distro "RedHat based"
 	if [ -f /etc/centos-release ]; then
-		yum install platform-python-devel dmidecode
+		yum install platform-python-devel dmidecode gcc cairo-devel gobject-introspection-devel cairo-gobject-devel gtk3-devel
 	else
-		yum install python-devel dmidecode
+		yum install python-devel dmidecode gcc cairo-devel gobject-introspection-devel cairo-gobject-devel gtk3-devel
 	fi
 	completed
 	complete_msg
 elif [ -f /etc/solus-release ]; then
 	detected_distro "Solus"
-	eopkg install pip python3 python3-devel dmidecode
+	eopkg install pip python3 python3-devel dmidecode gobject-introspection-devel libcairo-devel gcc libgtk-3
 	eopkg install -c system.devel
 	completed
  	complete_msg
@@ -172,23 +172,23 @@ elif [ -f /etc/os-release ];then
 	case $ID in
 	opensuse-leap)
 		detected_distro "OpenSUSE"
-		zypper install -y python3 python3-pip python3-setuptools python3-devel gcc dmidecode
+		zypper install -y python3 python3-pip python3-setuptools python3-devel gcc dmidecode gobject-introspection-devel python3-cairo-devel gtk3 gtk3-devel
 		completed
 		;;
-	opensuse)
+	opensuse-tumbleweed)
 		detected_distro "OpenSUSE"
     		echo -e "\nDetected an OpenSUSE distribution\n\nSetting up Python environment\n"
-		zypper install -y python38 python3-pip python3-setuptools python3-devel gcc dmidecode gobject-introspection-devel python3-cairo-devel
+		zypper install -y python38 python3-pip python3-setuptools python3-devel gcc dmidecode gobject-introspection-devel python3-cairo-devel gtk3 gtk3-devel
 		completed
 		;;
 	arch|manjaro|endeavouros|garuda|artix)
 		detected_distro "Arch Linux based"
-		pacman -S --noconfirm --needed python python-pip python-setuptools base-devel dmidecode  gobject-introspection
+		pacman -S --noconfirm --needed python python-pip python-setuptools base-devel dmidecode gobject-introspection gtk3 gcc
 		completed
 		;;
 	void)
 		detected_distro "Void Linux"
-    		xbps-install -Sy python3 python3-pip python3-devel python3-setuptools base-devel dmidecode
+    		xbps-install -Sy python3 python3-pip python3-devel python3-setuptools base-devel dmidecode cairo-devel gobject-introspection gcc gtk+3
 		completed
 		;;
 	*) #Any other distro


### PR DESCRIPTION
This change fixes the problem brought up in #544 where the install script was missing several dependencies for certain distros.

I tested this in a Void, Fedora, and OpenSUSE Tumbleweed container to confirm installing the packages fix the error given