### PR TITLE
nix: fail evaluation if power-profiles-daemon is enabled

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -50,5 +50,15 @@ in {
         ];
       };
     };
+
+    assertions = [
+      {
+        assertion = !config.services.power-profiles-daemon.enable;
+        message = ''
+          You have set services.power-profiles-daemon.enable = true;
+          which conflicts with auto-cpufreq
+        '';
+      }
+    ];
   };
 }


### PR DESCRIPTION
So I noticed auto-cpufreq systemd service was being killed immediately after boot on Nix. 
This was actually brought up previously in #740, but it seemed to fix itself for everyone.
Anyways, it started happening to me recently and was happening on every single boot so I knew something was wrong.

Basically I discovered that if a module enabled (or the user has it explicitly enabled)  `services.power-profiles-daemon`, systemd sees it as a conflict and just decides to kill auto-cpufreq in favor of power-profiles. In my situation, Cinnamon DE was enabling it by default.

This PR makes a change that causes an assertion error to be thrown if the user has `auto-cpufreq` enabled alongside `power-profiles`. This forces the user to disable `power-profiles`, in order for their config to build. I considered just making this a warning, since technically you can still run `auto-cpufreq` manually, but I feel like it is better to force users to enable one or the other in this case