### PR TITLE
Fixed auto-cpufreq error installation

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -112,7 +112,8 @@ function tool_install {
 
   if [ -f /etc/debian_version ]; then
     detected_distro "Debian based"
-    apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libcairo2-dev libgtk-3-dev gcc -y
+    # apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libcairo2-dev libgtk-3-dev gcc -y
+    apt install python3.10-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libcairo2-dev libgtk-3-dev gcc -y
 
   elif [ -f /etc/redhat-release ]; then
     detected_distro "RedHat based"
@@ -162,10 +163,10 @@ function tool_install {
 
   venv_dir=/opt/auto-cpufreq/venv
   mkdir -p "${venv_dir}"
-  python3 -m venv "${venv_dir}"
+  python3.10 -m venv "${venv_dir}"
 
   source "${venv_dir}/bin/activate"
-  python3 -m pip install --upgrade pip wheel
+  python3.10 -m pip install --upgrade pip wheel
 
   separator
   echo -e "\ninstalling auto-cpufreq tool\n"

--- a/auto-cpufreq.conf
+++ b/auto-cpufreq.conf
@@ -1,0 +1,61 @@
+# settings for when connected to a power source
+[charger]
+# see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
+# preferred governor.
+governor = performance
+
+# EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
+energy_performance_preference = performance
+
+# minimum cpu frequency (in kHz)
+# example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
+# see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
+# to use this feature, uncomment the following line and set the value accordingly
+# scaling_min_freq = 800000
+
+# maximum cpu frequency (in kHz)
+# example: for 1GHz = 1000 MHz = 1000000 kHz -> scaling_max_freq = 1000000
+# see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
+# to use this feature, uncomment the following line and set the value accordingly
+# scaling_max_freq = 1000000
+
+# turbo boost setting. possible values: always, auto, never
+turbo = auto
+
+# settings for when using battery power
+[battery]
+# see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
+# preferred governor
+governor = powersave
+
+# EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
+energy_performance_preference = power
+
+# minimum cpu frequency (in kHz)
+# example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
+# see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
+# to use this feature, uncomment the following line and set the value accordingly
+# scaling_min_freq = 800000
+
+# maximum cpu frequency (in kHz)
+# see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
+# example: for 1GHz = 1000 MHz = 1000000 kHz -> scaling_max_freq = 1000000
+# to use this feature, uncomment the following line and set the value accordingly
+# scaling_max_freq = 1000000
+
+# turbo boost setting. possible values: always, auto, never
+turbo = auto
+
+# experimental 
+
+# Add battery charging threshold (currently only available to Lenovo)
+# checkout README.md for more info
+
+# enable thresholds true or false
+#enable_thresholds = true
+#
+# start threshold (0 is off ) can be 0-99
+#start_threshold = 0
+#
+# stop threshold (100 is off) can be 1-100
+#stop_threshold = 100


### PR DESCRIPTION
This error was encountered when the python was lower than 3.10. 
You need to install multiple python in /usr/bin/python3.10 where the default /usr/bin/python3.8 exists.
