### PR TITLE
Resolve permission errors for --install, --remove, and cpufreqctl.auto-cpufreq on Ubuntu 24.04

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -285,6 +285,7 @@ def cpufreqctl():
     """
     if not (IS_INSTALLED_WITH_SNAP or os.path.isfile("/usr/local/bin/cpufreqctl.auto-cpufreq")):
         copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/local/bin/cpufreqctl.auto-cpufreq")
+        call(["chmod", "a+x", "/usr/local/bin/cpufreqctl.auto-cpufreq"])
 
 def cpufreqctl_restore():
     """
@@ -317,9 +318,11 @@ def deploy_daemon():
 
     print("\n* Deploy auto-cpufreq install script")
     copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/local/bin/auto-cpufreq-install")
+    call(["chmod", "a+x", "/usr/local/bin/auto-cpufreq-install"])
 
     print("\n* Deploy auto-cpufreq remove script")
     copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/local/bin/auto-cpufreq-remove")
+    call(["chmod", "a+x", "/usr/local/bin/auto-cpufreq-remove"])
 
     # output warning if gnome power profile is running
     gnome_power_detect_install()


### PR DESCRIPTION

Add execution permissions to auto-cpufreq-install, auto-cpufreq-remove, and cpufreqctl.auto-cpufreq to enable installation and removal of daemon, as well as statistics (--stats).
The install shell does display **Permission denied**, but goes on as though it was something unimportant. However, the program is not installed properly and cannot be used effectively.

![Screenshot from 2024-08-10 22-38-36](https://github.com/user-attachments/assets/2e833334-a016-42d3-bcfc-1a28c83110c8)
[debug.log](https://github.com/user-attachments/files/16570969/debug.log)
