### PR TITLE
Add support for setting "Platform Profile"

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,10 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
-# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# Platform Profiles
+# https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html
+# See available options by running:
+# cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = performance
 
 # minimum cpu frequency (in kHz)
@@ -330,7 +333,10 @@ governor = powersave
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
 
-# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# Platform Profiles
+# https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html
+# See available options by running:
+# cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = low-power
 
 # minimum cpu frequency (in kHz)

--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
+# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# platform_profile = performance
+
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
 # see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
@@ -326,6 +329,9 @@ governor = powersave
 
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
+
+# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# platform_profile = low-power
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -7,6 +7,9 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
+# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# platform_profile = performance
+
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
 # see conversion info: https://www.rapidtables.com/convert/frequency/mhz-to-hz.html
@@ -30,6 +33,9 @@ governor = powersave
 
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
+
+# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# platform_profile = low-power
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -7,7 +7,10 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
-# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# Platform Profiles
+# https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html
+# See available options by running:
+# cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = performance
 
 # minimum cpu frequency (in kHz)
@@ -34,7 +37,10 @@ governor = powersave
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
 
-# PP: see available preferences by running: cat /sys/firmware/acpi/platform_profile_choices
+# Platform Profiles
+# https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html
+# See available options by running:
+# cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = low-power
 
 # minimum cpu frequency (in kHz)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -476,6 +476,15 @@ def set_frequencies():
         # set the frequency
         run(f"cpufreqctl.auto-cpufreq {frequency[freq_type]['cmdargs']} --set={frequency[freq_type]['value']}", shell=True)
 
+def set_platform_profile(conf, profile):
+    if conf.has_option(profile, "platform_profile"):
+        if not Path("/sys/firmware/acpi/platform_profile").exists():
+            print('Not setting Platform Profile (not supported by system)')
+        else:
+            pp = conf[profile]["platform_profile"]
+            print(f'Setting to use: "{pp}" Platform Profile')
+            run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
+
 def set_powersave():
     conf = config.get_config()
     gov = conf["battery"]["governor"] if conf.has_option("battery", "governor") else AVAILABLE_GOVERNORS_SORTED[-1]
@@ -503,6 +512,7 @@ def set_powersave():
                 run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
                 print('Setting to use: "balance_power" EPP')
 
+    set_platform_profile(conf, "battery")
     set_frequencies()
 
     cpuload, load1m= get_load()
@@ -608,6 +618,8 @@ def set_performance():
                 else:
                     run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
                     print('Setting to use: "balance_performance" EPP')
+
+    set_platform_profile(conf, "charger")
     set_frequencies()
 
     cpuload, load1m = get_load()

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -3,6 +3,7 @@
 VERSION='20'
 cpucount=`cat /proc/cpuinfo | grep processor | wc -l`
 FLROOT=/sys/devices/system/cpu
+FWROOT=/sys/firmware
 DRIVER=auto
 VERBOSE=0
 
@@ -261,6 +262,16 @@ case $OPTION in
     else
       verbose "Setting CPU"$CORE" EPPs to "$VALUE
       set_energy_performance_preference
+    fi
+  ;;
+  -p|--pp)
+    if [ ! -z $AVAILABLE ]; then cat $FWROOT/acpi/platform_profile_choices
+    elif [ -z $VALUE ]; then
+      verbose "Getting Platform Profile"
+      cat $FWROOT/acpi/platform_profile
+    else
+      verbose "Getting Platform Profile to "$VALUE
+      echo $VALUE > $FWROOT/acpi/platform_profile
     fi
   ;;
   -f|--frequency)


### PR DESCRIPTION
Allow overriding/setting [Platform Profile](https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html) on supported platform for battery and charger profiles. Setting this profile could help avoid throttling issues in high performance mode on charging profile (like throttling due to lap-mode on ThinkPads) and save some power in battery mode if firmware supports.

Support for setting this in TLP: https://linrunner.de/tlp/settings/platform.html#platform-profile-on-ac-bat

Closes #468 