### PR TITLE
Add load from user config in XDG_CONFIG_HOME if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,11 @@ See [`--force` flag](#overriding-governor) for more info.
 
 You can configure separate profiles for the battery and power supply. These profiles will let you pick which governor to use, as well as how and when turbo boost is enabled. The possible values for turbo boost behavior are `always`, `auto`, and `never`. The default behavior is `auto`, which only activates turbo during high load.
 
-By default, auto-cpufreq does not use the config file! If you wish to use it, the location where it needs to be placed to be read automatically is: `/etc/auto-cpufreq.conf`
+By default, auto-cpufreq does not use a config file. If you wish to configure auto-cpufreq statically, we look for a configuration file in the following order:
+
+1. Commandline argument: `--config <FILE>` if passed as commandline argument to `auto-cpufreq`
+2. User-specific configuration: `$XDG_CONFIG_HOME/auto-cpufreq/auto-cpufreq.conf`
+3. System-wide configuration: `/etc/auto-cpufreq.conf`
 
 #### Example config file contents
 ```python

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -28,7 +28,7 @@ from auto_cpufreq.battery_scripts.battery import *
 @click.option(
     "--config",
     is_flag=False,
-    default="/etc/auto-cpufreq.conf",
+    required=False,
     help="Use config file at defined path",
 )
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
@@ -41,8 +41,10 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
 
     # display info if config file is used
     def config_info_dialog():
-        if get_config(config) and hasattr(get_config, "using_cfg_file"):
-            print("\nUsing settings defined in " + config + " file")
+
+        config_file = find_config_file(config)
+        if get_config(config_file) and hasattr(get_config, "using_cfg_file"):
+            print("\nUsing settings defined in " + config_file + " file")
 
     # set governor override unless None or invalid
     if force is not None:

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -105,7 +105,7 @@ def find_config_file(args_config_file):
     system_config_file = "/etc/auto-cpufreq.conf"
 
     # If config file is provided as a command line argument but is invalid, exit with error message
-    if args_config_file != None and args_config_file is not "":
+    if args_config_file is not None:
         if not os.path.isfile(args_config_file):
             print(f"Config file specified with '--config {args_config_file}' not found.")
             sys.exit(1)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -104,14 +104,14 @@ def find_config_file(args_config_file):
     user_config_file = os.path.join(user_config_dir, "auto-cpufreq/auto-cpufreq.conf")
     system_config_file = "/etc/auto-cpufreq.conf"
 
-    # If config file is provided as a command line argument but is invalid, exit with error message
-    if args_config_file is not None:
-        if not os.path.isfile(args_config_file):
+    if args_config_file is not None: # (1) Command line argument was specified
+        # Check if the config file path points to a valid file
+        if os.path.isfile(args_config_file):
+            return args_config_file
+        else:
+            # Not a valid file
             print(f"Config file specified with '--config {args_config_file}' not found.")
             sys.exit(1)
-
-    if args_config_file and os.path.isfile(args_config_file):  # (1) Command line argument
-        return args_config_file
     elif os.path.isfile(os.path.join(user_config_file)):  # (2) User config file
         return user_config_file
     else:  # (3) System config file (default if nothing else is found)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -84,6 +84,34 @@ def file_stats():
     auto_cpufreq_stats_file = open(auto_cpufreq_stats_path, "w")
     sys.stdout = auto_cpufreq_stats_file
 
+
+def find_config_file(args_config_file):
+    """
+    Find the config file to use.
+
+    Look for a config file in the following priorization order:
+    1. Command line argument
+    2. User config file
+    3. System config file
+
+    :param args_config_file: Path to the config file provided as a command line argument
+    :return: The path to the config file to use
+    """
+
+    # Prepare paths
+    home = os.getenv("HOME")
+    user_config_dir = os.getenv("XDG_CONFIG_HOME", default=os.path.join(home, ".config"))
+    user_config_file = os.path.join(user_config_dir, "auto-cpufreq/auto-cpufreq.conf")
+    system_config_file = "/etc/auto-cpufreq.conf"
+
+    if args_config_file and os.path.isfile(args_config_file):  # (1) Command line argument
+        return args_config_file
+    elif os.path.isfile(os.path.join(user_config_file)):  # (2) User config file
+        return user_config_file
+    else:  # (3) System config file (default if nothing else is found)
+        return system_config_file
+
+
 def get_config(config_file=""):
     if not hasattr(get_config, "config"):
         get_config.config = configparser.ConfigParser()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -104,6 +104,12 @@ def find_config_file(args_config_file):
     user_config_file = os.path.join(user_config_dir, "auto-cpufreq/auto-cpufreq.conf")
     system_config_file = "/etc/auto-cpufreq.conf"
 
+    # If config file is provided as a command line argument but is invalid, exit with error message
+    if args_config_file != None and args_config_file is not "":
+        if not os.path.isfile(args_config_file):
+            print(f"Config file specified with '--config {args_config_file}' not found.")
+            sys.exit(1)
+
     if args_config_file and os.path.isfile(args_config_file):  # (1) Command line argument
         return args_config_file
     elif os.path.isfile(os.path.join(user_config_file)):  # (2) User config file


### PR DESCRIPTION
This update introduces the flexibility to load the configuration file from multiple locations, prioritizing user preferences and system standards. Previously, the configuration was strictly read from a hardcoded system path (`/etc/auto-cpufreq.conf`). Now, the application first checks if the user has specified a configuration file path via command line arguments. If not, it looks for a configuration file in the user's config directory (`$XDG_CONFIG_HOME/auto-cpufreq/auto-cpufreq.conf`). If neither is found, it defaults to the original system-wide configuration file.

This allows users to add their auto-cpufreq configuration to their dotfiles.

In addition, since providing a config file path via `--config` is now an explicit choice, an error is raised if this path is not a valid file.

### Old behavior
```sh
auto-cpufreq --stats # Looks for config in "/etc/auto-cpufreq.conf"
auto-cpufreq --config <CONFIG> --stats # Looks for config in <CONFIG>
auto-cpufreq --config <INVALID_PATH> --stats  # No error/warning
```

### New behavior
```sh
auto-cpufreq --stats # Looks for config in (A) "$XDG_CONFIG_HOME/auto-cpufreq/auto-cpufreq.conf" then (B) "/etc/auto-cpufreq.conf"
auto-cpufreq --config <CONFIG> --stats # Looks for config in <CONFIG>
auto-cpufreq --config <INVALID_PATH> --stats  # Error
```

