### PR TITLE
Added notes to the documentation about the default `energy_perf_bias` settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ energy_performance_preference = performance
 # (where 0 = maximum performance and 15 = maximum power saving),
 # or one of the following strings:
 # performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# if the parameter is missing in the config and the hardware supports this setting, the default value will be used
+# the default value is `balance_performance` (for charger)
 # energy_perf_bias = balance_performance
 
 # Platform Profiles
@@ -370,6 +372,8 @@ energy_performance_preference = power
 # (where 0 = maximum performance and 15 = maximum power saving),
 # or one of the following strings:
 # performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# if the parameter is missing in the config and the hardware supports this setting, the default value will be used
+# the default value is `balance_power` (for battery)
 # energy_perf_bias = balance_power
 
 # Platform Profiles

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -13,6 +13,8 @@ energy_performance_preference = performance
 # (where 0 = maximum performance and 15 = maximum power saving),
 # or one of the following strings:
 # performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# if the parameter is missing in the config and the hardware supports this setting, the default value will be used
+# the default value is `balance_performance` (for charger)
 # energy_perf_bias = balance_performance
 
 # Platform Profiles
@@ -62,6 +64,8 @@ energy_performance_preference = power
 # (where 0 = maximum performance and 15 = maximum power saving),
 # or one of the following strings:
 # performance (0), balance_performance (4), default (6), balance_power (8), or power (15)
+# if the parameter is missing in the config and the hardware supports this setting, the default value will be used
+# the default value is `balance_power` (for battery)
 # energy_perf_bias = balance_power
 
 # Platform Profiles

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -319,10 +319,10 @@ case $OPTION in
   --epb)
     if [ ! -z $AVAILABLE ]; then cat $FLROOT/cpu0/power/energy_perf_bias
     elif [ -z $VALUE ]; then 
-      verbose "Getting CPU"$CORE" EBPs"
+      verbose "Getting CPU"$CORE" EPBs"
       get_energy_performance_bias
     else
-      verbose "Setting CPU"$CORE" EBPs to "$VALUE
+      verbose "Setting CPU"$CORE" EPBs to "$VALUE
       set_energy_performance_bias
     fi
   ;;


### PR DESCRIPTION
- Updated `energy_perf_bias` documentation (default settings behavior)
- Fixed typo in the `energy_perf_bias` verbose message for `cpufreqclt`