### PR TITLE
Add zenpower for AMD CPU temps

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1246,7 +1246,7 @@ def sysinfo():
                     continue
                 break
             else:
-                for sensor in ["acpitz", "k10temp"]:
+                for sensor in ["acpitz", "k10temp", "zenpower"]:
                     if sensor in temp_sensors:
                         if temp_sensors[sensor][0].current != 0:
                             temp_per_cpu = [temp_sensors[sensor][0].current] * online_cpu_count


### PR DESCRIPTION
#145 

So I couldn't get CPU temps of my AMD CPU with zenpower installed. This seems to fix it like it's mentioned in the issue. 