### PR TITLE
Unpin psutil and requests packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721373214,
-        "narHash": "sha256-crpGeGQGFlnCsMyCE5eheyjzo3xo03o1FXJ2sAbm7No=",
+        "lastModified": 1722478193,
+        "narHash": "sha256-htXWANIhuM3KgpK/3BvPao8DrJayuxUBXLwvTDWrW8E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af9c15bc7a314c226d7d5d85e159f7a73e8d9fae",
+        "rev": "799bc8d7b16e6779f0105713e6794899133c4a38",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,15 +7,6 @@
 }:
 let
 
-  psutil = python3Packages.psutil.overrideAttrs (oldAttrs: {
-    src = fetchFromGitHub {
-      owner = "giampaolo";
-      repo = "psutil";
-      rev = "4cf56e08c1bc883ec89758834b50954380759858";
-      sha256 = "61JwXP/cZrXqdBnb2J0kdDJoKpltO62KcpM0sYX6g1A=";
-    };
-  });
-
   pyinotify = python3Packages.pyinotify.overrideAttrs (oldAttrs: {
     src = fetchFromGitHub {
       owner = "shadeyg56";
@@ -24,14 +15,6 @@ let
       hash = "sha256-714CximEK4YhIqDmvqJYOUGs39gvDkWGrkNrXwxT8iM=";
     };
     patches = [];
-  });
-
-  requests = python3Packages.requests.overrideAttrs (oldAttrs: {
-    src = fetchPypi {
-      pname = "requests";
-      version = "2.32.1";
-      hash = "sha256-65fofmTHnmTluKx1zundH5f0niibCD7mvpYmiTByVoU=";
-    };
   });
 
 in

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,6 @@
 {
-  python310Packages,
   python3Packages,
+  pkgs,
   ...
 }: let
   mainPkg = python3Packages.callPackage ./default.nix {};
@@ -8,7 +8,8 @@ in
   mainPkg.overrideAttrs (oa: {
     nativeBuildInputs =
       [
-        python310Packages.pip
+        python3Packages.pip
+        pkgs.poetry
       ]
       ++ (oa.nativeBuildInputs or []);
   })

--- a/poetry.lock
+++ b/poetry.lock
@@ -796,21 +796,32 @@ poetry-core = ">=1.6.0,<2.0.0"
 
 [[package]]
 name = "psutil"
-version = "5.9.8"
+version = "6.0.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-files = []
-develop = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},
+    {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:a9a3dbfb4de4f18174528d87cc352d1f788b7496991cca33c6996f40c9e3c92c"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6ec7588fb3ddaec7344a825afe298db83fe01bfaaab39155fa84cf1c0d6b13c3"},
+    {file = "psutil-6.0.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:1e7c870afcb7d91fdea2b37c24aeb08f98b6d67257a5cb0a8bc3ac68d0f1a68c"},
+    {file = "psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35"},
+    {file = "psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1"},
+    {file = "psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd"},
+    {file = "psutil-6.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e8d0054fc88153ca0544f5c4d554d42e33df2e009c4ff42284ac9ebdef4132"},
+    {file = "psutil-6.0.0-cp36-cp36m-win32.whl", hash = "sha256:fc8c9510cde0146432bbdb433322861ee8c3efbf8589865c8bf8d21cb30c4d14"},
+    {file = "psutil-6.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:34859b8d8f423b86e4385ff3665d3f4d94be3cdf48221fbe476e883514fdb71c"},
+    {file = "psutil-6.0.0-cp37-abi3-win32.whl", hash = "sha256:a495580d6bae27291324fe60cea0b5a7c23fa36a7cd35035a16d93bdcf076b9d"},
+    {file = "psutil-6.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:33ea5e1c975250a720b3a6609c490db40dae5d83a4eb315170c4fe0d8b1f34b3"},
+    {file = "psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffe7fc9b6b36beadc8c322f84e1caff51e8703b88eee1da46d1e3a6ae11b4fd0"},
+    {file = "psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2"},
+]
 
 [package.extras]
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
-
-[package.source]
-type = "git"
-url = "https://github.com/giampaolo/psutil.git"
-reference = "4cf56e08c1bc883ec89758834b50954380759858"
-resolved_reference = "4cf56e08c1bc883ec89758834b50954380759858"
 
 [[package]]
 name = "ptyprocess"
@@ -1069,13 +1080,13 @@ full = ["numpy"]
 
 [[package]]
 name = "requests"
-version = "2.32.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.0-py3-none-any.whl", hash = "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"},
-    {file = "requests-2.32.0.tar.gz", hash = "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -1300,4 +1311,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3b6b635215c5c990a91560821d0122e60f7532cc3cbc1aa08fd5e5439fa0b6b9"
+content-hash = "cad3783d04e35b66b241352e76631d0a83c8df3d286b113979ba34a65847f06c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-psutil = {git = "https://github.com/giampaolo/psutil.git", rev = "4cf56e08c1bc883ec89758834b50954380759858"}
+psutil = "^6.0.0"
 click = "^8.1.0"
 distro = "^1.8.0"
-requests = "^2.32.0"
+requests = "^2.32.3"
 PyGObject = "^3.46.0"
 pyinotify = {git = "https://github.com/shadeyg56/pyinotify-3.12"}
 


### PR DESCRIPTION
We had these packages pinned because of #654 and #707. 
The psutil package had an official update so we no longer need to pull from the github repo and the requests package got updated in Nix so its now safe to unpin both of these dependencies

Also added poetry to the dev shell for Nix for convenience