### PR TITLE
Fix check_conservation_mode() function in ideapad_laptop.py

### DIFF
--- a/auto_cpufreq/battery_scripts/ideapad_laptop.py
+++ b/auto_cpufreq/battery_scripts/ideapad_laptop.py
@@ -24,7 +24,7 @@ def conservation_mode(value):
 
 def check_conservation_mode():
     try:
-        value = check_output(["cat", CONSERVATION_MODE_FILE], text=True)
+        value = check_output(["cat", CONSERVATION_MODE_FILE], text=True).rstrip()
         if value == "1": return True
         elif value == "0": return False
         else:


### PR DESCRIPTION
Add `.rstrip()` to `value = check_output(["cat", CONSERVATION_MODE_FILE], text=True)` to prevent new line character `\n` breaking if statement