### PR TITLE
Fix SyntaxWarning in objects.py

### DIFF
--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -32,7 +32,7 @@ def get_stats():
 def get_version():
     # snap package
     if os.getenv("PKG_MARKER") == "SNAP":
-        return getoutput("echo \(Snap\) $SNAP_VERSION")
+        return getoutput(r"echo \(Snap\) $SNAP_VERSION")
     # aur package
     elif dist_name in ["arch", "manjaro", "garuda"]:
         aur_pkg_check = run("pacman -Qs auto-cpufreq > /dev/null", shell=True)


### PR DESCRIPTION
Hi. I'm trying to package auto-cpufreq to Void Linux. Void Linux byte compiles python packages. A common annoyance that is commonly seen when byte compiling is warnings about unknown escape sequences. This exact warning happens when installing auto-cpufreq:

```
./usr/lib/python3.12/site-packages/auto_cpufreq/gui/objects.py:35: SyntaxWarning: invalid escape sequence '\('
  return getoutput("echo \(Snap\) $SNAP_VERSION")
./usr/lib/python3.12/site-packages/auto_cpufreq/gui/objects.py:35: SyntaxWarning: invalid escape sequence '\('
  return getoutput("echo \(Snap\) $SNAP_VERSION")
```

(The warning got doubled for some reason. This is probably Void's fault, not auto-cpufreq's. But it makes it twice as annoying.)

I fix this issue in this PR by using a raw string literal.