### PR TITLE
replaced #!/bin/bash  with  #!/usr/bin/env bash

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # auto-cpufreq-installer:
 # auto-cpufreq source code based installer

--- a/scripts/auto-cpufreq-install.sh
+++ b/scripts/auto-cpufreq-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # auto-cpufreq daemon install script
 # reference: https://github.com/AdnanHodzic/auto-cpufreq

--- a/scripts/snapdaemon.sh
+++ b/scripts/snapdaemon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # workaround for running Daemon without polluting syslog (#53, #82)
 $SNAP/bin/auto-cpufreq --daemon 2>&1 >> $SNAP_DATA/auto-cpufreq.stats


### PR DESCRIPTION
Some Distros do not have /bin/bash by default, but have bash installed at some other location and in PATH.
To allow all of these distros to use these shell scripts, change the shebangs to search for bash in PATH.

More to why this is better [here](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my)