### PR TITLE
docs(README): add instruction for failing buildings in case of missing git directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Only devices with an Intel, AMD, or ARM CPU are supported. This tool was develop
 
 ### auto-cpufreq-installer
 
+> As auto-cpufreq relies on git based versioning, users are advised to install `auto-cpufreq`  using `git clone` method only. Downloading source code as a zip/from release will emit build error like [these](https://github.com/AdnanHodzic/auto-cpufreq/issues/623).
+
 Get source code, run installer, and follow on-screen instructions:
 
 ```


### PR DESCRIPTION
Builds when done through external zip file having source code, won't work out and will result in error due to `poetry_dynamic_versioning` requiring .git directory. This PR seem to add specific instruction regarding that in README

Fixes #623 