### PR TITLE
Ignore "Device or resource busy" error message when writing value

### DIFF
--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -105,8 +105,8 @@ function write_value () {
     ERROR_MESSAGE=$((echo $VALUE > $FLNM) 2>& 1)
     EXIT_STATUS=$?
 
-    if ! [[ -z $ERROR_MESSAGE || $ERROR_MESSAGE == *"write error: Device or resource busy."* ]]; then
-      echo ERROR_MESSAGE >& 2
+    if ! [[ -z $ERROR_MESSAGE || $ERROR_MESSAGE == *"write error: Device or resource busy"* ]]; then
+      echo $ERROR_MESSAGE >& 2
     fi
 
     return $EXIT_STATUS

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -103,10 +103,13 @@ function driver () {
 function write_value () {
   if [ -w $FLNM ]; then
     ERROR_MESSAGE=$((echo $VALUE > $FLNM) 2>& 1)
+    EXIT_STATUS=$?
 
     if ! [[ -z $ERROR_MESSAGE || $ERROR_MESSAGE =~ .*write[[:space:]]error:[[:space:]]Device[[:space:]]or[[:space:]]resource[[:space:]]busy.* ]]; then
       echo ERROR_MESSAGE >& 2
     fi
+
+    return $EXIT_STATUS
   fi
 }
 

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -105,7 +105,7 @@ function write_value () {
     ERROR_MESSAGE=$((echo $VALUE > $FLNM) 2>& 1)
     EXIT_STATUS=$?
 
-    if ! [[ -z $ERROR_MESSAGE || $ERROR_MESSAGE =~ .*write[[:space:]]error:[[:space:]]Device[[:space:]]or[[:space:]]resource[[:space:]]busy.* ]]; then
+    if ! [[ -z $ERROR_MESSAGE || $ERROR_MESSAGE == *"write error: Device or resource busy."* ]]; then
       echo ERROR_MESSAGE >& 2
     fi
 

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -102,7 +102,11 @@ function driver () {
 
 function write_value () {
   if [ -w $FLNM ]; then
-    echo $VALUE > $FLNM
+    ERROR_MESSAGE=$((echo $VALUE > $FLNM) 2>& 1)
+
+    if ! [[ -z $ERROR_MESSAGE || $ERROR_MESSAGE =~ .*write[[:space:]]error:[[:space:]]Device[[:space:]]or[[:space:]]resource[[:space:]]busy.* ]]; then
+      echo ERROR_MESSAGE >& 2
+    fi
   fi
 }
 


### PR DESCRIPTION
Potential fix for the issue described in #563 by ignoring "write error: Device or resource busy" error message when writing a value.