### PR TITLE
#Issue 601: Installation on Atomic Systems by Removing GUI Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,10 @@ Once you have made the necessary changes to the `cmdline` file, you can update i
 
 - If the AUR installer does not work for your system, fallback to `auto-cpufreq-installer` and open an issue. 
 
+### Read-only Filesystem Workaround
+
+- On immutable operating systems, the standard `auto-cpufreq` installer is prevented from making necessary changes to system directories.  Renaming the provided installation configuration file `pyproject_cli_only` to `pyproject.toml` will allow you to install a CLI-only version of `auto-cpufreq` in your user home directory.
+
 ## Discussion:
 
 - Blogpost: [auto-cpufreq - Automatic CPU speed & power optimizer for Linux](http://foolcontrol.org/?p=3124)

--- a/pyproject_cli_only.toml.txt
+++ b/pyproject_cli_only.toml.txt
@@ -1,0 +1,54 @@
+[tool.poetry]
+name = "auto-cpufreq"
+version = "2.2.0"
+description = "Automatic CPU speed & power optimizer for Linux"
+authors = ["Adnan Hodzic <adnan@hodzic.org>"]
+license = "GPL-3.0-or-later"
+readme = "README.md"
+classifiers=[
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX :: Linux",
+    "Environment :: Console",
+    "Natural Language :: English"
+]
+keywords=["linux", "cpu", "speed", "power", "frequency", "turbo", "optimzier", "auto", "cpufreq"]
+repository = "https://github.com/AdnanHodzic/auto-cpufreq"
+documentation = "https://github.com/AdnanHodzic/auto-cpufreq#readme"
+packages = [
+    { include = "./auto_cpufreq" },
+    { include = "./auto_cpufreq/gui" },
+]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+psutil = "^5.9.8"
+click = "^8.1.0"
+distro = "^1.9.0"
+requests = "^2.31.0"
+pyinotify = "^0.9.6"
+pyasyncore = "^1.0.0" 
+#PyGObject = {version= "^3.46.0", optional=true}
+
+[tool.poetry.extras]
+#guix = ["PyGObject"]
+
+[tool.poetry.group.dev.dependencies]
+poetry = "^1.6.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry.scripts]
+auto-cpufreq = "auto_cpufreq.bin.auto_cpufreq:main"
+auto-cpufreq-gtk = "auto_cpufreq.bin.auto_cpufreq_gtk:main"
+
+# https://github.com/mtkennerly/poetry-dynamic-versioning
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+format = "v{base}+{commit}"
+
+# SideNote
+# Regarding zip_safe = https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html


### PR DESCRIPTION
This provides a workaround to allow installation of on Fedora Atomic and similar systems where installing GUI dependencies (specifically PyGObject and related packages) is problematic.

This PR creates a separate `pyproject.toml` file to remove all dependencies and build instructions related to the GUI component. This allows the core functionality of `auto-cpufreq` to be installed without requiring the GUI.
