### PR TITLE
Add EPB (Energy Performance Bias) settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,14 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
+# EPB (Energy Performance Bias) for the intel_pstate driver
+# see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
+# available EPB options include a numeric value between 0-15
+# (where 0 = maximum performance and 15 = maximum power saving),
+# or one of the following strings:
+# performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# energy_perf_bias = balance_performance
+
 # Platform Profiles
 # https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html
 # See available options by running:
@@ -355,6 +363,14 @@ governor = powersave
 
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
+
+# EPB (Energy Performance Bias) for the intel_pstate driver
+# see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
+# available EPB options include a numeric value between 0-15
+# (where 0 = maximum performance and 15 = maximum power saving),
+# or one of the following strings:
+# performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# energy_perf_bias = balance_power
 
 # Platform Profiles
 # https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -7,6 +7,14 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
+# EPB (Energy Performance Bias) for the intel_pstate driver
+# see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
+# available EPB options include a numeric value between 0-15
+# (where 0 = maximum performance and 15 = maximum power saving),
+# or one of the following strings:
+# performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# energy_perf_bias = balance_performance
+
 # Platform Profiles
 # https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html
 # See available options by running:
@@ -47,6 +55,14 @@ governor = powersave
 
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
+
+# EPB (Energy Performance Bias) for the intel_pstate driver
+# see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
+# available EPB options include a numeric value between 0-15
+# (where 0 = maximum performance and 15 = maximum power saving),
+# or one of the following strings:
+# performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# energy_perf_bias = balance_power
 
 # Platform Profiles
 # https://www.kernel.org/doc/html/latest/userspace-api/sysfs-platform_profile.html

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -504,6 +504,18 @@ def set_platform_profile(conf, profile):
             print(f'Setting to use: "{pp}" Platform Profile')
             run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
 
+def set_energy_perf_bias(conf, profile):
+    if Path("/sys/devices/system/cpu/intel_pstate").exists() is False:
+        print('Not setting EPB (not supported by system)')
+        return
+    epb = "balance_performance" if profile == "charger" else "balance_power"
+    if conf.has_option(profile, "energy_perf_bias"):
+        epb = conf[profile]["energy_perf_bias"]
+
+    run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
+    print(f'Setting to use: "{epb}" EPB')
+
+
 def set_powersave():
     conf = config.get_config()
     gov = conf["battery"]["governor"] if conf.has_option("battery", "governor") else AVAILABLE_GOVERNORS_SORTED[-1]
@@ -530,19 +542,8 @@ def set_powersave():
             else:
                 run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
                 print('Setting to use: "balance_power" EPP')
-    
-    if Path("/sys/devices/system/cpu/intel_pstate").exists():
-        if Path("/sys/devices/system/cpu/cpu0/power/energy_perf_bias").exists() is False:
-            print('Not setting EPB (not supported by system)')
-        else:
-            if conf.has_option("battery", "energy_perf_bias"):
-                epb = conf["battery"]["energy_perf_bias"]
-                run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
-                print(f'Setting to use: "{epb}" EPB')
-            else:
-                run("cpufreqctl.auto-cpufreq --epb --set=balance-power", shell=True)
-                print('Setting to use: "balance-power" EPB')
 
+    set_energy_perf_bias(conf, "battery")
     set_platform_profile(conf, "battery")
     set_frequencies()
 
@@ -629,17 +630,6 @@ def set_performance():
                     else:
                         run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
                         print('Setting to use: "balance_performance" EPP')
-
-            if Path("/sys/devices/system/cpu/cpu0/power/energy_perf_bias").exists() is False:
-                print('Not setting EPB (not supported by system)')
-            else:
-                if conf.has_option("charger", "energy_perf_bias"):
-                    epb = conf["charger"]["energy_perf_bias"]
-                    run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
-                    print(f'Setting to use: "{epb}" EPB')
-                else:
-                    run("cpufreqctl.auto-cpufreq --epb --set=default", shell=True)
-                    print('Setting to use: "default" EPB')
         elif Path("/sys/devices/system/cpu/amd_pstate").exists():
             amd_pstate_status_path = "/sys/devices/system/cpu/amd_pstate/status"
 
@@ -660,7 +650,8 @@ def set_performance():
                 else:
                     run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
                     print('Setting to use: "balance_performance" EPP')
-
+    
+    set_energy_perf_bias(conf, "charger")
     set_platform_profile(conf, "charger")
     set_frequencies()
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -530,6 +530,18 @@ def set_powersave():
             else:
                 run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
                 print('Setting to use: "balance_power" EPP')
+    
+    if Path("/sys/devices/system/cpu/intel_pstate").exists():
+        if Path("/sys/devices/system/cpu/cpu0/power/energy_perf_bias").exists() is False:
+            print('Not setting EPB (not supported by system)')
+        else:
+            if conf.has_option("battery", "energy_perf_bias"):
+                epb = conf["battery"]["energy_perf_bias"]
+                run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
+                print(f'Setting to use: "{epb}" EPB')
+            else:
+                run("cpufreqctl.auto-cpufreq --epb --set=balance-power", shell=True)
+                print('Setting to use: "balance-power" EPB')
 
     set_platform_profile(conf, "battery")
     set_frequencies()
@@ -617,6 +629,17 @@ def set_performance():
                     else:
                         run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
                         print('Setting to use: "balance_performance" EPP')
+
+            if Path("/sys/devices/system/cpu/cpu0/power/energy_perf_bias").exists() is False:
+                print('Not setting EPB (not supported by system)')
+            else:
+                if conf.has_option("charger", "energy_perf_bias"):
+                    epb = conf["charger"]["energy_perf_bias"]
+                    run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
+                    print(f'Setting to use: "{epb}" EPB')
+                else:
+                    run("cpufreqctl.auto-cpufreq --epb --set=default", shell=True)
+                    print('Setting to use: "default" EPB')
         elif Path("/sys/devices/system/cpu/amd_pstate").exists():
             amd_pstate_status_path = "/sys/devices/system/cpu/amd_pstate/status"
 

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -269,9 +269,9 @@ function set_energy_performance_bias () {
   else
     case $VALUE in
       performance) EPB_VALUE=0;;
-      balance-performance) EPB_VALUE=4;;
-      normal| default) EPB_VALUE=6;;
-      balance-power) EPB_VALUE=8;;
+      balance_performance) EPB_VALUE=4;;
+      default) EPB_VALUE=6;;
+      balance_power) EPB_VALUE=8;;
       power) EPB_VALUE=15;;
       *)
         verbose "Invalid value provided for EPB"


### PR DESCRIPTION
This PR adds support for the `energy_perf_bias` setting, giving users more control over how their Intel CPU (`intel_pstate` driver) balances performance and power efficiency

What's Changed:
- Introduced a new `energy_perf_bias` option, which can be set as a number (0-15) or using predefined strings like "performance", "balance_performance", "default", "balance_power" and "power" (made their names the same as EPP's)
- Integrated the `energy_perf_bias` setting into the existing power management logic, dynamically adjusting it based on the selected profile or user preferences
- Updated the documentation to explain how to configure and use the new `energy_perf_bias` setting

Closes: #522 

Looking forward to any feedback or suggestions!