### PR TITLE
Fix #715, #713, #634 issues

### DIFF
--- a/auto_cpufreq/battery_scripts/ideapad_acpi.py
+++ b/auto_cpufreq/battery_scripts/ideapad_acpi.py
@@ -33,10 +33,6 @@ def ideapad_acpi_print_thresholds():
     print(f"battery count = {len(batteries)}")
     for bat in batteries:
         try:
-            with open(f'{POWER_SUPPLY_DIR}{bat}/charge_start_threshold', 'r') as f:
-                print(f'{bat} start threshold = {f.read()}', end="")
-
-            with open(f'{POWER_SUPPLY_DIR}{bat}/charge_stop_threshold', 'r') as f:
-                print(f'{bat} stop threshold = {f.read()}', end="")
-
-        except Exception: print(f"ERROR: failed to read battery {bat} thresholds")
+            print(f'{bat} start threshold = {subprocess.getoutput(f"cat {POWER_SUPPLY_DIR}{bat}/charge_start_threshold")}')
+            print(f'{bat} start threshold = {subprocess.getoutput(f"cat {POWER_SUPPLY_DIR}{bat}/charge_stop_threshold")}')
+        except Exception as e: print(f"ERROR: failed to read battery {bat} thresholds: ", repr(e))

--- a/auto_cpufreq/battery_scripts/ideapad_laptop.py
+++ b/auto_cpufreq/battery_scripts/ideapad_laptop.py
@@ -64,10 +64,6 @@ def ideapad_laptop_print_thresholds():
     print(f"battery count = {len(batteries)}")
     for bat in batteries:
         try:
-            with open(f'{POWER_SUPPLY_DIR}{bat}/charge_start_threshold', 'r') as f:
-                print(f'{bat} start threshold = {f.read()}', end="")
-
-            with open(f'{POWER_SUPPLY_DIR}{bat}/charge_stop_threshold', 'r') as f:
-                print(f'{bat} stop threshold = {f.read()}', end="")
-
-        except Exception as e: print(f"ERROR: failed to read {bat} thresholds: {e}")
+            print(f'{bat} start threshold = {subprocess.getoutput(f"cat {POWER_SUPPLY_DIR}{bat}/charge_start_threshold")}')
+            print(f'{bat} start threshold = {subprocess.getoutput(f"cat {POWER_SUPPLY_DIR}{bat}/charge_stop_threshold")}')
+        except Exception as e: print(f"ERROR: failed to read battery {bat} thresholds: ", repr(e))

--- a/auto_cpufreq/battery_scripts/thinkpad.py
+++ b/auto_cpufreq/battery_scripts/thinkpad.py
@@ -34,10 +34,6 @@ def thinkpad_print_thresholds():
     print(f"battery count = {len(batteries)}")
     for bat in batteries:
         try:
-            with open(f'{POWER_SUPPLY_DIR}{bat}/charge_start_threshold', 'r') as f:
-                print(f'{bat} start threshold = {f.read()}', end="")
-
-            with open(f'{POWER_SUPPLY_DIR}{bat}/charge_stop_threshold', 'r') as f:
-                print(f'{bat} stop threshold = {f.read()}', end="")
-
-        except Exception: print(f"ERROR: failed to read battery {bat} thresholds")
+            print(f'{bat} start threshold = {subprocess.getoutput(f"cat {POWER_SUPPLY_DIR}{bat}/charge_start_threshold")}')
+            print(f'{bat} start threshold = {subprocess.getoutput(f"cat {POWER_SUPPLY_DIR}{bat}/charge_stop_threshold")}')
+        except Exception as e: print(f"ERROR: failed to read battery {bat} thresholds: ", repr(e))

--- a/auto_cpufreq/utils/config.py
+++ b/auto_cpufreq/utils/config.py
@@ -5,7 +5,7 @@ from subprocess import run, PIPE
 import os
 import sys
 
-def find_config_file(args_config_file: str | None) -> str:
+def find_config_file(args_config_file) -> str:
     """
     Find the config file to use.
 

--- a/scripts/auto-cpufreq-venv-wrapper
+++ b/scripts/auto-cpufreq-venv-wrapper
@@ -3,32 +3,15 @@
 
 set -eu
 
-# get script name
-PROGNAME=$(basename "${0}")
-
 # bailout function
-err_exit()
-{
-    echo "${PROGNAME}: ${1:-wrong invocation. try --help for help.}" 1>&2
-    exit 1
+err_exit() {
+  echo "$(basename $0): ${1:-wrong invocation. try --help for help.}" 1>&2
+  exit 1
 }
 
-# invocation handling
-#
-
 # load python virtual environment
-venv_dir=/opt/auto-cpufreq/venv
-. "$venv_dir/bin/activate"
+opt_path=/opt/auto-cpufreq
+venv_bin_dir=$opt_path/venv/bin
+. "$venv_bin_dir/activate"
 
-# run python code with venv loaded
-if [[ "$#" -ne 1 ]]; then
-   PYTHONPATH=/opt/auto-cpufreq \
-            /opt/auto-cpufreq/venv/bin/python \
-            /opt/auto-cpufreq/venv/bin/auto-cpufreq 
-else
-    param="$1"
-    PYTHONPATH=/opt/auto-cpufreq \
-            /opt/auto-cpufreq/venv/bin/python \
-            /opt/auto-cpufreq/venv/bin/auto-cpufreq \
-            "${param}"
-fi
+PYTHONPATH=$opt_path $venv_bin_dir/python $venv_bin_dir/auto-cpufreq "$@"


### PR DESCRIPTION
Closes #715 : Pipe can cause problem for python 3.9 or earlier
Closes  #713 : Using `getoutput` instead `read` to bypass symbolic link problem
Closes #634 : Compatible with many arguments 