### PR TITLE
Fix AVAILABLE_GOVERNORS

### DIFF
--- a/auto_cpufreq/globals.py
+++ b/auto_cpufreq/globals.py
@@ -2,7 +2,7 @@ from os import getenv, path
 from subprocess import getoutput
 
 ALL_GOVERNORS = ('performance', 'ondemand', 'conservative', 'schedutil', 'userspace', 'powersave') # from the highest performance to the lowest
-AVAILABLE_GOVERNORS = getoutput('cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors').split(' ')
+AVAILABLE_GOVERNORS = getoutput('cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors').strip().split(' ')
 AVAILABLE_GOVERNORS_SORTED = tuple(filter(lambda gov: gov in AVAILABLE_GOVERNORS, ALL_GOVERNORS))
 
 CONSERVATION_MODE_FILE = "/sys/bus/platform/drivers/ideapad_acpi/VPC2004:00/conservation_mode"


### PR DESCRIPTION
The refactor in #736 missed a `strip()` from `get_avail_gov()` (see [blame](https://github.com/AdnanHodzic/auto-cpufreq/blame/34ebd04df0fd605c6c741f834f7b2d9205999f30/auto_cpufreq/core.py#L360)), which caused constant failures in `gov_check()` when trying to install the daemon, even if the required scaling governors are present.