### PR TITLE
Update nix flake instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This repo contains a flake that exposes a NixOS Module that manages and offers o
     inputs = {
         # ---Snip---
         auto-cpufreq = {
-            url = "github:adnanhodzic/auto-cpufreq/nix";
+            url = "github:AdnanHodzic/auto-cpufreq";
             inputs.nixpkgs.follows = "nixpkgs";
         };
         # ---Snip---


### PR DESCRIPTION
`/nix` caused a build failure, I suspect it's a holdover from before it was merged to main.