### PR TITLE
nix: bump version to 2.1.0 and update lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696261572,
-        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
+        "lastModified": 1700823757,
+        "narHash": "sha256-PStAVLO8ycnFBSThYKTFwQ6rw+OH4ZM5KiN0fRE0OuM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
+        "rev": "068bacb9b6fbee6a603d1b1f68d7cf032c4feed1",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,7 @@ python310Packages.buildPythonPackage {
   format = "pyproject";
 
   pname = "auto-cpufreq";
-  version = "2.0.0";
+  version = "2.1.0";
   src = ../.;
 
   nativeBuildInputs = with pkgs; [wrapGAppsHook gobject-introspection];


### PR DESCRIPTION
Simple enough, just updating the version in the nix package to the newest and went ahead and updated the lock file while I was at it