### PR TITLE
feat(cli): added supported for shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ auto-cpufreq should be run with with one of the following options:
 * help
     - Shows all of the above options
 
+* completions=TEXT
+    - To support shell completions (currently bash, zsh and fish)
+    - TEXT can be bash, zsh or fish (shell name)
+
 Running `auto-cpufreq --help` will print the same list of options as above. Read [auto-cpufreq modes and options](#auto-cpufreq-modes-and-options) for more details.
 
 ## auto-cpufreq modes and options

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -269,9 +269,11 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
             if completions == "bash":
                 print("Run the below command in your current shell!\n")
                 print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=bash_source auto-cpufreq)\"' >> ~/.bashrc")
+                print("source ~/.bashrc")
             elif completions == "zsh":
                 print("Run the below command in your current shell!\n")
                 print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=zsh_source auto-cpufreq)\"' >> ~/.zshrc")
+                print("source ~/.zshrc")
             elif completions == "fish":
                 print("Run the below command in your current shell!\n")
                 print("echo '_AUTO_CPUFREQ_COMPLETE=fish_source auto-cpufreq | source' > ~/.config/fish/completions/auto-cpufreq.fish")

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -34,9 +34,10 @@ from auto_cpufreq.power_helper import *
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
+@click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
-def main(config, daemon, debug, update, install, remove, live, log, monitor, stats, version, donate, force, get_state):
+def main(config, daemon, debug, update, install, remove, live, log, monitor, stats, version, donate, force, get_state, completions):
 
     # display info if config file is used
     def config_info_dialog():
@@ -50,7 +51,6 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
         set_override(force) # Calling set override, only if force has some values
 
     if len(sys.argv) == 1:
- 
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
  
@@ -264,6 +264,21 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
                     run(["auto-cpufreq", "--version"])
                 else:
                     print("Aborted")
+
+        elif completions:
+            if completions == "bash":
+                print("Run the below command in your current shell!\n")
+                print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=bash_source auto-cpufreq)\"' >> ~/.bashrc")
+            elif completions == "zsh":
+                print("Run the below command in your current shell!\n")
+                print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=zsh_source auto-cpufreq)\"' >> ~/.zshrc")
+            elif completions == "fish":
+                print("Run the below command in your current shell!\n")
+                print("echo '_AUTO_CPUFREQ_COMPLETE=fish_source auto-cpufreq | source' > ~/.config/fish/completions/auto-cpufreq.fish")
+            else:
+                print("Invalid Option, try bash|zsh|fish as argument to --completions")
+                
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/auto-cpufreq-venv-wrapper
+++ b/scripts/auto-cpufreq-venv-wrapper
@@ -15,20 +15,21 @@ err_exit()
 
 # invocation handling
 #
-param=""
-if [ "${#}" -ne 1 ];
-then
-    err_exit
-else
-    param="${1}"
-fi
+
 
 # load python virtual environment
 venv_dir=/opt/auto-cpufreq/venv
 . "${venv_dir}/bin/activate"
 
 # run python code with venv loaded
-PYTHONPATH=/opt/auto-cpufreq \
+if [[ "${#}" -ne 1 ]]; then
+   PYTHONPATH=/opt/auto-cpufreq \
+            /opt/auto-cpufreq/venv/bin/python \
+            /opt/auto-cpufreq/venv/bin/auto-cpufreq 
+else
+    param="${1}"
+    PYTHONPATH=/opt/auto-cpufreq \
             /opt/auto-cpufreq/venv/bin/python \
             /opt/auto-cpufreq/venv/bin/auto-cpufreq \
             "${param}"
+fi


### PR DESCRIPTION
## Introduction
 Added opt-in shell completions support for bash, zsh and fish shells

### Generating completions

1. ```bash
    auto-cpufreq --completions=zsh # shell name
    ```
2. Copy the displayed command and run it once! Voila! you have the completions working
3. Restart the shell or `source <rc-file>`

### Screenshots 
![Screenshot](https://github.com/AdnanHodzic/auto-cpufreq/assets/35325046/44e19f62-bea3-4202-8836-f5cb06cd3b63)


## Resources
- [Click lib docs](https://click.palletsprojects.com/en/8.1.x/shell-completion/)