### PR TITLE
Nix: fix duplicated package

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -31,15 +31,21 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [defaultPackage];
+    environment.systemPackages = [ defaultPackage ];
 
-    services.auto-cpufreq.enable = true;
-    systemd.services.auto-cpufreq = {
-      overrideStrategy = "asDropin";
-      serviceConfig.ExecStart = mkForce [
-        ""
-        "${defaultPackage}/bin/auto-cpufreq --daemon --config ${cfgFile}"
-      ];
+    systemd = {
+      packages =  [ defaultPackage ];
+      services.auto-cpufreq = {
+        wantedBy = [ "multi-user.target" ];
+        path = with pkgs; [ bash coreutils ];
+        overrideStrategy = "asDropin";
+
+        serviceConfig.WorkingDirectory = "";
+        serviceConfig.ExecStart = mkForce [
+          ""
+          "${defaultPackage}/bin/auto-cpufreq --daemon --config ${cfgFile}"
+        ];
+      };
     };
   };
 }


### PR DESCRIPTION
I noticed when messing with my Nix config, that there were 2 versions of `auto-cpufreq` being installed, which didn't seem right. Took a look at our Nix module, and noticed it was pulling in the outdated version of `auto-cpufreq` from the `nixpkgs` repo alongside the git version

This is just a simple fix to stop it from pulling the unnecessary package and dependencies 