### PR TITLE
Issue #698: Add --fullcharge flag to set battery thresholds to max

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ start_threshold = 20
 stop_threshold = 80
 ```
 
+Use `auto-cpufreq --fullcharge` to temporarily set thresholds 99
+
 ### Lenovo_laptop conservation mode
 
 this works only with `lenovo_laptop` kernel module compatable laptops.  

--- a/auto_cpufreq/battery_scripts/battery.py
+++ b/auto_cpufreq/battery_scripts/battery.py
@@ -9,6 +9,9 @@ from auto_cpufreq.battery_scripts.thinkpad import thinkpad_set_fullcharge
 from auto_cpufreq.battery_scripts.ideapad_acpi import ideapad_acpi_set_fullcharge
 from auto_cpufreq.battery_scripts.ideapad_laptop import ideapad_laptop_set_fullcharge
 
+from auto_cpufreq.utils.config import config
+from auto_cpufreq.core import footer
+
 def lsmod(module): return module in subprocess.run(['lsmod'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True).stdout
 
 def battery_setup():
@@ -17,6 +20,7 @@ def battery_setup():
     elif lsmod("ideapad_laptop"): ideapad_laptop_setup()
     else: return
 
+# print both current thresholds and config thresholds
 def battery_get_thresholds():
     if lsmod("thinkpad_acpi"): thinkpad_print_thresholds()
     elif lsmod("ideapad_acpi"): ideapad_acpi_print_thresholds()
@@ -24,6 +28,13 @@ def battery_get_thresholds():
     else: return
 
 def fullcharge_thresholds():
+    conf = config.get_config()
+    if not (conf.has_option("battery", "enable_thresholds") and conf["battery"]["enable_thresholds"] == "true"): 
+        print("\n" + "-" * 33 + " Fullcharge " + "-" * 34 + "\n")
+        print("ERROR:\n\nCan only run this command if default start/stop thresholds are set in a config file!")
+        footer()
+        exit(1)
+   
     if lsmod("thinkpad_acpi"): thinkpad_set_fullcharge()
     elif lsmod("ideapad_acpi"): ideapad_acpi_set_fullcharge()
     elif lsmod("ideapad_laptop"): ideapad_laptop_set_fullcharge()

--- a/auto_cpufreq/battery_scripts/battery.py
+++ b/auto_cpufreq/battery_scripts/battery.py
@@ -5,6 +5,10 @@ from auto_cpufreq.battery_scripts.thinkpad import thinkpad_setup, thinkpad_print
 from auto_cpufreq.battery_scripts.ideapad_acpi import ideapad_acpi_setup, ideapad_acpi_print_thresholds
 from auto_cpufreq.battery_scripts.ideapad_laptop import ideapad_laptop_setup, ideapad_laptop_print_thresholds
 
+from auto_cpufreq.battery_scripts.thinkpad import thinkpad_set_fullcharge
+from auto_cpufreq.battery_scripts.ideapad_acpi import ideapad_acpi_set_fullcharge
+from auto_cpufreq.battery_scripts.ideapad_laptop import ideapad_laptop_set_fullcharge
+
 def lsmod(module): return module in subprocess.run(['lsmod'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True).stdout
 
 def battery_setup():
@@ -17,4 +21,10 @@ def battery_get_thresholds():
     if lsmod("thinkpad_acpi"): thinkpad_print_thresholds()
     elif lsmod("ideapad_acpi"): ideapad_acpi_print_thresholds()
     elif lsmod("ideapad_laptop"): ideapad_laptop_print_thresholds()
+    else: return
+
+def fullcharge_thresholds():
+    if lsmod("thinkpad_acpi"): thinkpad_set_fullcharge()
+    elif lsmod("ideapad_acpi"): ideapad_acpi_set_fullcharge()
+    elif lsmod("ideapad_laptop"): ideapad_laptop_set_fullcharge()
     else: return

--- a/auto_cpufreq/battery_scripts/battery.py
+++ b/auto_cpufreq/battery_scripts/battery.py
@@ -20,7 +20,6 @@ def battery_setup():
     elif lsmod("ideapad_laptop"): ideapad_laptop_setup()
     else: return
 
-# print both current thresholds and config thresholds
 def battery_get_thresholds():
     if lsmod("thinkpad_acpi"): thinkpad_print_thresholds()
     elif lsmod("ideapad_acpi"): ideapad_acpi_print_thresholds()

--- a/auto_cpufreq/battery_scripts/ideapad_acpi.py
+++ b/auto_cpufreq/battery_scripts/ideapad_acpi.py
@@ -10,6 +10,15 @@ def set_battery(value, mode, bat):
     if os.path.isfile(path): subprocess.check_output(f"echo {value} | tee {path}", shell=True, text=True)
     else: print(f"WARNING: {path} does NOT exist")
 
+def ideapad_acpi_set_fullcharge():
+    if os.path.exists(POWER_SUPPLY_DIR):
+        batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]
+
+        for bat in batteries:
+            set_battery(98, "start", bat)
+            set_battery(99, "stop", bat)
+    else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
+
 def get_threshold_value(mode):
     conf = config.get_config()
     return conf["battery"][f"{mode}_threshold"] if conf.has_option("battery", f"{mode}_threshold") else (0 if mode == "start" else 100)

--- a/auto_cpufreq/battery_scripts/ideapad_acpi.py
+++ b/auto_cpufreq/battery_scripts/ideapad_acpi.py
@@ -15,8 +15,8 @@ def ideapad_acpi_set_fullcharge():
         batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]
 
         for bat in batteries:
-            set_battery(98, "start", bat)
-            set_battery(99, "stop", bat)
+            set_battery("98", "start", bat)
+            set_battery("99", "stop", bat)
     else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
 
 def get_threshold_value(mode):

--- a/auto_cpufreq/battery_scripts/ideapad_laptop.py
+++ b/auto_cpufreq/battery_scripts/ideapad_laptop.py
@@ -11,6 +11,15 @@ def set_battery(value, mode, bat):
         subprocess.check_output(f"echo {value} | tee {POWER_SUPPLY_DIR}{bat}/charge_{mode}_threshold", shell=True, text=True)
     else: print(f"WARNING: {path} does NOT exist")
 
+def ideapad_laptop_set_fullcharge():
+    if os.path.exists(POWER_SUPPLY_DIR):
+        batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]
+
+        for bat in batteries:
+            set_battery(98, "start", bat)
+            set_battery(99, "stop", bat)
+    else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
+
 def get_threshold_value(mode):
     conf = config.get_config()
     return conf["battery"][f"{mode}_threshold"] if conf.has_option("battery", f"{mode}_threshold") else (0 if mode == "start" else 100)

--- a/auto_cpufreq/battery_scripts/ideapad_laptop.py
+++ b/auto_cpufreq/battery_scripts/ideapad_laptop.py
@@ -16,8 +16,8 @@ def ideapad_laptop_set_fullcharge():
         batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]
 
         for bat in batteries:
-            set_battery(98, "start", bat)
-            set_battery(99, "stop", bat)
+            set_battery("98", "start", bat)
+            set_battery("99", "stop", bat)
     else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
 
 def get_threshold_value(mode):

--- a/auto_cpufreq/battery_scripts/thinkpad.py
+++ b/auto_cpufreq/battery_scripts/thinkpad.py
@@ -10,6 +10,15 @@ def set_battery(value, mode, bat):
     if os.path.isfile(path): subprocess.check_output(f"echo {value} | tee {path}", shell=True, text=True)
     else: print(f"WARNING: {path} does NOT exist")
 
+def thinkpad_set_fullcharge():
+    if os.path.exists(POWER_SUPPLY_DIR):
+        batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]
+
+        for bat in batteries:
+            set_battery(98, "start", bat)
+            set_battery(99, "stop", bat)
+    else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
+
 def get_threshold_value(mode):
     conf = config.get_config()
     return conf["battery"][f"{mode}_threshold"] if conf.has_option("battery", f"{mode}_threshold") else (0 if mode == "start" else 100)
@@ -26,7 +35,6 @@ def thinkpad_setup():
             set_battery(get_threshold_value("start"), "start", bat)
             set_battery(get_threshold_value("stop"), "stop", bat)
     else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
-
 
 def thinkpad_print_thresholds():
     batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]

--- a/auto_cpufreq/battery_scripts/thinkpad.py
+++ b/auto_cpufreq/battery_scripts/thinkpad.py
@@ -15,8 +15,8 @@ def thinkpad_set_fullcharge():
         batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]
 
         for bat in batteries:
-            set_battery(98, "start", bat)
-            set_battery(99, "stop", bat)
+            set_battery("98", "start", bat)
+            set_battery("99", "stop", bat)
     else: print(f"WARNING {POWER_SUPPLY_DIR} does NOT esixt")
 
 def get_threshold_value(mode):

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -24,9 +24,6 @@ from auto_cpufreq.utils.config import config as conf, find_config_file
 @click.option("--update", is_flag=False, help="Update daemon and package for (permanent) automatic CPU optimizations", flag_value="--update")
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 
-@click.option("--fullcharge", is_flag=True, help="Temporarily set charge thresholds to vedor presets until next boot.")
-#@click.option("--setcharge")
-
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
 @click.option("--get-state", is_flag=True, hidden=True)
@@ -37,6 +34,7 @@ from auto_cpufreq.utils.config import config as conf, find_config_file
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
+@click.option("--fullcharge", is_flag=True, help="Temporarily raise charge thresholds to 99 until next reboot.")
 def main(config, daemon, debug, update, install, remove, fullcharge, live, log, monitor, stats, version, donate, force, get_state, completions):
     # display info if config file is used
     config_path = find_config_file(config)

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -24,6 +24,9 @@ from auto_cpufreq.utils.config import config as conf, find_config_file
 @click.option("--update", is_flag=False, help="Update daemon and package for (permanent) automatic CPU optimizations", flag_value="--update")
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 
+@click.option("--fullcharge", is_flag=True, help="Temporarily set charge thresholds to vedor presets until next boot.")
+#@click.option("--setcharge")
+
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
 @click.option("--get-state", is_flag=True, hidden=True)
@@ -34,7 +37,7 @@ from auto_cpufreq.utils.config import config as conf, find_config_file
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
-def main(config, daemon, debug, update, install, remove, live, log, monitor, stats, version, donate, force, get_state, completions):
+def main(config, daemon, debug, update, install, remove, fullcharge, live, log, monitor, stats, version, donate, force, get_state, completions):
     # display info if config file is used
     config_path = find_config_file(config)
     conf.set_path(config_path)
@@ -268,5 +271,8 @@ def main(config, daemon, debug, update, install, remove, live, log, monitor, sta
                 print("Run the below command in your current shell!\n")
                 print("echo '_AUTO_CPUFREQ_COMPLETE=fish_source auto-cpufreq | source' > ~/.config/fish/completions/auto-cpufreq.fish")
             else: print("Invalid Option, try bash|zsh|fish as argument to --completions")
+        elif fullcharge:
+            print("--- FEATURE IN PROGRESS --- ")
+            fullcharge_thresholds()
                 
 if __name__ == "__main__": main()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -34,7 +34,7 @@ from auto_cpufreq.utils.config import config as conf, find_config_file
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--log", is_flag=True, hidden=True)
 @click.option("--daemon", is_flag=True, hidden=True)
-@click.option("--fullcharge", is_flag=True, help="Temporarily raise charge thresholds to 99 until next reboot.")
+@click.option("--fullcharge", is_flag=True, help="Temporarily raise battery threshold to 99 until next reboot. (Set the default to return to in config)")
 def main(config, daemon, debug, update, install, remove, fullcharge, live, log, monitor, stats, version, donate, force, get_state, completions):
     # display info if config file is used
     config_path = find_config_file(config)
@@ -270,7 +270,8 @@ def main(config, daemon, debug, update, install, remove, fullcharge, live, log, 
                 print("echo '_AUTO_CPUFREQ_COMPLETE=fish_source auto-cpufreq | source' > ~/.config/fish/completions/auto-cpufreq.fish")
             else: print("Invalid Option, try bash|zsh|fish as argument to --completions")
         elif fullcharge:
-            print("--- FEATURE IN PROGRESS --- ")
+            root_check()
             fullcharge_thresholds()
+            battery_get_thresholds()
                 
 if __name__ == "__main__": main()


### PR DESCRIPTION
This pull request closes [Issue #698](https://github.com/AdnanHodzic/auto-cpufreq/issues/698). It adds a `--fullcharge` flag to the auto-cpufreq command. For the`thinkpad`, `ideapad_acpi`, and `ideapad_laptop` interfaces, this sets the charge thresholds to 98 and 99 for start and end respectively to allow for a full charge if you are using very low thresholds for battery longevity. The command only runs if default thresholds are set in a config which then will be set back on the next reboot of the laptop.

ps. This is one of my first very first contributions to any open source project, but it's something that I was looking for in a piece of software that I rely on daily. (without auto-cpufreq I wouldn't be able to use my laptop off of a charger at all so thank you for creating this lol) Any feedback about anything being wrong, "unsafe", missing, or things I could improve would be greatly appreciated. 