### PR TITLE
Fixes auto-cpufreq --update for Arch based distros for non AUR installations

### DIFF
--- a/bin/auto-cpufreq
+++ b/bin/auto-cpufreq
@@ -232,7 +232,7 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
 
                 print("Please update using snap package manager, i.e: `sudo snap refresh auto-cpufreq`.")
                 #check for AUR 
-            elif subprocess.run(["bash", "-c", "command -v yay >/dev/null 2>&1"]).returncode == 0 or subprocess.run(["bash", "-c", "command -v pacman >/dev/null 2>&1"]).returncode == 0:
+            elif subprocess.run(["bash", "-c", "command -v pacman >/dev/null 2>&1"]).returncode == 0 and subprocess.run(["bash", "-c", "pacman -Q auto-cpufreq >/dev/null 2>&1"]).returncode == 0:
                 print("Arch-based distribution with AUR support detected. Please refresh auto-cpufreq using your AUR helper.")
             else:
                 verify_update()


### PR DESCRIPTION
Details:
-  Updated logic now checks if auto-cpufreq is installed via AUR or not (pacman -Q auto-cpufreq). If found, it recommends using the system package manager to refresh it.

-  Removed the obsolete yay checking as yay is considered a Pacman wrapper. (Need confirmation from @cosmos1721 for intent) 

Fixes:
Persistant `Arch-based distribution with AUR support detected. Please refresh auto-cpufreq using your AUR helper.` error, even when you haven't installed auto-cpufreq from AUR, on Arch Distro.

References:
[Arch Wiki - AUR Helpers](https://wiki.archlinux.org/title/AUR_helpers)