### PR TITLE
fix: fix eval on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     pkgsForEach = nixpkgs.legacyPackages;
   in {
     packages = forAllSystems (system: {
-      default = pkgsForEach.${system}.python3Packages.callPackage ./nix/default.nix {};
+      default = pkgsForEach.${system}.callPackage ./nix/default.nix {};
     });
 
     devShells = forAllSystems (system: {


### PR DESCRIPTION
Fixes #829
```
error: do not use python3Packages when building Python packages, specify each used package as a separate argument
```