### PR TITLE
Update README.md - troubleshoot turbo mode not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ If the daemon has been installed, live stats of CPU/system load monitoring and o
 * high CPU temperatures
 * CPU not scaling to minimum/maximum frequencies
 * suboptimal CPU performance
+* turbo mode not available
 
 **A:** If you're using the `intel_pstate/amd-pstate` CPU management driver, consider changing it to `acpi-cpufreq`.
 


### PR DESCRIPTION
Add another point in troubleshooting regarding turbo not available on some CPUs. This relates to https://github.com/AdnanHodzic/auto-cpufreq/issues/602 (workaround consisting in switching driver tested on AMD Zen 3+ and Zen 4 CPUs).