### PR TITLE
Fix #545: additional cpu temp sensors

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1194,31 +1194,34 @@ def sysinfo():
     offline_cpus = [str(cpu) for cpu in range(total_cpu_count) if cpu not in cpu_core]
 
     # temperatures
-    core_temp = psutil.sensors_temperatures()
+    temp_sensors = psutil.sensors_temperatures()
     temp_per_cpu = [float("nan")] * online_cpu_count
     try:
-        if "coretemp" in core_temp:
+        # the priority for CPU temp is as follows: coretemp sensor -> sensor with CPU in the label -> acpi -> k10temp
+        if "coretemp" in temp_sensors:
             # list labels in 'coretemp'
-            core_temp_labels = [temp.label for temp in core_temp["coretemp"]]
+            core_temp_labels = [temp.label for temp in temp_sensors["coretemp"]]
             for i, cpu in enumerate(cpu_core):
-                # get correct index in core_temp
+                # get correct index in temp_sensors
                 core = cpu_core[cpu]
                 cpu_temp_index = core_temp_labels.index(f"Core {core}")
-                temp_per_cpu[i] = core_temp["coretemp"][cpu_temp_index].current
+                temp_per_cpu[i] = temp_sensors["coretemp"][cpu_temp_index].current
         else:
             # iterate over all sensors
-            for sensor in core_temp:
+            for sensor in temp_sensors:
                 # iterate over all temperatures in the current sensor
-                for temp in core_temp[sensor]:
-                    if temp.label == 'CPU':
+                for temp in temp_sensors[sensor]:
+                    if 'CPU' in temp.label:
                         temp_per_cpu = [temp.current] * online_cpu_count
                         break
                 else:
                     continue
                 break
-            else: # if 'CPU' label not found in any sensor, use first available temperature
-                temp = list(core_temp.keys())[0]
-                temp_per_cpu = [core_temp[temp][0].current] * online_cpu_count
+            else:
+                if "acpitz" in temp_sensors:
+                    temp_per_cpu = [temp_sensors["acpitz"][0].current] * online_cpu_count
+                elif "k10temp" in temp_sensors:
+                    temp_per_cpu = [temp_sensors["k10temp"][0].current] * online_cpu_count
     except Exception as e:
         print(repr(e))
         pass


### PR DESCRIPTION
This resolves #545.

Not sure how I didn't notice this before, as I was experiencing the same on my laptop.

I believe AMD drivers on Linux do not report individual core temps, so the `coretemp` sensor was not found and it was defaulting to the first sensor it could find which was my SSD temperature.
I added 2 additional sensors to check for. My temp is reported by ACPI, and then k10temp reports the Tctl which is used as a last resort. Now, if it can't find a sensor it will return "nan".