### PR TITLE
wrapper: switch sh to bash (Void fix)

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -149,7 +149,7 @@ def app_version():
 
     # snap package
     if os.getenv("PKG_MARKER") == "SNAP":
-        print(getoutput("echo \(Snap\) $SNAP_VERSION"))
+        print(getoutput(r"echo \(Snap\) $SNAP_VERSION"))
     # aur package
     elif dist_name in ["arch", "manjaro", "garuda"]:
         aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)

--- a/scripts/auto-cpufreq-runit
+++ b/scripts/auto-cpufreq-runit
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 export PATH="$PATH:/usr/local/bin"
 exec /usr/local/bin/auto-cpufreq --daemon

--- a/scripts/auto-cpufreq-venv-wrapper
+++ b/scripts/auto-cpufreq-venv-wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Wrapper script around auto-cpufreq using the python virtual environment
 
 set -eu


### PR DESCRIPTION
Fixes #577 

Using sh in the wrapper shebang threw an error, but only on Void for some reason, so it has been exchanged for bash instead. Also fixed another warning that was only showing up on Void
