### PR TITLE
Add support for configuring/overriding "Energy Performance Preference (EPP)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ By default, auto-cpufreq does not use the config file! If you wish to use it, th
 # preferred governor
 governor = performance
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
+# EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
 # minimum cpu frequency (in kHz)
@@ -310,7 +310,7 @@ turbo = auto
 # preferred governor
 governor = powersave
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
+# EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
 
 # minimum cpu frequency (in kHz)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ By default, auto-cpufreq does not use the config file! If you wish to use it, th
 # preferred governor
 governor = performance
 
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+energy_performance_preference = performance
+
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
 # see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
@@ -306,6 +309,9 @@ turbo = auto
 # see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
 # preferred governor
 governor = powersave
+
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+energy_performance_preference = power
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ By default, auto-cpufreq does not use the config file! If you wish to use it, th
 # preferred governor
 governor = performance
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
 # minimum cpu frequency (in kHz)
@@ -310,7 +310,7 @@ turbo = auto
 # preferred governor
 governor = powersave
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
 
 # minimum cpu frequency (in kHz)

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -4,7 +4,7 @@
 # preferred governor.
 governor = performance
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
 # minimum cpu frequency (in kHz)
@@ -28,7 +28,7 @@ turbo = auto
 # preferred governor
 governor = powersave
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
 
 # minimum cpu frequency (in kHz)

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -4,6 +4,9 @@
 # preferred governor.
 governor = performance
 
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+energy_performance_preference = performance
+
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
 # see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
@@ -24,6 +27,9 @@ turbo = auto
 # see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
 # preferred governor
 governor = powersave
+
+# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+energy_performance_preference = power
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -4,7 +4,7 @@
 # preferred governor.
 governor = performance
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
+# EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
 # minimum cpu frequency (in kHz)
@@ -28,7 +28,7 @@ turbo = auto
 # preferred governor
 governor = powersave
 
-# see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
+# EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
 
 # minimum cpu frequency (in kHz)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -683,6 +683,8 @@ def set_powersave():
         else:
             run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
             print('Setting to use: "balance_power" EPP')
+    else:
+        print('Not setting EPP (not supported by system)')
 
     # set frequencies
     set_frequencies()
@@ -899,6 +901,8 @@ def set_performance():
         else:
             run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
             print('Setting to use: "balance_performance" EPP')
+    else:
+        print('Not setting EPP (not supported by system)')
 
     # set frequencies
     set_frequencies()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -676,8 +676,13 @@ def set_powersave():
         Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists()
         and Path("/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").exists() is False
     ):
-        run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
-        print('Setting to use: "balance_power" EPP')
+        if conf.has_option("battery", "energy_performance_preference"):
+            epp = conf["battery"]["energy_performance_preference"]
+            run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
+            print(f'Setting to use: "{epp}" EPP')
+        else:
+            run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
+            print('Setting to use: "balance_power" EPP')
 
     # set frequencies
     set_frequencies()
@@ -887,8 +892,13 @@ def set_performance():
         Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists()
         and Path("/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").exists() is False
     ):
-        run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
-        print('Setting to use: "balance_performance" EPP')
+        if conf.has_option("charger", "energy_performance_preference"):
+            epp = conf["charger"]["energy_performance_preference"]
+            run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
+            print(f'Setting to use: "{epp}" EPP')
+        else:
+            run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
+            print('Setting to use: "balance_performance" EPP')
 
     # set frequencies
     set_frequencies()


### PR DESCRIPTION
These changes add support for configuring the energy performance preference value to be used when on charger and battery, via the auto-cpufreq config file. I've updated the readme and example config with examples.