### PR TITLE
add Nix flake and better Nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ auto-cpufreq is looking for [co-maintainers & open source developers to help sha
     * [Snap store](#snap-store)
     * [auto-cpufreq-installer](#auto-cpufreq-installer)
     * [AUR package (Arch/Manjaro Linux)](#aur-package-archmanjaro-linux)
+    * [NixOS](#nixos)
     * [Update using installer](#update-using-auto-cpufreq-installer)
 * [Post Installation](#post-installation)
 * [Configuring auto-cpufreq](#configuring-auto-cpufreq)
@@ -115,6 +116,81 @@ In case you encounter any problems with `auto-cpufreq-installer`, please [submit
 (For the latest binary release on github)
 * [Git Package](https://aur.archlinux.org/packages/auto-cpufreq-git)
 (For the latest commits/changes)
+
+### NixOS
+
+<details>
+<summary>Flakes</summary>
+<br>
+
+This repo contains a flake that exposes a NixOS Module that manages and offers options for auto-cpufreq. To use it, add the flake as an input to your `flake.nix` file, and enable the module
+
+```nix 
+# flake.nix
+
+{
+
+    inputs = {
+        # ---Snip---
+        auto-cpufreq = {
+            url = "github:adnanhodzic/auto-cpufreq/nix";
+            inputs.nixpkgs.follows = "nixpkgs";
+        };
+        # ---Snip---
+    }
+
+    outputs = {nixpkgs, auto-cpufreq, ...} @ inputs: {
+        nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+            specialArgs = { inherit inputs; };
+            modules = [
+                ./configuration.nix
+                auto-cpufreq.nixosModules.default
+            ];
+        };
+    } 
+}
+```
+Then you can enable the program in your `configuration.nix` file
+```nix
+# configuration.nix
+
+{inputs, pkgs, ...}: {
+    # ---Snip---
+    programs.auto-cpufreq.enable = true;
+    # optionally, you can configure your auto-cpufreq settings, if you have any
+    programs.auto-cpufreq.settings = {
+    charger = {
+      governor = "performance";
+      turbo = "auto";
+    };
+
+    battery = {
+      governor = "powersave";
+      turbo = "auto";
+    };
+  };
+    # ---Snip---
+}
+```
+</details>
+
+<details>
+<summary>Nixpkgs</summary>
+<br>
+
+There is a nixpkg available but it is more prone to being outdated whereas the flake pulls from the latest commit. You can install it in your `configuration.nix` and enable the system service
+```nix
+# configuration.nix
+
+# ---Snip---
+environment.systemPackages = with pkgs; [
+    auto-cpufreq
+];
+
+services.auto-cpufreq.enable = true;
+# ---Snip---
+```
+</details>
 
 ## Post Installation
 After installation `auto-cpufreq` will be available as a binary and you can refer to [auto-cpufreq modes and options](https://github.com/AdnanHodzic/auto-cpufreq#auto-cpufreq-modes-and-options) for more information on how to run and configure `auto-cpufreq`.

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -191,6 +191,11 @@ elif [ -f /etc/os-release ];then
     		xbps-install -Sy python3 python3-pip python3-devel python3-setuptools base-devel dmidecode cairo-devel gobject-introspection gcc gtk+3
 		completed
 		;;
+  nixos)
+    echo -e "NixOS detected\n"
+    echo -e "This installer is not supported on NixOS.\nPlease refer to the install instructions for NixOS at https://github.com/AdnanHodzic/auto-cpufreq#nixos"
+    exit 1
+    ;;
 	*) #Any other distro
 	manual_install
 	completed

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693355128,
+        "narHash": "sha256-+ZoAny3ZxLcfMaUoLVgL9Ywb/57wP+EtsdNGuXUJrwg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a63a64b593dcf2fe05f7c5d666eb395950f36bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+
+    outputs = {self, nixpkgs}@inputs :
+    let
+        system = "x86_64-linux"; # replace this as needed
+        pkgs = nixpkgs.legacyPackages.${system};
+        auto-cpufreq = pkgs.python3Packages.callPackage ./nix/default.nix {};
+    in {
+        packages.${system}.default = auto-cpufreq; 
+
+	    devShells.${system}.default = pkgs.mkShell {
+		    inputsFrom = [ auto-cpufreq ];
+            packages = [ pkgs.python310Packages.pip ];
+	    };
+
+        nixosModules.default = import ./nix/module.nix inputs;
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,64 @@
+{ lib, python310Packages, fetchFromGitHub, callPackage, pkgs, version ? "git"}:
+
+python310Packages.buildPythonPackage rec {
+  pname = "auto-cpufreq";
+  inherit version;
+
+  # src = fetchFromGitHub {
+  #   owner = "AdnanHodzic";
+  #   repo = pname;
+  #   rev = "v${version}";
+  #   sha256 = "sha256-ElYzVteBnoz7BevA6j/730BMG0RsmhBQ4PNl9+0Kw4k=";
+  # };
+  src = ../.;
+
+  nativeBuildInputs = with pkgs; [ wrapGAppsHook gobject-introspection ];
+
+  buildInputs = with pkgs; [ gtk3 ];
+
+  propagatedBuildInputs = with python310Packages; [ requests pygobject3 click distro psutil setuptools (callPackage ./pkgs/setuptools-git-versioning.nix {})];
+
+  doCheck = false;
+  pythonImportsCheck = [ "auto_cpufreq" ];
+
+  patches = [
+
+    #  patch to prevent script copying and to disable install
+    ./patches/prevent-install-and-copy.patch
+
+  ];
+
+  postPatch = ''
+    substituteInPlace auto_cpufreq/core.py --replace '/opt/auto-cpufreq/override.pickle' /var/run/override.pickle
+    substituteInPlace scripts/org.auto-cpufreq.pkexec.policy --replace "/opt/auto-cpufreq/venv/bin/auto-cpufreq" $out/bin/auto-cpufreq
+  '';
+
+  postInstall = ''
+    # copy script manually
+    cp scripts/cpufreqctl.sh $out/bin/cpufreqctl.auto-cpufreq
+
+    # systemd service
+    mkdir -p $out/lib/systemd/system
+    cp scripts/auto-cpufreq.service $out/lib/systemd/system
+    substituteInPlace $out/lib/systemd/system/auto-cpufreq.service --replace "/usr/local" $out
+
+    # desktop icon
+    mkdir -p $out/share/applications
+    mkdir $out/share/pixmaps
+    cp scripts/auto-cpufreq-gtk.desktop $out/share/applications
+    cp images/icon.png $out/share/pixmaps/auto-cpufreq.png
+
+    # polkit policy
+    mkdir -p $out/share/polkit-1/actions
+    cp scripts/org.auto-cpufreq.pkexec.policy $out/share/polkit-1/actions
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/AdnanHodzic/auto-cpufreq";
+    description = "Automatic CPU speed & power optimizer for Linux";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.Technical27 ];
+    mainProgram = "auto-cpufreq";
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,43 @@
+inputs: { config, lib, pkgs, options, ... }:
+
+with lib; let
+
+    cfg = config.programs.auto-cpufreq;
+    system = "x86_64-linux";
+    defaultPackage = inputs.self.packages.${system}.default;
+    cfgFilename = "auto-cpufreq.conf";
+    cfgFile = format.generate cfgFilename cfg.settings;
+
+    format = pkgs.formats.ini {};
+
+in {
+
+    options.programs.auto-cpufreq = {
+        enable = mkEnableOption "Automatic CPU speed & power optimizer for Linux";
+
+        settings = mkOption {
+            description = lib.mdDoc ''
+            Configuration for `auto-cpufreq`.
+
+            See its [example configuration file] for supported settings.
+            [example configuration file]: https://github.com/AdnanHodzic/auto-cpufreq/blob/master/auto-cpufreq.conf-example
+            '';
+
+            default = {};
+            type = types.submodule { freeformType = format.type; };
+        };
+    };
+
+    config = mkIf cfg.enable {
+        environment.systemPackages = [ defaultPackage ];
+
+        services.auto-cpufreq.enable = true;
+        systemd.services.auto-cpufreq = {
+            overrideStrategy = "asDropin";
+            serviceConfig.ExecStart = lib.mkForce [ 
+                "" 
+                "${defaultPackage}/bin/auto-cpufreq --daemon --config ${cfgFile}"
+            ]; 
+        };
+    };
+}

--- a/nix/patches/prevent-install-and-copy.patch
+++ b/nix/patches/prevent-install-and-copy.patch
@@ -1,0 +1,113 @@
+diff --git a/auto_cpufreq/core.py b/auto_cpufreq/core.py
+index 99397a9..16869ab 100755
+--- a/auto_cpufreq/core.py
++++ b/auto_cpufreq/core.py
+@@ -350,29 +350,12 @@ def get_current_gov():
+ 
+ 
+ def cpufreqctl():
+-    """
+-    deploy cpufreqctl script
+-    """
+-
+-    # detect if running on a SNAP
+-    if os.getenv("PKG_MARKER") == "SNAP":
+-        pass
+-    else:
+-        # deploy cpufreqctl.auto-cpufreq script
+-        if not os.path.isfile("/usr/local/bin/cpufreqctl.auto-cpufreq"):
+-            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/local/bin/cpufreqctl.auto-cpufreq")
+-
++    # scripts are already in the correct place
++    pass
+ 
+ def cpufreqctl_restore():
+-    """
+-    remove cpufreqctl.auto-cpufreq script
+-    """
+-    # detect if running on a SNAP
+-    if os.getenv("PKG_MARKER") == "SNAP":
+-        pass
+-    else:
+-        if os.path.isfile("/usr/local/bin/cpufreqctl.auto-cpufreq"):
+-            os.remove("/usr/local/bin/cpufreqctl.auto-cpufreq")
++    #no need to restore
++    pass
+ 
+ 
+ def footer(l=79):
+@@ -400,30 +383,8 @@ def remove_complete_msg():
+ 
+ 
+ def deploy_daemon():
+-    print("\n" + "-" * 21 + " Deploying auto-cpufreq as a daemon " + "-" * 22 + "\n")
+-
+-    # deploy cpufreqctl script func call
+-    cpufreqctl()
+-
+-    # turn off bluetooth on boot
+-    bluetooth_disable()
+-
+-    auto_cpufreq_stats_path.touch(exist_ok=True)
+-
+-    print("\n* Deploy auto-cpufreq install script")
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/local/bin/auto-cpufreq-install")
+-
+-    print("\n* Deploy auto-cpufreq remove script")
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/local/bin/auto-cpufreq-remove")
+-
+-    # output warning if gnome power profile is running
+-    gnome_power_detect_install()
+-    gnome_power_svc_disable()
+-
+-    # output warning if TLP service is detected
+-    tlp_service_detect()
+-
+-    call("/usr/local/bin/auto-cpufreq-install", shell=True)
++    # prevent needless copying and system changes
++    pass
+ 
+ 
+ def deploy_daemon_performance():
+@@ -463,40 +424,7 @@ def deploy_daemon_performance():
+ 
+ # remove auto-cpufreq daemon
+ def remove_daemon():
+-
+-    # check if auto-cpufreq is installed
+-    if not os.path.exists("/usr/local/bin/auto-cpufreq-remove"):
+-        print("\nauto-cpufreq daemon is not installed.\n")
+-        sys.exit(1)
+-
+-    print("\n" + "-" * 21 + " Removing auto-cpufreq daemon " + "-" * 22 + "\n")
+-
+-    # turn on bluetooth on boot
+-    bluetooth_enable()
+-
+-    # output warning if gnome power profile is stopped
+-    gnome_power_rm_reminder()
+-    gnome_power_svc_enable()
+-
+-    # run auto-cpufreq daemon remove script
+-    call("/usr/local/bin/auto-cpufreq-remove", shell=True)
+-
+-    # remove auto-cpufreq-remove
+-    os.remove("/usr/local/bin/auto-cpufreq-remove")
+-
+-    # delete override pickle if it exists
+-    if os.path.exists(governor_override_state):
+-        os.remove(governor_override_state)
+-
+-    # delete stats file
+-    if auto_cpufreq_stats_path.exists():
+-        if auto_cpufreq_stats_file is not None:
+-            auto_cpufreq_stats_file.close()
+-
+-        auto_cpufreq_stats_path.unlink()
+-
+-    # restore original cpufrectl script
+-    cpufreqctl_restore()
++    pass
+ 
+ 
+ def gov_check():

--- a/nix/pkgs/setuptools-git-versioning.nix
+++ b/nix/pkgs/setuptools-git-versioning.nix
@@ -1,0 +1,11 @@
+{ fetchPypi, python310Packages}:
+
+python310Packages.buildPythonPackage rec {
+    pname = "setuptools-git-versioning";
+    version = "1.13.5";
+    src = fetchPypi {
+        inherit pname version;
+        sha256 = "af9ad1e8103b5abb5b128c2db4fef99407328ac9c12f65d3ff9550c4bb39ad1c";
+    };
+    propagatedBuildInputs = with python310Packages; [ toml packaging];
+}


### PR DESCRIPTION
As a fairly new user of NixOS, I found that the [current nixpkg](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/tools/system/auto-cpufreq/default.nix) is very outdated.

After discovering this, I decided to package auto-cpufreq myself so I could enjoy it from the latest releases. Also as someone who has been helping develop parts of auto-cpufreq, I wanted to setup a Nix dev environment through a `flake.nix` file. I also rewrote my Nix package to work with the flake and created a NixOS module that any NixOS user can take advantage of. This will allow us to keep up with the latest changes of `auto-cpufreq` without worrying that the nixpkg is outdated.

Note that the `flake.lock` file will need to be updated every once in a while to keep up with changes to Python, packages, etc... This is super easy and I can take care of this as needed. It could even be setup automatically through a GitHub action if we so wish

In addition to the flake, I have updated the README to include info about how to install on NixOS and have updated `auto-cpufreq-installer` to exit and give the user a message upon detection of NixOS

In the meantime, I do plan on writing a PR to update the nixpkg to the latest release, but I still think this is a good change for the minority of Nix users :)
