### PR TITLE
Add some features for config

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -17,6 +17,7 @@ AUTO_CPUFREQ_FILE="/usr/local/bin/auto-cpufreq"
 AUTO_CPUFREQ_GTK_FILE=$AUTO_CPUFREQ_FILE-gtk
 AUTO_CPUFREQ_GTK_DESKTOP_FILE="$(basename $AUTO_CPUFREQ_GTK_FILE).desktop"
 
+CONFIG_FILE="/etc/auto-cpufreq.conf"
 IMG_FILE="/usr/share/pixmaps/auto-cpufreq.png"
 ORG_FILE="/usr/share/polkit-1/actions/org.auto-cpufreq.pkexec.policy"
 
@@ -140,6 +141,8 @@ function tool_install {
   mkdir -p $SHARE_DIR
   cp -r scripts/ $SHARE_DIR
   cp -r images/ $SHARE_DIR
+
+  cp "$(basename $CONFIG_FILE)-example" $CONFIG_FILE
   cp images/icon.png $IMG_FILE
   cp scripts/$(basename $ORG_FILE) $(dirname $ORG_FILE)
 
@@ -185,6 +188,7 @@ function tool_remove {
   remove_file $srv_remove
   remove_file $AUTO_CPUFREQ_FILE
   remove_file $AUTO_CPUFREQ_GTK_FILE
+  remove_file $CONFIG_FILE
   remove_file $IMG_FILE
   remove_file $ORG_FILE
   remove_file "/usr/local/bin/cpufreqctl.auto-cpufreq"

--- a/auto_cpufreq/battery_scripts/ideapad_acpi.py
+++ b/auto_cpufreq/battery_scripts/ideapad_acpi.py
@@ -2,8 +2,7 @@
 import os
 from subprocess import check_output
 
-from auto_cpufreq.config.config import config
-from auto_cpufreq.globals import POWER_SUPPLY_DIR
+from auto_cpufreq.globals import CONFIG, POWER_SUPPLY_DIR
 
 def set_battery(value, mode, bat):
     path = f"{POWER_SUPPLY_DIR}{bat}/charge_{mode}_threshold"
@@ -11,13 +10,12 @@ def set_battery(value, mode, bat):
     else: print(f"WARNING: {path} does NOT exist")
 
 def get_threshold_value(mode):
-    conf = config.get_config()
-    return conf["battery"][f"{mode}_threshold"] if conf.has_option("battery", f"{mode}_threshold") else (0 if mode == "start" else 100)
+    option = ("battery", f"{mode}_threshold")
+    return CONFIG.get_option(*option) if CONFIG.has_option(*option) else (0 if mode == "start" else 100)
 
 def ideapad_acpi_setup():
-    conf = config.get_config()
-
-    if not (conf.has_option("battery", "enable_thresholds") and conf["battery"]["enable_thresholds"] == "true"): return
+    option = ("battery", "enable_thresholds")
+    if not (CONFIG.has_option(*option) and CONFIG.get_option(*option) == "true"): return
 
     if os.path.exists(POWER_SUPPLY_DIR):
         batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]

--- a/auto_cpufreq/battery_scripts/ideapad_laptop.py
+++ b/auto_cpufreq/battery_scripts/ideapad_laptop.py
@@ -2,8 +2,7 @@
 import os
 from subprocess import check_output
 
-from auto_cpufreq.config.config import config
-from auto_cpufreq.globals import CONSERVATION_MODE_FILE, POWER_SUPPLY_DIR
+from auto_cpufreq.globals import CONFIG, CONSERVATION_MODE_FILE, POWER_SUPPLY_DIR
 
 def set_battery(value, mode, bat):
     path = f"{POWER_SUPPLY_DIR}{bat}/charge_{mode}_threshold"
@@ -12,8 +11,8 @@ def set_battery(value, mode, bat):
     else: print(f"WARNING: {path} does NOT exist")
 
 def get_threshold_value(mode):
-    conf = config.get_config()
-    return conf["battery"][f"{mode}_threshold"] if conf.has_option("battery", f"{mode}_threshold") else (0 if mode == "start" else 100)
+    option = ("battery", f"{mode}_threshold")
+    return CONFIG.get_option(*option) if CONFIG.has_option(*option) else (0 if mode == "start" else 100)
 
 def conservation_mode(value):
     try:
@@ -35,17 +34,17 @@ def check_conservation_mode():
         return False
 
 def ideapad_laptop_setup():
-    conf = config.get_config()
-
-    if not (conf.has_option("battery", "enable_thresholds") and conf["battery"]["enable_thresholds"] == "true"): return
+    option = ("battery", "enable_thresholds")
+    if not (CONFIG.has_option(*option) and CONFIG.get_option(*option) == "true"): return
 
     batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith("BAT")]
 
-    if conf.has_option("battery", "ideapad_laptop_conservation_mode"):
-        if conf["battery"]["ideapad_laptop_conservation_mode"] == "true":
+    option = ("battery", "ideapad_laptop_conservation_mode")
+    if CONFIG.has_option(*option):
+        if CONFIG.get_option(*option) == "true":
             conservation_mode(1)
             return
-        if conf["battery"]["ideapad_laptop_conservation_mode"] == "false": conservation_mode(0)
+        if CONFIG.get_option(*option) == "false": conservation_mode(0)
 
     if not check_conservation_mode():
         for bat in batteries:

--- a/auto_cpufreq/battery_scripts/thinkpad.py
+++ b/auto_cpufreq/battery_scripts/thinkpad.py
@@ -2,8 +2,7 @@
 import os
 from subprocess import check_output
 
-from auto_cpufreq.config.config import config
-from auto_cpufreq.globals import POWER_SUPPLY_DIR
+from auto_cpufreq.globals import CONFIG, POWER_SUPPLY_DIR
 
 def set_battery(value, mode, bat):
     path = f"{POWER_SUPPLY_DIR}{bat}/charge_{mode}_threshold"
@@ -11,13 +10,12 @@ def set_battery(value, mode, bat):
     else: print(f"WARNING: {path} does NOT exist")
 
 def get_threshold_value(mode):
-    conf = config.get_config()
-    return conf["battery"][f"{mode}_threshold"] if conf.has_option("battery", f"{mode}_threshold") else (0 if mode == "start" else 100)
+    option = ("battery", f"{mode}_threshold")
+    return CONFIG.get_option(*option) if CONFIG.has_option(*option) else (0 if mode == "start" else 100)
 
 def thinkpad_setup():
-    conf = config.get_config()
-
-    if not (conf.has_option("battery", "enable_thresholds") and conf["battery"]["enable_thresholds"] == "true"): return
+    option = ("battery", "enable_thresholds")
+    if not (CONFIG.has_option(*option) and CONFIG.get_option(*option) == "true"): return
 
     if os.path.exists(POWER_SUPPLY_DIR):
         batteries = [name for name in os.listdir(POWER_SUPPLY_DIR) if name.startswith('BAT')]

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -23,7 +23,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
 @click.option("--config", is_flag=False, required=False, help="Use config file at defined path")
-@click.option("--config-reload", is_flag=True, help="Reload auto-cpufreq daemon|monitor|live to pick up changes made in auto-cpufreq config file")
+@click.option("--config-reload", is_flag=True, help="Reload auto-cpufreq monitor|live|daemon to pick up changes made in auto-cpufreq config file")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--get-state", is_flag=True, hidden=True)
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
@@ -31,6 +31,8 @@ from auto_cpufreq.power_helper import *
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
 def main(monitor, live, daemon, install, update, remove, force, config, config_reload, stats, get_state, completions, debug, version, donate):
+    if config_reload and not (monitor or live or daemon): print('Error: Use --config-reload command with --monitor|live|daemon')
+
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -30,7 +30,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
-def main(monitor, live, daemon, install, update, remove, force, config, reload, stats, get_state, completions, debug, version, donate):
+def main(monitor, live, daemon, install, update, remove, force, config, config_reload, stats, get_state, completions, debug, version, donate):
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
@@ -50,7 +50,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, reload, 
         if monitor:
             root_check()
             print('\nNote: You can quit monitor mode by pressing "ctrl+c"')
-            CONFIG.setup(config, reload)
+            CONFIG.setup(config, config_reload)
             battery_setup()
             battery_get_thresholds()
             if IS_INSTALLED_WITH_SNAP:
@@ -75,7 +75,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, reload, 
         elif live:
             root_check()
             print('\nNote: You can quit live mode by pressing "ctrl+c"')
-            CONFIG.setup(config, reload)
+            CONFIG.setup(config, config_reload)
             time.sleep(1)
             battery_setup()
             battery_get_thresholds()
@@ -103,7 +103,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, reload, 
             CONFIG.stop_notifier()
         elif daemon:
             root_check()
-            CONFIG.setup(config, reload)
+            CONFIG.setup(config, config_reload)
             file_stats()
             if IS_INSTALLED_WITH_SNAP and dcheck == "enabled":
                 gnome_power_detect_snap()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -23,7 +23,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
 @click.option("--config", is_flag=False, required=False, help="Use config file at defined path")
-@click.option("--config-reload", is_flag=True, help="Reload auto-cpufreq daemon to pick up changes made in auto-cpufreq config file")
+@click.option("--config-reload", is_flag=True, help="Reload auto-cpufreq daemon|monitor|live to pick up changes made in auto-cpufreq config file")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--get-state", is_flag=True, hidden=True)
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
@@ -31,8 +31,6 @@ from auto_cpufreq.power_helper import *
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
 def main(monitor, live, daemon, install, update, remove, force, config, reload, stats, get_state, completions, debug, version, donate):
-    CONFIG.setup(config, reload)
-
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
@@ -52,6 +50,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, reload, 
         if monitor:
             root_check()
             print('\nNote: You can quit monitor mode by pressing "ctrl+c"')
+            CONFIG.setup(config, reload)
             battery_setup()
             battery_get_thresholds()
             if IS_INSTALLED_WITH_SNAP:
@@ -76,6 +75,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, reload, 
         elif live:
             root_check()
             print('\nNote: You can quit live mode by pressing "ctrl+c"')
+            CONFIG.setup(config, reload)
             time.sleep(1)
             battery_setup()
             battery_get_thresholds()
@@ -103,6 +103,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, reload, 
             CONFIG.stop_notifier()
         elif daemon:
             root_check()
+            CONFIG.setup(config, reload)
             file_stats()
             if IS_INSTALLED_WITH_SNAP and dcheck == "enabled":
                 gnome_power_detect_snap()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -10,9 +10,8 @@ from subprocess import run
 from shutil import rmtree
 
 from auto_cpufreq.battery_scripts.battery import *
-from auto_cpufreq.config.config import config as conf, find_config_file
 from auto_cpufreq.core import *
-from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_AUR, IS_INSTALLED_WITH_SNAP
+from auto_cpufreq.globals import CONFIG, GITHUB, IS_INSTALLED_WITH_AUR, IS_INSTALLED_WITH_SNAP
 from auto_cpufreq.power_helper import *
 
 @click.command()
@@ -32,11 +31,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--donate", is_flag=True, help="Support the project")
 def main(monitor, live, daemon, install, update, remove, force, config, stats, get_state, completions, debug, version, donate):
     # display info if config file is used
-    config_path = find_config_file(config)
-    conf.set_path(config_path)
-    def config_info_dialog():
-        if conf.has_config():
-            print("\nUsing settings defined in " + config_path + " file")
+    CONFIG.set_path(config)
 
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
@@ -55,12 +50,11 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             set_override(force) # Calling set override, only if force has some values
 
         if monitor:
-            config_info_dialog()
             root_check()
             print('\nNote: You can quit monitor mode by pressing "ctrl+c"')
             battery_setup()
             battery_get_thresholds()
-            conf.notifier.start()
+            CONFIG.notifier.start()
             if IS_INSTALLED_WITH_SNAP:
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
@@ -79,15 +73,14 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     mon_autofreq()
                     countdown(2)
                 except KeyboardInterrupt: break
-            conf.notifier.stop()
+            CONFIG.notifier.stop()
         elif live:
             root_check()
-            config_info_dialog()
             print('\nNote: You can quit live mode by pressing "ctrl+c"')
             time.sleep(1)
             battery_setup()
             battery_get_thresholds()
-            conf.notifier.start()
+            CONFIG.notifier.start()
             if IS_INSTALLED_WITH_SNAP:
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
@@ -109,9 +102,8 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     gnome_power_start_live()
                     print()
                     break
-            conf.notifier.stop()
+            CONFIG.notifier.stop()
         elif daemon:
-            config_info_dialog()
             root_check()
             file_stats()
             if IS_INSTALLED_WITH_SNAP and dcheck == "enabled":
@@ -121,7 +113,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 gnome_power_detect()
                 tlp_service_detect()
             battery_setup()
-            conf.notifier.start()
+            CONFIG.notifier.start()
             while True:
                 try:
                     footer()
@@ -132,7 +124,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     set_autofreq()
                     countdown(2)
                 except KeyboardInterrupt: break
-            conf.notifier.stop()
+            CONFIG.notifier.stop()
         elif install:
             root_check()
             if IS_INSTALLED_WITH_SNAP:
@@ -202,7 +194,6 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             remove_complete_msg()
         elif stats:
             not_running_daemon_check()
-            config_info_dialog()
             print('\nNote: You can quit stats mode by pressing "ctrl+c"')
             if IS_INSTALLED_WITH_SNAP:
                 gnome_power_detect_snap()
@@ -231,7 +222,6 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             else: print("Invalid Option, try bash|zsh|fish as argument to --completions")
         elif debug:
             # ToDo: add status of GNOME Power Profile service status
-            config_info_dialog()
             root_check()
             battery_get_thresholds()
             cpufreqctl()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -31,8 +31,6 @@ from auto_cpufreq.power_helper import *
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
 def main(monitor, live, daemon, install, update, remove, force, config, config_reload, stats, get_state, completions, debug, version, donate):
-    if config_reload and not (monitor or live or daemon): print('Error: Use --config-reload command with --monitor|live|daemon')
-
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
@@ -48,6 +46,8 @@ def main(monitor, live, daemon, install, update, remove, force, config, config_r
             not_running_daemon_check()
             root_check() # Calling root_check before set_override as it will require sudo access
             set_override(force) # Calling set override, only if force has some values
+        
+        if config_reload and not (monitor or live or daemon): print('Error: Use --config-reload command with --monitor|live|daemon')
 
         if monitor:
             root_check()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -22,16 +22,16 @@ from auto_cpufreq.power_helper import *
 @click.option("--update", is_flag=False, help="Update daemon and package for (permanent) automatic CPU optimizations", flag_value="--update")
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
-@click.option("--config", is_flag=False, required=False, help="Use config file at defined path",)
+@click.option("--config", is_flag=False, required=False, help="Use config file at defined path")
+@click.option("--reload", is_flag=True, help="Reload when the configuration has been modified")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--get-state", is_flag=True, hidden=True)
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
-def main(monitor, live, daemon, install, update, remove, force, config, stats, get_state, completions, debug, version, donate):
-    # display info if config file is used
-    CONFIG.set_path(config)
+def main(monitor, live, daemon, install, update, remove, force, config, reload, stats, get_state, completions, debug, version, donate):
+    CONFIG.setup(config, reload)
 
     if len(sys.argv) == 1:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
@@ -54,7 +54,6 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             print('\nNote: You can quit monitor mode by pressing "ctrl+c"')
             battery_setup()
             battery_get_thresholds()
-            CONFIG.notifier.start()
             if IS_INSTALLED_WITH_SNAP:
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
@@ -73,14 +72,13 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     mon_autofreq()
                     countdown(2)
                 except KeyboardInterrupt: break
-            CONFIG.notifier.stop()
+            CONFIG.stop_notifier()
         elif live:
             root_check()
             print('\nNote: You can quit live mode by pressing "ctrl+c"')
             time.sleep(1)
             battery_setup()
             battery_get_thresholds()
-            CONFIG.notifier.start()
             if IS_INSTALLED_WITH_SNAP:
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
@@ -102,7 +100,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     gnome_power_start_live()
                     print()
                     break
-            CONFIG.notifier.stop()
+            CONFIG.stop_notifier()
         elif daemon:
             root_check()
             file_stats()
@@ -113,7 +111,6 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 gnome_power_detect()
                 tlp_service_detect()
             battery_setup()
-            CONFIG.notifier.start()
             while True:
                 try:
                     footer()
@@ -124,7 +121,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     set_autofreq()
                     countdown(2)
                 except KeyboardInterrupt: break
-            CONFIG.notifier.stop()
+            CONFIG.stop_notifier()
         elif install:
             root_check()
             if IS_INSTALLED_WITH_SNAP:

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -23,7 +23,7 @@ from auto_cpufreq.power_helper import *
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
 @click.option("--config", is_flag=False, required=False, help="Use config file at defined path")
-@click.option("--reload", is_flag=True, help="Reload when the configuration has been modified")
+@click.option("--config-reload", is_flag=True, help="Reload auto-cpufreq daemon to pick up changes made in auto-cpufreq config file")
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--get-state", is_flag=True, hidden=True)
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")

--- a/auto_cpufreq/config/config.py
+++ b/auto_cpufreq/config/config.py
@@ -1,68 +1,46 @@
-import os, pyinotify, sys
 from configparser import ConfigParser, ParsingError
-from subprocess import run, PIPE
+from os import getenv, path
+from pyinotify import ThreadedNotifier, WatchManager
+from subprocess import getoutput
 
-from auto_cpufreq.config.config_event_handler import ConfigEventHandler
+from auto_cpufreq.config.event_handler import ConfigEventHandler, MASK
 
 def find_config_file(args_config_file) -> str:
-    """
-    Find the config file to use.
+    if args_config_file is not None:
+        if path.isfile(args_config_file): return args_config_file    # (1) Command line argument was specified
+        print(f'Error: Config file specified with "--config {args_config_file}" not found.')
+        exit(1)
 
-    Look for a config file in the following priorization order:
-    1. Command line argument
-    2. User config file
-    3. System config file
-
-    :param args_config_file: Path to the config file provided as a command line argument
-    :return: The path to the config file to use
-    """
-    # Prepare paths
-
-    # use $SUDO_USER or $USER to get home dir since sudo can't access
-    # user env vars
-    home = run(["getent passwd ${SUDO_USER:-$USER} | cut -d: -f6"],
-        shell=True,
-        stdout=PIPE,
-        universal_newlines=True
-    ).stdout.rstrip()
-    user_config_dir = os.getenv("XDG_CONFIG_HOME", default=os.path.join(home, ".config"))
-    user_config_file = os.path.join(user_config_dir, "auto-cpufreq/auto-cpufreq.conf")
-    system_config_file = "/etc/auto-cpufreq.conf"
-
-    if args_config_file is not None:                                # (1) Command line argument was specified
-        # Check if the config file path points to a valid file
-        if os.path.isfile(args_config_file): return args_config_file
-        else:
-            # Not a valid file
-            print(f"Config file specified with '--config {args_config_file}' not found.")
-            sys.exit(1)
-    elif os.path.isfile(user_config_file): return user_config_file  # (2) User config file
-    else: return system_config_file                                 # (3) System config file (default if nothing else is found)
-
-class _Config:
-    def __init__(self) -> None:
-        self.path: str = ""
-        self._config: ConfigParser = ConfigParser()
-        self.watch_manager: pyinotify.WatchManager = pyinotify.WatchManager()
-        self.config_handler = ConfigEventHandler(self)
-
-        # check for file changes using threading
-        self.notifier: pyinotify.ThreadedNotifier = pyinotify.ThreadedNotifier(self.watch_manager, self.config_handler)
-        
-    def set_path(self, path: str) -> None:
-        self.path = path
-        mask = pyinotify.IN_CREATE | pyinotify.IN_DELETE | pyinotify.IN_MODIFY | pyinotify.IN_MOVED_FROM | pyinotify.IN_MOVED_TO
-        self.watch_manager.add_watch(os.path.dirname(path), mask=mask)
-        if os.path.isfile(path): self.update_config()
-
-    def has_config(self) -> bool: return os.path.isfile(self.path)
+    user_config_path = getenv('XDG_CONFIG_HOME', default=getoutput('getent passwd ${SUDO_USER:-$USER} | cut -d: -f6')+'/.config')
+    for dir in ('', '/auto-cpufreq'):
+        conf_file = user_config_path+dir+'/auto-cpufreq.conf'
+        if path.isfile(conf_file): return conf_file                  # (2) User config file
     
-    def get_config(self) -> ConfigParser: return self._config
+    system_config_file = '/etc/auto-cpufreq.conf'
+    if path.isfile(system_config_file): return system_config_file    # (3) System config file (default if nothing else is found)
+    print('Error: No config file found')
+    exit(1)
+
+class Config:
+    conf:ConfigParser = None
+    file:str = ""
+
+    def __init__(self) -> None:
+        # check for file changes using threading
+        self.watch_manager: WatchManager = WatchManager()
+        self.notifier: ThreadedNotifier = ThreadedNotifier(self.watch_manager, ConfigEventHandler(self))
+
+    def get_option(self, section:str, option:str) -> str: return self.conf[section][option]
+
+    def has_option(self, section:str, option:str) -> bool: return self.conf.has_option(section, option)
+        
+    def set_path(self, args_config_file:str) -> None:
+        self.file = find_config_file(args_config_file)
+        print(f"Info: Using settings defined in {self.file} file")
+        self.watch_manager.add_watch(path.dirname(self.file), mask=MASK)
+        self.update_config()
     
     def update_config(self) -> None:
-        # create new ConfigParser to prevent old data from remaining
-        self._config = ConfigParser()
-        try: self._config.read(self.path)
+        self.conf = ConfigParser()      # create new ConfigParser to prevent old data from remaining
+        try: self.conf.read(self.file)
         except ParsingError as e: print(f"The following error occured while parsing the config file: \n{repr(e)}")
-
-config = _Config()

--- a/auto_cpufreq/config/config.py
+++ b/auto_cpufreq/config/config.py
@@ -31,7 +31,6 @@ class Config:
 
     def set_file(self, file:str):
         self.file = file
-        print(f"Info: Using settings defined in {file} file")
         self.update_config()
         if self.auto_reload: self.watch_manager.add_watch(path.dirname(file), mask=MASK)
         
@@ -49,5 +48,6 @@ class Config:
     
     def update_config(self) -> None:
         self.conf = ConfigParser()      # create new ConfigParser to prevent old data from remaining
+        print(f"Info: Using settings defined in {self.file} file")
         try: self.conf.read(self.file)
         except ParsingError as e: print(f"The following error occured while parsing the config file: \n{repr(e)}")

--- a/auto_cpufreq/config/event_handler.py
+++ b/auto_cpufreq/config/event_handler.py
@@ -1,11 +1,13 @@
-from pyinotify import Event, ProcessEvent
+from pyinotify import Event, IN_CREATE, IN_DELETE, IN_MODIFY, IN_MOVED_FROM, IN_MOVED_TO, ProcessEvent
+
+MASK = IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO
 
 class ConfigEventHandler(ProcessEvent):
     def __init__(self, config) -> None:
         self.config = config
 
     def _process_update(self, event: Event):
-        if event.pathname.rstrip("~") == self.config.path: self.config.update_config()
+        if event.pathname.rstrip("~") == self.config.file: self.config.update_config()
 
     # activates when auto-cpufreq config file is modified
     def process_IN_MODIFY(self, event: Event) -> None: self._process_update(event)

--- a/auto_cpufreq/globals.py
+++ b/auto_cpufreq/globals.py
@@ -1,9 +1,13 @@
 from os import getenv, path
 from subprocess import getoutput
 
+from auto_cpufreq.config.config import Config
+
 ALL_GOVERNORS = ('performance', 'ondemand', 'conservative', 'schedutil', 'userspace', 'powersave') # from the highest performance to the lowest
 AVAILABLE_GOVERNORS = getoutput('cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors').strip().split(' ')
 AVAILABLE_GOVERNORS_SORTED = tuple(filter(lambda gov: gov in AVAILABLE_GOVERNORS, ALL_GOVERNORS))
+
+CONFIG = Config()
 
 CONSERVATION_MODE_FILE = "/sys/bus/platform/drivers/ideapad_acpi/VPC2004:00/conservation_mode"
 GITHUB = "https://github.com/AdnanHodzic/auto-cpufreq"


### PR DESCRIPTION
- Add detection of `$HOME/.config/auto-cpufreq.conf` file
- Add `--config-reload` option, the user chooses to enable or not the auto-reload when the configuration has been modified
- Auto install and remove `/etc/auto-cpufreq.conf` file
- Clean code
  - Add `has_option` and `get_option` functions
  - Remove `get_config` function because it's more cumbersome to call it