### PR TITLE
fix dubious ownership error in auto-cpufreq-installer

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -59,6 +59,7 @@ function setup_venv {
 
 # tool install
 function install {
+  git config --global --add safe.directory $(pwd)
   python -m pip install .
   mkdir -p /usr/local/share/auto-cpufreq/
   cp -r scripts/ /usr/local/share/auto-cpufreq/


### PR DESCRIPTION
When trying to install auto-cpufreq in Fedora 39, I got the following error: 

> Detected Git repository, but failed because of dubious ownership

Adding the line at the top of the install function according to https://sam.hooke.me/note/2023/08/poetry-fixing-dubious-ownership-error/ solved the error for me.