### PR TITLE
A Fix for GUI not launching in some cases.

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -76,26 +76,18 @@ function tool_install {
     header "Setting up Python environment"
   }
 
-  if [ -f /etc/debian_version ]; then
-    detected_distro "Debian based"
+  if [ -f /etc/debian_version ]; then  
+    VERSION=$(cat /etc/debian_version)  
 
-    # Load system info
-    . /etc/os-release  
-
-    # Extract major version number (e.g., "22.1" → "22")
-    VER=${VERSION_ID%%.*}
-
-    # Default to libgirepository-2.0-dev
-    LIB_GI_REPO="libgirepository-2.0-dev"
-
-    # Use the older package for Debian < 13 and Ubuntu < 24.04
-    if [[ "$VER" -lt 13 && "$VERSION_CODENAME" != "trixie" && "$VERSION_CODENAME" != "sid" ]]; then
+    if [[ "$VERSION" -ge 13 ]]; then  
+        LIB_GI_REPO="libgirepository-2.0-dev"
+    else  
         LIB_GI_REPO="libgirepository1.0-dev"
     fi
 
-    # Install required packages
+    
     apt install -y python3-dev python3-pip python3-venv python3-setuptools dmidecode \
-        "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc
+    "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc
 
   elif [ -f /etc/redhat-release ]; then
     detected_distro "RedHat based"

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -86,11 +86,7 @@ function tool_install {
     fi
 
     echo $LIB_GI_REPO needs to be installed for version $VERSION
-    echo =====================================
-    echo =====================================
-    echo =====================================
-    echo =====================================
-    echo =====================================
+    echo '---- '
     apt install -y python3-dev python3-pip python3-venv python3-setuptools dmidecode \
     "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc
 

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -78,14 +78,19 @@ function tool_install {
 
   if [ -f /etc/debian_version ]; then  
     VERSION=$(cat /etc/debian_version)  
-
-    if [[ "$VERSION" -ge 13 ]]; then  
-        LIB_GI_REPO="libgirepository-2.0-dev"
-    else  
+    # VERSION="CSCS"
+    if [[ "$VERSION" =~ ^12(\.[0-9]+)?$ || ("$VERSION" =~ ^[0-9]+$ && "$VERSION" -lt 12) ]]; then  
         LIB_GI_REPO="libgirepository1.0-dev"
+    else  
+        LIB_GI_REPO="libgirepository-2.0-dev"
     fi
 
-    
+    echo $LIB_GI_REPO needs to be installed for version $VERSION
+    echo =====================================
+    echo =====================================
+    echo =====================================
+    echo =====================================
+    echo =====================================
     apt install -y python3-dev python3-pip python3-venv python3-setuptools dmidecode \
     "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc
 
@@ -141,7 +146,15 @@ elif [ -f /etc/os-release ];then
   source "$venv_dir/bin/activate"
   python3 -m pip install --upgrade pip wheel
 
-  # required for GUI
+
+  # debian specific PyGObject Installation
+  if [ -f /etc/debian_version ]; then  
+    VERSION=$(cat /etc/debian_version | cut -d'.' -f1)  
+
+    if [[ "$VERSION" =~ ^12(\.[0-9]+)?$ ]]; then 
+        python3 -m pip install PyGObject==3.50.0
+    fi
+  fi
   python3 -m pip install PyGObject
 
   header "Installing auto-cpufreq tool"

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -78,7 +78,7 @@ function tool_install {
 
   if [ -f /etc/debian_version ]; then
     detected_distro "Debian based"
-    apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libcairo2-dev libgtk-3-dev gcc -y
+    apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libgirepository-2.0-dev libcairo2-dev libgtk-3-dev gcc -y
 
   elif [ -f /etc/redhat-release ]; then
     detected_distro "RedHat based"
@@ -131,6 +131,9 @@ elif [ -f /etc/os-release ];then
 
   source "$venv_dir/bin/activate"
   python3 -m pip install --upgrade pip wheel
+
+  # required for GUI
+  python3 -m pip install PyGObject
 
   header "Installing auto-cpufreq tool"
   

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -78,7 +78,24 @@ function tool_install {
 
   if [ -f /etc/debian_version ]; then
     detected_distro "Debian based"
-    apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository-2.0-dev libcairo2-dev libgtk-3-dev gcc -y
+
+    # Load system info
+    . /etc/os-release  
+
+    # Extract major version number (e.g., "22.1" → "22")
+    VER=${VERSION_ID%%.*}
+
+    # Default to libgirepository-2.0-dev
+    LIB_GI_REPO="libgirepository-2.0-dev"
+
+    # Use the older package for Debian < 13 and Ubuntu < 24.04
+    if [[ "$VER" -lt 13 && "$VERSION_CODENAME" != "trixie" && "$VERSION_CODENAME" != "sid" ]]; then
+        LIB_GI_REPO="libgirepository1.0-dev"
+    fi
+
+    # Install required packages
+    apt install -y python3-dev python3-pip python3-venv python3-setuptools dmidecode \
+        "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc
 
   elif [ -f /etc/redhat-release ]; then
     detected_distro "RedHat based"

--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -78,7 +78,7 @@ function tool_install {
 
   if [ -f /etc/debian_version ]; then
     detected_distro "Debian based"
-    apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository1.0-dev libgirepository-2.0-dev libcairo2-dev libgtk-3-dev gcc -y
+    apt install python3-dev python3-pip python3-venv python3-setuptools dmidecode libgirepository-2.0-dev libcairo2-dev libgtk-3-dev gcc -y
 
   elif [ -f /etc/redhat-release ]; then
     detected_distro "RedHat based"


### PR DESCRIPTION
libgirepository-2.0-dev is now required for PyGObject which is required for gi module in [ python file which initiate GUI](https://github.com/AdnanHodzic/auto-cpufreq/blob/master/auto_cpufreq/gui/app.py) see: https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/320

so here is sample PR for issue #825 