### PR TITLE
Fix unsafe access to PATH

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -22,7 +22,10 @@ from auto_cpufreq.power_helper import *
 filterwarnings("ignore")
 
 # add path to auto-cpufreq executables for GUI
-os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + "/usr/local/bin"
+if "PATH" in os.environ:
+    os.environ["PATH"] += os.pathsep + "/usr/local/bin"
+else:
+    os.environ["PATH"] = "/usr/local/bin"
 
 # ToDo:
 # - replace get system/CPU load from: psutil.getloadavg() | available in 5.6.2)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -22,7 +22,7 @@ from auto_cpufreq.power_helper import *
 filterwarnings("ignore")
 
 # add path to auto-cpufreq executables for GUI
-os.environ["PATH"] += ":/usr/local/bin"
+os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + "/usr/local/bin"
 
 # ToDo:
 # - replace get system/CPU load from: psutil.getloadavg() | available in 5.6.2)


### PR DESCRIPTION
This addresses #755 - an immediate crash due to a KeyError when PATH is not present in os.environ (which is the case when the service is ran through dinit).