### PR TITLE
Rework read_stats output formatting

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1334,9 +1334,37 @@ def sysinfo():
 
 # read stats func
 def read_stats():
-    # read stats
     if os.path.isfile(auto_cpufreq_stats_path):
-        call(["tail", "-n 50", "-f", str(auto_cpufreq_stats_path)], stderr=DEVNULL)
+        proc = subprocess.Popen(["tail", "-n", "50", "-f", str(auto_cpufreq_stats_path)], stdout=subprocess.PIPE, stderr=DEVNULL)
+        
+        # Read the tail output line by line
+        for line in iter(proc.stdout.readline, b''):
+            line = line.decode('utf-8').strip()
+            
+            if line.startswith("Core\t"):
+                # Color each column header in green for easier visual parsing
+                line = line.replace("Core", "\033[32mCore\033[0m")
+                line = line.replace("Usage", "\033[32mUsage\033[0m")
+                line = line.replace("Temperature", "\033[32mTemperature\033[0m")
+                line = line.replace("Frequency", "\033[32mFrequency\033[0m")
+            if line.startswith("CPU") and "max" not in line and "min" not in line and "fan" not in line:
+                split_line = line.split()
+
+                # If temperature is above 85°C print temperature in red
+                if int(split_line[2]) > 85:
+                    split_line[2] = split_line[2].replace(split_line[2], f"   \033[31m{split_line[2]}°C\033[0m")
+
+                formatted_line = "{:<{}} {:<{}} {:>{}} {} {:>{}} {}".format(
+                    split_line[0], 7,
+                    split_line[1], 7,
+                    split_line[2], 5,
+                    split_line[3],
+                    split_line[4], 12,
+                    split_line[5]
+                )
+                line = formatted_line.replace(" °C", "°C").replace("°C\033[0m°C", "°C\033[0m")
+            print(line)
+    
     footer()
 
 


### PR DESCRIPTION
Makes the output of the --stats argument easier to read.

* Formatted the output of each core properly into a table, the spacing was slightly off before.

* Colored the headers of each table column in green for easier visual parsing

* Colored the temperature reading in red for any core that is above 85 degrees so it's easy to quickly tell if something is going wrong. Might want to adjust the number it is pretty arbitrary.

This is kind of jank but only because it was already jank to begin with. The reading and writing of stats as a whole should probably be refactored to use a more convenient interface but it works fine as it is now so I'm not sure if it's actually necessary.

Old Output:
![old_output](https://github.com/AdnanHodzic/auto-cpufreq/assets/87823030/b7ff27b1-07be-4b3d-bd26-b6cb18e8be1c)

New Output:
![new_output](https://github.com/AdnanHodzic/auto-cpufreq/assets/87823030/54cd4fe7-cd4f-4f37-8b92-53b55c96ec2b)
