### PR TITLE
Improve systemd service management

### DIFF
--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -119,9 +119,7 @@ def gnome_power_svc_enable():
         try:
             print("* Enabling GNOME power profiles\n")
             call(["systemctl", "unmask", "power-profiles-daemon"])
-            call(["systemctl", "start", "power-profiles-daemon"])
-            call(["systemctl", "enable", "power-profiles-daemon"])
-            call(["systemctl", "daemon-reload"])
+            call(["systemctl", "enable", "--now", "power-profiles-daemon"])
         except:
             print("\nUnable to enable GNOME power profiles")
             print("If this causes any problems, please submit an issue:")
@@ -221,10 +219,8 @@ def disable_power_profiles_daemon():
     # always disable power-profiles-daemon
     try:
         print("\n* Disabling GNOME power profiles")
-        call(["systemctl", "stop", "power-profiles-daemon"])
-        call(["systemctl", "disable", "power-profiles-daemon"])
+        call(["systemctl", "disable", "--now", "power-profiles-daemon"])
         call(["systemctl", "mask", "power-profiles-daemon"])
-        call(["systemctl", "daemon-reload"])
     except:
         print("\nUnable to disable GNOME power profiles")
         print("If this causes any problems, please submit an issue:")


### PR DESCRIPTION
systemd 220(released in 2015) [supports the "--now" switch.](https://github.com/systemd/systemd/blob/e37701a8cd2db1e67d28bcf337467d8efc6de41e/NEWS#L13992-L13995)

When this switch is present, the units that are enabled will also be started, and the ones disabled also stopped.

This is a good opportunity to remove some unnecessary lines of code and improve code readability.
We can start and stop services with just one single command:
~~~
systemctl enable/disable --now <service-name>
~~~

Also, systemctl daemon-reload is not really necessary when disabling/enabling a service.

Let me know if you notice any unintended side effects or if you have any feedback in general!


