### PR TITLE
Fix spam error message when setting energy_performance_preference

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -937,12 +937,20 @@ def set_performance():
         if dynboost_enabled:
             print('Not setting EPP (dynamic boosting is enabled)')
         else:
+            intel_pstate_status_path = "/sys/devices/system/cpu/intel_pstate/status"
+
             if conf.has_option("charger", "energy_performance_preference"):
                 epp = conf["charger"]["energy_performance_preference"]
+
+                if Path(intel_pstate_status_path).exists() and open(intel_pstate_status_path, 'r').read().strip() == "active" and epp != "performance":
+                    print(f'Warning "{epp}" EPP is not allowed in Intel CPU')
+                    print('Overriding EPP to "performance"')
+                    epp = "performance"
+
                 run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
                 print(f'Setting to use: "{epp}" EPP')
             else:
-                if Path("/sys/devices/system/cpu/intel_pstate/status").exists() and open("/sys/devices/system/cpu/intel_pstate/status", 'r').read().strip() == "active":
+                if Path(intel_pstate_status_path).exists() and open(intel_pstate_status_path, 'r').read().strip() == "active":
                     run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
                     print('Setting to use: "performance" EPP')
                 else:

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -942,8 +942,12 @@ def set_performance():
                 run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
                 print(f'Setting to use: "{epp}" EPP')
             else:
-                run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
-                print('Setting to use: "performance" EPP')
+                if Path("/sys/devices/system/cpu/intel_pstate/status").exists() is True:
+                    run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
+                    print('Setting to use: "performance" EPP')
+                else:
+                    run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
+                    print('Setting to use: "balance_performance" EPP')
 
     # set frequencies
     set_frequencies()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -122,14 +122,14 @@ except PermissionError:
     # Current work-around for Pop!_OS where symlink causes permission issues
     print("[!] Warning: Cannot get distro name")
     if os.path.exists("/etc/pop-os/os-release"):
-            # Check if using a Snap 
+            # Check if using a Snap
             if os.getenv("PKG_MARKER") == "SNAP":
-                print("[!] Snap install on PopOS detected, you must manually run the following" 
-                        " commands in another terminal:\n")            
+                print("[!] Snap install on PopOS detected, you must manually run the following"
+                        " commands in another terminal:\n")
                 print("[!] Backup the /etc/os-release file:")
-                print("sudo mv /etc/os-release /etc/os-release-backup\n")                
+                print("sudo mv /etc/os-release /etc/os-release-backup\n")
                 print("[!] Create hardlink to /etc/os-release:")
-                print("sudo ln /etc/pop-os/os-release /etc/os-release\n")            
+                print("sudo ln /etc/pop-os/os-release /etc/os-release\n")
                 print("[!] Aborting. Restart auto-cpufreq when you created the hardlink")
                 sys.exit(1)
             else:
@@ -182,7 +182,7 @@ def check_for_update():
             print("Error fetching recent release!")
             if message is not None and message.startswith("API rate limit exceeded"):
                 print("GitHub Rate limit exceeded. Please try again later within 1 hour or use different network/VPN.")
-            else: 
+            else:
                 print("Unexpected status code:", response.status_code)
             return False
     except (requests.exceptions.ConnectionError, requests.exceptions.Timeout,
@@ -215,8 +215,8 @@ def check_for_update():
         # Handle the case where "tag_name" key doesn't exist
         print("Malformed Released data!\nReinstall manually or Open an issue on GitHub for help!")
 
-    
-    
+
+
 def new_update(custom_dir):
     os.chdir(custom_dir)
     print(f"Cloning the latest release to {custom_dir}")
@@ -247,7 +247,7 @@ def get_formatted_version():
     literal_version = get_literal_version("auto-cpufreq")
     splitted_version = literal_version.split("+")
     formatted_version = splitted_version[0]
-    
+
     if len(splitted_version) > 1:
         formatted_version += " (git: " + splitted_version[1] + ")"
 
@@ -571,7 +571,7 @@ def countdown(s):
     os.environ["TERM"] = "xterm"
 
     print("\t\t\"auto-cpufreq\" is about to refresh ", end = "")
-    
+
     # empty log file if size is larger then 10mb
     if auto_cpufreq_stats_file is not None:
         log_size = os.path.getsize(auto_cpufreq_stats_path)
@@ -942,8 +942,8 @@ def set_performance():
                 run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
                 print(f'Setting to use: "{epp}" EPP')
             else:
-                run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
-                print('Setting to use: "balance_performance" EPP')
+                run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
+                print('Setting to use: "performance" EPP')
 
     # set frequencies
     set_frequencies()
@@ -1382,4 +1382,3 @@ def not_running_daemon_check():
     elif os.getenv("PKG_MARKER") == "SNAP" and dcheck == "disabled":
         daemon_not_running_msg()
         exit(1)
-

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -942,7 +942,7 @@ def set_performance():
                 run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
                 print(f'Setting to use: "{epp}" EPP')
             else:
-                if Path("/sys/devices/system/cpu/intel_pstate/status").exists() is True:
+                if Path("/sys/devices/system/cpu/intel_pstate/status").exists() and open("/sys/devices/system/cpu/intel_pstate/status", 'r').read().strip() == "active":
                     run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
                     print('Setting to use: "performance" EPP')
                 else:


### PR DESCRIPTION
The 'intel_pstate' driver does not allow the EPP to be set to anything but 'performance' when the scaling governor is set to 'performance', previously auto-cpufreq when the scaling-governor was set to 'performance' tried to set the EPP to 'balance-performance' which caused a spam of write error messages in journalctl in system with 'intel_pstate' drivers. This is an intended behavior, since according to the [kernel documentation](https://docs.kernel.org/admin-guide/pm/intel_pstate.html#hwp-performance) when HWP is enabled[(which is enabled by default during boot with supported processors)](https://docs.kernel.org/admin-guide/pm/intel_pstate.html#active-mode-with-hwp) and scaling governor is set to performance the processor’s internal P-state selection logic is expected to focus entirely on performance. And this will override the EPP setting and reject any value different from 0 (“performance”). This commit just changes the 'balance-performance' EPP preference in set_performance() to 'performance'. Which fixes the spam issue.

Fixes: #661