### PR TITLE
Adding Gentoo Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ The AUR [Release Package](https://aur.archlinux.org/packages/auto-cpufreq) is cu
 
 ### Gentoo Linux (GURU Repository)
 
-New versions of auto-cpufreq were recently added GURU, one of the largest community maintained ebuild repositories for Gentoo Linux. The [ebuild](https://github.com/gentoo-mirror/guru/tree/master/sys-power/auto-cpufreq) is maintaned by GURU contributors. In order to be able to build it from source using Portage (Gentoo's package manager), it is necessary to add GURU repository first and sync it. Adding ~amd64 keyword to the package is also necessary to unmask it.
+New versions of auto-cpufreq were recently added to GURU, Gentoo's official community-maintained ebuild repository. The [ebuild](https://github.com/gentoo-mirror/guru/tree/master/sys-power/auto-cpufreq) is maintaned by [S41G0N](https://github.com/S41G0N) and other [GURU contributors](https://bugs.gentoo.org), who can respond in case of issues.
+
+In order to build auto-cpufreq, it is necessary to add & sync GURU repository first. Adding ~amd64 keyword is also needed to unmask the package.
 
 ``` 
 # echo "sys-power/auto-cpufreq ~amd64" >> /etc/portage/package.accept_keywords

--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ The AUR [Release Package](https://aur.archlinux.org/packages/auto-cpufreq) is cu
 - The GNOME Power Profiles daemon is [automatically disabled by auto-cpufreq-installer](https://github.com/AdnanHodzic/auto-cpufreq#1-power_helperpy-script-snap-package-install-only) due to it's conflict with auto-cpufreq.service. However, this doesn't happen with AUR installs, which can lead to problems (e.g., [#463](https://github.com/AdnanHodzic/auto-cpufreq/issues/463)) if not masked manually.
   - Open a terminal and run `sudo systemctl mask power-profiles-daemon.service` (then `enable` and `start` the auto-cpufreq.service if you haven't already).
 
+### Gentoo Linux (GURU Repository)
+
+New versions of auto-cpufreq were recently added GURU, one of the largest community maintained ebuild repositories for Gentoo Linux. The [ebuild](https://github.com/gentoo-mirror/guru/tree/master/sys-power/auto-cpufreq) is maintaned by GURU contributors. In order to be able to build it from source using Portage (Gentoo's package manager), it is necessary to add GURU repository first and sync it. Adding ~amd64 keyword to the package is also necessary to unmask it.
+
+``` 
+# echo "sys-power/auto-cpufreq ~amd64" >> /etc/portage/package.accept_keywords
+# eselect repository enable guru
+# emaint sync -r guru
+# emerge --ask auto-cpufreq
+```
+
+**Notices**
+
+- The build process links to `/usr/share/` instead of `/usr/local/share/`
+- The build works on both systemd/OpenRC systems (both systemd and OpenRC will have a service called auto-cpufreq which can be started automatically)
+- The daemon installer provided does work, but it is RECOMMENDED to install the daemon with:
+``` 
+# systemctl enable --now auto-cpufreq 
+# rc-update add auto-cpufreq default && rc-service auto-cpufreq start
+```
 
 ### NixOS
 


### PR DESCRIPTION
Hi, my name is Michal and I have been using auto-cpufreq on Gentoo for quite some time. I absolutely love it. I recently became a contributor to GURU (Gentoo's official community-maintained ebuild repository, where users can compile non-standard apps missing in the main repo). I added the most recent versions of auto-cpufreq to this repository, which have been recently merged into GURU's master branch.

This is why I wanted to add this section: to expand auto-cpufreq's reach and make it available to more people. I'm willing to maintain these ebuilds for as long as I can.  I would be more than glad to fix issues ASAP in case they appear.

Thanks for your time and consideration. Let me know if there are any issues.