### PR TITLE
deps: allow psutil 7.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-psutil = "^6.0.0"
+psutil = ">=6.0.0,<8.0.0"
 click = "^8.1.0"
 distro = "^1.8.0"
 requests = "^2.32.3"


### PR DESCRIPTION
This allows building with both psutil 6.x and 7.x. Closes #817.

Upstream [1] released psutil 7.0.0 recently, which caused a build failure on nixpkgs ci [2].
Checking release notes [3], `memory_info_ex` was removed (unused in auto-cpufreq),
and minimum python version requirements were increased to what this project uses already anyways.

[1] https://pypi.org/project/psutil/#history
[2] https://hydra.nixos.org/build/292453144/log
[3] https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#700

Tested with:
```patch
diff --git a/flake.nix b/flake.nix
index ab3449b..89a11db 100644
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/staging-next";
   };

   outputs = {nixpkgs, ...} @ inputs: let
```
