### PR TITLE
Fixed wrong sensor being monitored (AMD)

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -856,7 +856,7 @@ def sysinfo():
             for sensor in temp_sensors:
                 # iterate over all temperatures in the current sensor
                 for temp in temp_sensors[sensor]:
-                    if 'CPU' in temp.label and temp.current != 0:
+                    if ('CPU' in temp.label or 'Tctl' in temp.label) and temp.current != 0:
                         temp_per_cpu = [temp.current] * online_cpu_count
                         break
                 else: continue


### PR DESCRIPTION
When I installed auto-cpufreq on my fresh EndevourOS install it was monitoring the wrong sensor, and showing temperatures of 17 degrees. 

This is the fix I did, and it is currently showing the correct temp:
Instead of only looking for 'CPU' temp.label, I added that it should look for 'Tctl', as that is the sensor for average temp on my 7800X3D CPU.