### PR TITLE
nix: add overlay; use best practices

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700823757,
-        "narHash": "sha256-PStAVLO8ycnFBSThYKTFwQ6rw+OH4ZM5KiN0fRE0OuM=",
+        "lastModified": 1717112898,
+        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "068bacb9b6fbee6a603d1b1f68d7cf032c4feed1",
+        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
       default = pkgsForEach.${system}.callPackage ./nix/shell.nix {};
     });
 
+    overlays.default = final: _: {
+      auto-cpufreq = final.callPackage ./nix/default.nix {};
+    };
+
     nixosModules.default = import ./nix/module.nix inputs;
   };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -57,11 +57,11 @@ python3Packages.buildPythonPackage {
   ];
 
   postPatch = ''
-    substituteInPlace auto_cpufreq/core.py --replace '/opt/auto-cpufreq/override.pickle' /var/run/override.pickle
-    substituteInPlace scripts/org.auto-cpufreq.pkexec.policy --replace "/opt/auto-cpufreq/venv/bin/auto-cpufreq" $out/bin/auto-cpufreq
+    substituteInPlace auto_cpufreq/core.py --replace-fail '/opt/auto-cpufreq/override.pickle' /var/run/override.pickle
+    substituteInPlace scripts/org.auto-cpufreq.pkexec.policy --replace-fail "/opt/auto-cpufreq/venv/bin/auto-cpufreq" $out/bin/auto-cpufreq
 
-    substituteInPlace auto_cpufreq/gui/app.py auto_cpufreq/gui/objects.py --replace "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
-    substituteInPlace auto_cpufreq/gui/app.py --replace "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
+    substituteInPlace auto_cpufreq/gui/app.py auto_cpufreq/gui/objects.py --replace-fail "/usr/local/share/auto-cpufreq/images/icon.png" $out/share/pixmaps/auto-cpufreq.png
+    substituteInPlace auto_cpufreq/gui/app.py --replace-fail "/usr/local/share/auto-cpufreq/scripts/style.css" $out/share/auto-cpufreq/scripts/style.css
   '';
 
   postInstall = ''
@@ -75,7 +75,7 @@ python3Packages.buildPythonPackage {
     # systemd service
     mkdir -p $out/lib/systemd/system
     cp scripts/auto-cpufreq.service $out/lib/systemd/system
-    substituteInPlace $out/lib/systemd/system/auto-cpufreq.service --replace "/usr/local" $out
+    substituteInPlace $out/lib/systemd/system/auto-cpufreq.service --replace-fail "/usr/local" $out
 
     # desktop icon
     mkdir -p $out/share/applications
@@ -88,12 +88,12 @@ python3Packages.buildPythonPackage {
     cp scripts/org.auto-cpufreq.pkexec.policy $out/share/polkit-1/actions
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/AdnanHodzic/auto-cpufreq";
     description = "Automatic CPU speed & power optimizer for Linux";
-    license = licenses.lgpl3Plus;
-    platforms = platforms.linux;
-    maintainers = [maintainers.Technical27];
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [Technical27];
     mainProgram = "auto-cpufreq";
   };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -75,7 +75,6 @@ python3Packages.buildPythonPackage {
     # systemd service
     mkdir -p $out/lib/systemd/system
     cp scripts/auto-cpufreq.service $out/lib/systemd/system
-    substituteInPlace $out/lib/systemd/system/auto-cpufreq.service --replace-fail "/usr/local" $out
 
     # desktop icon
     mkdir -p $out/share/applications

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2,15 +2,18 @@ inputs: {
   config,
   lib,
   pkgs,
-  options,
   ...
 }:
-with lib; let
+let
   cfg = config.programs.auto-cpufreq;
   inherit (pkgs.stdenv.hostPlatform) system;
   defaultPackage = inputs.self.packages.${system}.default;
   cfgFilename = "auto-cpufreq.conf";
   cfgFile = format.generate cfgFilename cfg.settings;
+
+  inherit (lib) types;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption;
 
   format = pkgs.formats.ini {};
 in {
@@ -18,7 +21,7 @@ in {
     enable = mkEnableOption "Automatic CPU speed & power optimizer for Linux";
 
     settings = mkOption {
-      description = mdDoc ''
+      description = ''
         Configuration for `auto-cpufreq`.
 
         See its [example configuration file] for supported settings.


### PR DESCRIPTION
Hey 👋 , been a while since I last checked up on this project.

Changes made:

- Remove deprecated [`lib.mdDoc`](https://github.com/NixOS/nixpkgs/blob/316b65cb7d266e3126314f566bd660decf6268af/lib/options.nix#L407)
- Add package overlay
- removed all instances of `with lib;` they are advised against, see https://github.com/NixOS/nixpkgs/issues/208242.
- `--replace` -> `--replace-fail`, using `--replace` will warn you that its being removed and the safe choice is `--replace-fail` since if something ever changes the build will fail.