### PR TITLE
Implement support for Fedora 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The AUR [Release Package](https://aur.archlinux.org/packages/auto-cpufreq) is cu
 ```
 - The GNOME Power Profiles daemon is [automatically disabled by auto-cpufreq-installer](https://github.com/AdnanHodzic/auto-cpufreq#1-power_helperpy-script-snap-package-install-only) due to it's conflict with auto-cpufreq.service. However, this doesn't happen with AUR installs, which can lead to problems (e.g., [#463](https://github.com/AdnanHodzic/auto-cpufreq/issues/463)) if not masked manually.
   - Open a terminal and run `sudo systemctl mask power-profiles-daemon.service` (then `enable` and `start` the auto-cpufreq.service if you haven't already).
+- The TuneD daemon(enabled by default with Fedora 41) is [automatically disabled by auto-cpufreq-installer](https://github.com/AdnanHodzic/auto-cpufreq#1-power_helperpy-script-snap-package-install-only) due to it's conflict with auto-cpufreq.service.
 
 ### Gentoo Linux (GURU Repository)
 

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -94,6 +94,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             else:
                 gnome_power_detect_install()
                 gnome_power_stop_live()
+                tuned_stop_live()
                 tlp_service_detect()
             while True:
                 try:
@@ -107,6 +108,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                     countdown(2)
                 except KeyboardInterrupt:
                     gnome_power_start_live()
+                    tuned_start_live()
                     print()
                     break
             conf.notifier.stop()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -324,6 +324,8 @@ def deploy_daemon():
     gnome_power_detect_install()
     gnome_power_svc_disable()
 
+    tuned_svc_disable()
+
     tlp_service_detect() # output warning if TLP service is detected
 
     call("/usr/local/bin/auto-cpufreq-install", shell=True)
@@ -371,6 +373,8 @@ def remove_daemon():
     # output warning if gnome power profile is stopped
     gnome_power_rm_reminder()
     gnome_power_svc_enable()
+
+    tuned_svc_enable()
 
     # run auto-cpufreq daemon remove script
     call("/usr/local/bin/auto-cpufreq-remove", shell=True)

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -25,6 +25,7 @@ bluetoothctl_exists = does_command_exists("bluetoothctl")
 powerprofilesctl_exists = does_command_exists("powerprofilesctl")
 systemctl_exists = does_command_exists("systemctl")
 tlp_stat_exists = does_command_exists("tlp-stat")
+tuned_stat_exists = does_command_exists("tuned")
 
 # detect if gnome power profile service is running
 if not IS_INSTALLED_WITH_SNAP:
@@ -99,9 +100,17 @@ def gnome_power_stop_live():
         call(["powerprofilesctl", "set", "balanced"])
         call(["systemctl", "stop", "power-profiles-daemon"])
 
+# stops tuned (live)
+def tuned_stop_live():
+    if systemctl_exists and tuned_stat_exists:
+        call(["systemctl", "stop", "tuned"])
+
 # starts gnome >= 40 power profiles (live)
 def gnome_power_start_live():
     if systemctl_exists: call(["systemctl", "start", "power-profiles-daemon"])
+
+def tuned_start_live():
+    if systemctl_exists: call(["systemctl", "start", "tuned"])
 
 # enable gnome >= 40 power profiles (uninstall)
 def gnome_power_svc_enable():
@@ -112,6 +121,17 @@ def gnome_power_svc_enable():
             call(["systemctl", "start", "power-profiles-daemon"])
             call(["systemctl", "enable", "power-profiles-daemon"])
             call(["systemctl", "daemon-reload"])
+        except:
+            print("\nUnable to enable GNOME power profiles")
+            print("If this causes any problems, please submit an issue:")
+            print(GITHUB+"/issues")
+
+def tuned_svc_enable():
+    if systemctl_exists:
+        try:
+            print("* Enabling TuneD\n")
+            call(["systemctl", "unmask", "tuned"])
+            call(["systemctl", "enable", "--now", "tuned"])
         except:
             print("\nUnable to enable GNOME power profiles")
             print("If this causes any problems, please submit an issue:")
@@ -209,6 +229,17 @@ def disable_power_profiles_daemon():
         print("If this causes any problems, please submit an issue:")
         print(GITHUB+"/issues")
 
+def disable_tuned_daemon():
+    # always disable TuneD daemon
+    try:
+        print("\n* Disabling TuneD daemon")
+        call(["systemctl", "disable", "--now", "tuned"])
+        call(["systemctl", "mask", "tuned"])
+    except:
+        print("\nUnable to disable TuneD daemon")
+        print("If this causes any problems, please submit an issue:")
+        print(GITHUB+"/issues")
+
 # default gnome_power_svc_disable func (balanced)
 def gnome_power_svc_disable():
     snap_pkg_check = 0
@@ -244,6 +275,10 @@ def gnome_power_svc_disable():
                 call(["powerprofilesctl", "set", "balanced"])
 
                 disable_power_profiles_daemon()
+
+def tuned_svc_disable():
+    if systemctl_exists and tuned_stat_exists:
+        disable_tuned_daemon()
 
 # cli
 @click.command()


### PR DESCRIPTION
This PR closes #779. It adds the support to Fedora 41.

Fedora 41 uses [TuneD](https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/sysadmin/#tuned-def-pwr-mgmt-daemon) as a default power profile management daemon and it is conflicting with auto-cpufreq service.

Thanks to this PR, TuneD is automatically disabled when installing auto-cpufreq.

