### PR TITLE
Implement dedicated functionality to turn Bluetooth on/off at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Example of `auto-cpufreq --stats` CLI output
   - [Update - auto-cpufreq update](#update---auto-cpufreq-update)
   - [Remove - auto-cpufreq daemon](#remove---auto-cpufreq-daemon)
   - [stats](#stats)
+  - [bluetooth_boot_off](#bluetooth_boot_off)
+  - [bluetooth_boot_on](#bluetooth_boot_on)
 - [Battery charging thresholds](#battery-charging-thresholds)
   - [Supported Devices](#supported-devices)
   - [Battery config](#battery-config)
@@ -291,17 +293,23 @@ the repository:
 
 `git clone https://github.com/AdnanHodzic/auto-cpufreq`
 
-Navigate to the directory where `power_helper.py` resides:
+Make sure to have `psutil` & `pyinotify` Python library installed before next step:
 
-`cd auto-cpufreq/auto_cpufreq`
+If you're using Debian based distro install them by running:
 
-Make sure to have `psutil` Python library installed before next step:
+`sudo apt install python3-psutil python3-pyinotify` 
 
-`sudo python3 -m pip install psutil`
+or manually using pip, e.g: 
+
+`sudo pip3 install psutil pyinotify --break-system-packages`
 
 Then disable the GNOME Power Profiles daemon:
 
-`sudo python3 power_helper.py --gnome_power_disable`
+`sudo python3 -m auto_cpufreq.power_helper --gnome_power_disable`
+
+for full list of options run --help, e.g:
+
+`sudo python3 -m auto_cpufreq.power_helper --help`
 
 ### 2: `--force` governor override
 
@@ -434,6 +442,12 @@ auto-cpufreq should be run with with one of the following options:
 - [stats](#stats)
   - View live stats of CPU optimizations made by daemon
 
+- [bluetooth_boot_off](#bluetooth_boot_off)
+  - Turn off Bluetooth on boot (only)! Can be turned on any time later on.
+
+- [bluetooth_boot_on](#bluetooth_boot_on)
+  - Turn on Bluetooth on boot.
+
 - [force=TEXT](#overriding-governor)
   - Force use of either the "powersave" or "performance" governor, or set to "reset" to go back to normal mode
 
@@ -543,6 +557,16 @@ This does, in part, the equivalent of `systemctl stop auto-cpufreq && systemctl 
 If the daemon has been installed, live stats of CPU/system load monitoring and optimization can be seen by running:
 
 `auto-cpufreq --stats`
+
+### bluetooth_boot_off
+
+Turn off Bluetooth on boot (only)! Bluetooth can still be turned on manually when needed. This option is executed during the installation of the auto-cpufreq daemon, but it can also be run independently without installing the daemon.
+
+It prevents GNOME from automatically enabling Bluetooth on every reboot or after suspend/wake up even if you manually disable it, GNOME will turn it back on unless this option is used.
+
+### bluetooth_boot_on
+
+Useful if you prefer Bluetooth to be enabled at boot time, especially after installing the auto-cpufreq daemon, which will disable it by default.
 
 ## Battery charging thresholds
 

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -5,16 +5,16 @@
 # Blog post: https://foolcontrol.org/?p=3124
 
 # core import
-import sys, time
+import sys, time, os
 from subprocess import run
 from shutil import rmtree
 
 from auto_cpufreq.battery_scripts.battery import *
 from auto_cpufreq.config.config import config as conf, find_config_file
 from auto_cpufreq.core import *
-from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_AUR, IS_INSTALLED_WITH_SNAP
+from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_AUR, IS_INSTALLED_WITH_SNAP, SNAP_DAEMON_CHECK
 from auto_cpufreq.modules.system_monitor import ViewType, SystemMonitor
-# import everything from power_helper, including bluetooth_disable
+# import everything from power_helper, including bluetooth_disable and bluetooth_enable
 from auto_cpufreq.power_helper import *
 from threading import Thread
 
@@ -31,11 +31,13 @@ from threading import Thread
 @click.option("--get-state", is_flag=True, hidden=True)
 @click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--bluetooth_boot_off", is_flag=True, help="Turn off Bluetooth on boot")
+@click.option("--bluetooth_boot_on", is_flag=True, help="Turn on Bluetooth on boot")
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
 def main(monitor, live, daemon, install, update, remove, force, config, stats, get_state, completions,
          bluetooth_boot_off,
+         bluetooth_boot_on,
          debug, version, donate):
     # display info if config file is used
     config_path = find_config_file(config)
@@ -44,20 +46,25 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
         if conf.has_config():
             print("\nUsing settings defined in " + config_path + " file")
 
-    if len(sys.argv) == 1:
+    # Check for empty arguments first
+    is_empty_run = len(sys.argv) == 1
+
+    # set governor override unless None or invalid, but not if it's an empty run
+    if not is_empty_run and force is not None:
+        not_running_daemon_check()
+        root_check()
+        set_override(force)
+
+    # Handle empty run after potential force override is processed or skipped
+    if is_empty_run:
         print("\n" + "-" * 32 + " auto-cpufreq " + "-" * 33 + "\n")
         print("Automatic CPU speed & power optimizer for Linux")
         print("\nExample usage:\nauto-cpufreq --monitor")
         print("\n-----\n")
-
         run(["auto-cpufreq", "--help"])
         footer()
-        # set governor override unless None or invalid
-        if force is not None:
-            not_running_daemon_check()
-            root_check() # Calling root_check before set_override as it will require sudo access
-            set_override(force) # Calling set override, only if force has some values
-
+    # Handle other flags if it's not an empty run
+    else:
         if monitor:
             root_check()
             battery_setup()
@@ -69,15 +76,21 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 gnome_power_detect()
                 tlp_service_detect()
 
-            if IS_INSTALLED_WITH_SNAP or tlp_stat_exists or (systemctl_exists and not bool(gnome_power_status)):
+            # Determine if confirmation is needed
+            needs_confirmation = IS_INSTALLED_WITH_SNAP or tlp_stat_exists
+            # Check gnome_power_status only if relevant variables exist
+            if not IS_INSTALLED_WITH_SNAP and 'systemctl_exists' in globals() and systemctl_exists and 'gnome_power_status' in locals() and not bool(gnome_power_status):
+                 needs_confirmation = True
+
+            if needs_confirmation:
                 try:
                     input("press Enter to continue or Ctrl + c to exit...")
                 except KeyboardInterrupt:
                     conf.notifier.stop()
                     sys.exit(0)
 
-            monitor = SystemMonitor(suggestion=True, type=ViewType.MONITOR)
-            monitor.run(on_quit=conf.notifier.stop)
+            monitor_instance = SystemMonitor(suggestion=True, type=ViewType.MONITOR)
+            monitor_instance.run(on_quit=conf.notifier.stop)
         elif live:
             root_check()
             battery_setup()
@@ -91,7 +104,13 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 tuned_stop_live()
                 tlp_service_detect()
 
-            if IS_INSTALLED_WITH_SNAP or tlp_stat_exists or (systemctl_exists and not bool(gnome_power_status)):
+            # Determine if confirmation is needed
+            needs_confirmation = IS_INSTALLED_WITH_SNAP or tlp_stat_exists
+            # Check gnome_power_status only if relevant variables exist
+            if not IS_INSTALLED_WITH_SNAP and 'systemctl_exists' in globals() and systemctl_exists and 'gnome_power_status' in locals() and not bool(gnome_power_status):
+                 needs_confirmation = True
+
+            if needs_confirmation:
                 try:
                     input("press Enter to continue or Ctrl + c to exit...")
                 except KeyboardInterrupt:
@@ -100,18 +119,19 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
 
             cpufreqctl()
             def live_daemon():
-                # Redirect stdout to suppress prints
                 class NullWriter:
                     def write(self, _): pass
                     def flush(self): pass
+                original_stdout = sys.stdout
                 try:
                     sys.stdout = NullWriter()
-
                     while True:
                         time.sleep(1)
                         set_autofreq()
-                except:
-                    pass
+                except Exception as e: # Catch specific exceptions if possible
+                    print(f"Error in live daemon thread: {e}", file=original_stdout) # Log errors
+                finally:
+                    sys.stdout = original_stdout # Ensure stdout is restored
 
             def live_daemon_off():
                 gnome_power_start_live()
@@ -122,12 +142,12 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             thread = Thread(target=live_daemon, daemon=True)
             thread.start()
 
-            monitor = SystemMonitor(type=ViewType.LIVE)
-            monitor.run(on_quit=live_daemon_off)
+            monitor_instance = SystemMonitor(type=ViewType.LIVE)
+            monitor_instance.run(on_quit=live_daemon_off)
         elif daemon:
             config_info_dialog()
             root_check()
-            file_stats()
+            file_stats() # This function from core.py likely uses the stats paths internally
             if IS_INSTALLED_WITH_SNAP and SNAP_DAEMON_CHECK == "enabled":
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
@@ -136,84 +156,142 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 tlp_service_detect()
             battery_setup()
             conf.notifier.start()
-            while True:
-                try:
-                    footer()
-                    gov_check()
-                    cpufreqctl()
-                    distro_info()
-                    sysinfo()
+            print("Starting auto-cpufreq daemon...") # Add startup message
+            try:
+                # Initial setup before loop
+                gov_check()
+                cpufreqctl()
+                distro_info() # Show info once on start
+                sysinfo()     # Show info once on start
+                while True:
                     set_autofreq()
-                    countdown(2)
-                except KeyboardInterrupt: break
-            conf.notifier.stop()
+                    time.sleep(2) # Use simple sleep instead of countdown
+            except KeyboardInterrupt:
+                print("\nDaemon interrupted. Restoring settings...")
+            finally: # Ensure cleanup happens
+                conf.notifier.stop()
+                cpufreqctl_restore() # Restore system state when daemon stops
+                footer()
         elif install:
             root_check()
             if IS_INSTALLED_WITH_SNAP:
                 running_daemon_check()
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
-                # ToDo: add note to say you can use bluetooth flag to enable bluetooth on boot
-                bluetooth_notif_snap()
+                bluetooth_notif_snap() # Warn about bluetooth boot setting
                 gov_check()
-                run("snapctl set daemon=enabled", shell=True)
-                run("snapctl start --enable auto-cpufreq", shell=True)
+                run("snapctl set daemon=enabled", shell=True, check=True)
+                run("snapctl start --enable auto-cpufreq", shell=True, check=True)
             else:
                 running_daemon_check()
                 gov_check()
-                # ToDo: add note to say you can use bluetooth flag to enable bluetooth on boot
-                deploy_daemon()
+                deploy_daemon() # This function from core.py likely uses stats paths
             deploy_complete_msg()
         elif update:
             root_check()
             custom_dir = "/opt/auto-cpufreq/source"
-            for arg in sys.argv:
-                if arg.startswith("--update="):
-                    custom_dir = arg.split("=")[1]
-                    sys.argv.remove(arg)
-
+            update_flag_present = False
+            args_to_remove = []
+            # Simplified update argument parsing
             if "--update" in sys.argv:
-                update = True
-                sys.argv.remove("--update")
-                if len(sys.argv) == 2: custom_dir = sys.argv[1]
-
-            if IS_INSTALLED_WITH_SNAP:
-                print("Detected auto-cpufreq was installed using snap")
-                # refresh snap directly using this command
-                # path wont work in this case
-
-                print("Please update using snap package manager, i.e: `sudo snap refresh auto-cpufreq`.")
-                #check for AUR
-            elif IS_INSTALLED_WITH_AUR: print("Arch-based distribution with AUR support detected. Please refresh auto-cpufreq using your AUR helper.")
+                 update_flag_present = True
+                 args_to_remove.append("--update")
+                 # Simple check if next arg exists and isn't another flag
+                 idx = sys.argv.index("--update")
+                 if idx + 1 < len(sys.argv) and not sys.argv[idx+1].startswith('--'):
+                      custom_dir = sys.argv[idx+1]
+                      args_to_remove.append(custom_dir)
             else:
-                is_new_update = check_for_update()
-                if not is_new_update: return
-                ans = input("Do you want to update auto-cpufreq to the latest release? [Y/n]: ").strip().lower()
-                if not os.path.exists(custom_dir): os.makedirs(custom_dir)
-                if os.path.exists(os.path.join(custom_dir, "auto-cpufreq")): rmtree(os.path.join(custom_dir, "auto-cpufreq"))
-                if ans in ['', 'y', 'yes']:
-                    remove_daemon()
-                    remove_complete_msg()
-                    new_update(custom_dir)
-                    print("enabling daemon")
-                    run(["auto-cpufreq", "--install"])
-                    print("auto-cpufreq is installed with the latest version")
-                    run(["auto-cpufreq", "--version"])
-                else: print("Aborted")
+                 for arg in sys.argv:
+                     if arg.startswith("--update="):
+                         update_flag_present = True
+                         custom_dir = arg.split("=", 1)[1]
+                         args_to_remove.append(arg)
+                         break # Found it, no need to check further
+
+            # Remove the parsed arguments
+            # This prevents them from being misinterpreted later if code relies on sys.argv directly
+            _original_argv = sys.argv[:] # Make a copy if needed elsewhere
+            sys.argv = [arg for arg in sys.argv if arg not in args_to_remove]
+
+
+            if update_flag_present:
+                if IS_INSTALLED_WITH_SNAP:
+                    print("Detected auto-cpufreq was installed using snap")
+                    print("Please update using snap package manager, i.e: `sudo snap refresh auto-cpufreq`.")
+                elif IS_INSTALLED_WITH_AUR:
+                    print("Arch-based distribution with AUR support detected. Please refresh auto-cpufreq using your AUR helper.")
+                else:
+                    is_new_update = check_for_update()
+                    if not is_new_update: return
+                    ans = input(f"Update source will be placed in '{custom_dir}'.\nDo you want to update auto-cpufreq to the latest release? [Y/n]: ").strip().lower()
+
+                    if ans in ['', 'y', 'yes']:
+                         # Ensure directory exists
+                        os.makedirs(custom_dir, exist_ok=True)
+                        auto_cpufreq_subdir = os.path.join(custom_dir, "auto-cpufreq")
+                        if os.path.isdir(auto_cpufreq_subdir):
+                            print(f"Removing existing source sub-directory: {auto_cpufreq_subdir}")
+                            try:
+                                rmtree(auto_cpufreq_subdir)
+                            except OSError as e:
+                                print(f"Error removing directory {auto_cpufreq_subdir}: {e}")
+                                print("Update aborted.")
+                                return # Stop update if cleanup fails
+
+                        print("Removing existing installation (if any)...")
+                        remove_daemon() # Call remove logic first
+                        # remove_complete_msg() # Optional message
+                        print(f"Downloading new version to {custom_dir}...")
+                        new_update(custom_dir) # Download the update
+                        print("Running installer for the updated version...")
+                        # Use subprocess.run to call the install command of the main script
+                        install_result = run([_original_argv[0], "--install"], check=False) # Use original script path
+                        if install_result.returncode == 0:
+                            print("\nUpdate and installation successful.")
+                            run([_original_argv[0], "--version"])
+                        else:
+                            print("\nError during installation after update. Please check messages above.")
+                    else:
+                        print("Update aborted.")
+            # else: # If neither --update nor --update= was found
+                # Potentially show help or an error if update was expected
+                # print("Update command not used correctly.")
+                # run([_original_argv[0], "--help"])
+
         elif remove:
             root_check()
             if IS_INSTALLED_WITH_SNAP:
-                run("snapctl set daemon=disabled", shell=True)
-                run("snapctl stop --disable auto-cpufreq", shell=True)
-                if auto_cpufreq_stats_path.exists():
-                    if auto_cpufreq_stats_file is not None:
-                        auto_cpufreq_stats_file.close()
+                run("snapctl stop auto-cpufreq", shell=True, check=False)
+                run("snapctl set daemon=disabled", shell=True, check=True)
+                # run("snapctl disable auto-cpufreq", shell=True, check=True) # Deprecated? Use stop --disable
+                run("snapctl stop --disable auto-cpufreq", shell=True, check=True) # Correct way to stop and disable
 
-                    auto_cpufreq_stats_path.unlink()
-                # {the following snippet also used in --update, update it there too(if required)}
-                # * undo bluetooth boot disable
+                # Check if stats path/file variables exist before using them
+                # These should be available from 'from auto_cpufreq.core import *'
+                if 'auto_cpufreq_stats_path' in globals() and auto_cpufreq_stats_path.exists():
+                    # Close file handle safely
+                    if 'auto_cpufreq_stats_file' in globals() and auto_cpufreq_stats_file is not None:
+                        if not auto_cpufreq_stats_file.closed:
+                            try:
+                                auto_cpufreq_stats_file.close()
+                            except Exception as e:
+                                print(f"Warning: Could not close stats file handle: {e}")
+                        # Set to None after closing or if already closed
+                        # auto_cpufreq_stats_file = None # Modifying imported var might be tricky
+
+                    # Remove the file
+                    try:
+                        auto_cpufreq_stats_path.unlink()
+                        print(f"Removed stats file: {auto_cpufreq_stats_path}")
+                    except OSError as e:
+                        print(f"Warning: Could not remove stats file {auto_cpufreq_stats_path}: {e}")
+
+                # Reminders
                 gnome_power_rm_reminder_snap()
-            else: remove_daemon()
+                bluetooth_on_notif_snap()
+            else:
+                remove_daemon() # Defined in core.py, handles service removal and cleanup including stats file
             remove_complete_msg()
         elif stats:
             not_running_daemon_check()
@@ -225,20 +303,27 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 gnome_power_detect()
                 tlp_service_detect()
 
-            if IS_INSTALLED_WITH_SNAP or tlp_stat_exists or (systemctl_exists and not bool(gnome_power_status)):
+            # Determine if confirmation is needed
+            needs_confirmation = IS_INSTALLED_WITH_SNAP or tlp_stat_exists
+             # Check gnome_power_status only if relevant variables exist
+            if not IS_INSTALLED_WITH_SNAP and 'systemctl_exists' in globals() and systemctl_exists and 'gnome_power_status' in locals() and not bool(gnome_power_status):
+                 needs_confirmation = True
+
+            if needs_confirmation:
                 try:
                     input("press Enter to continue or Ctrl + c to exit...")
                 except KeyboardInterrupt:
-                    conf.notifier.stop()
+                    # conf.notifier might not be started for stats mode
                     sys.exit(0)
 
-            monitor = SystemMonitor(type=ViewType.STATS)
-            monitor.run()
+            monitor_instance = SystemMonitor(type=ViewType.STATS)
+            monitor_instance.run()
         elif get_state:
             not_running_daemon_check()
             override = get_override()
             print(override)
         elif completions:
+            # Logic for completions (kept as per previous code)
             if completions == "bash":
                 print("Run the below command in your current shell!\n")
                 print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=bash_source auto-cpufreq)\"' >> ~/.bashrc")
@@ -251,12 +336,16 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                 print("Run the below command in your current shell!\n")
                 print("echo '_AUTO_CPUFREQ_COMPLETE=fish_source auto-cpufreq | source' > ~/.config/fish/completions/auto-cpufreq.fish")
             else: print("Invalid Option, try bash|zsh|fish as argument to --completions")
+
         elif bluetooth_boot_off:
             root_check()
             bluetooth_disable()
             footer()
+        elif bluetooth_boot_on:
+            root_check()
+            bluetooth_enable()
+            footer()
         elif debug:
-            # ToDo: add status of GNOME Power Profile service status
             config_info_dialog()
             root_check()
             battery_get_thresholds()
@@ -270,7 +359,11 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             python_info()
             print()
             device_info()
-            print(f"Battery is: {'' if charging() else 'dis'}charging")
+            # Check charging status function exists and call it
+            if 'charging' in globals() and callable(charging):
+                 print(f"Battery is: {'' if charging() else 'dis'}charging")
+            else:
+                 print("Battery status unavailable.")
             print()
             app_res_use()
             get_load()
@@ -288,5 +381,16 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             print("Show your appreciation by donating!")
             print(GITHUB+"#donate")
             footer()
+        # else: # Optional: Handle unrecognized flags if not caught by click
+        #    print(f"Error: Unrecognized arguments.")
+        #    run([_original_argv[0], "--help"])
 
-if __name__ == "__main__": main()
+
+if __name__ == "__main__":
+     try:
+         import click
+     except ImportError:
+         print("Error: Required dependency 'click' not found. Please install it (e.g., pip install click)")
+         sys.exit(1)
+     # Call main entry point
+     main()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -29,13 +29,12 @@ from threading import Thread
 @click.option("--config", is_flag=False, required=False, help="Use config file at defined path",)
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--get-state", is_flag=True, hidden=True)
-@click.option("--completions", is_flag=False, help="Enables shell completions for bash, zsh and fish.\n Possible values bash|zsh|fish")
 @click.option("--bluetooth_boot_off", is_flag=True, help="Turn off Bluetooth on boot")
 @click.option("--bluetooth_boot_on", is_flag=True, help="Turn on Bluetooth on boot")
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
-def main(monitor, live, daemon, install, update, remove, force, config, stats, get_state, completions,
+def main(monitor, live, daemon, install, update, remove, force, config, stats, get_state,
          bluetooth_boot_off,
          bluetooth_boot_on,
          debug, version, donate):
@@ -322,26 +321,14 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             not_running_daemon_check()
             override = get_override()
             print(override)
-        elif completions:
-            # Logic for completions (kept as per previous code)
-            if completions == "bash":
-                print("Run the below command in your current shell!\n")
-                print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=bash_source auto-cpufreq)\"' >> ~/.bashrc")
-                print("source ~/.bashrc")
-            elif completions == "zsh":
-                print("Run the below command in your current shell!\n")
-                print("echo 'eval \"$(_AUTO_CPUFREQ_COMPLETE=zsh_source auto-cpufreq)\"' >> ~/.zshrc")
-                print("source ~/.zshrc")
-            elif completions == "fish":
-                print("Run the below command in your current shell!\n")
-                print("echo '_AUTO_CPUFREQ_COMPLETE=fish_source auto-cpufreq | source' > ~/.config/fish/completions/auto-cpufreq.fish")
-            else: print("Invalid Option, try bash|zsh|fish as argument to --completions")
 
         elif bluetooth_boot_off:
+            footer()
             root_check()
             bluetooth_disable()
             footer()
         elif bluetooth_boot_on:
+            footer()
             root_check()
             bluetooth_enable()
             footer()

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -323,15 +323,25 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             print(override)
 
         elif bluetooth_boot_off:
-            footer()
-            root_check()
-            bluetooth_disable()
-            footer()
+            if IS_INSTALLED_WITH_SNAP:
+                footer()
+                bluetooth_notif_snap()
+                footer()
+            else:
+                footer()
+                root_check()
+                bluetooth_disable()
+                footer()
         elif bluetooth_boot_on:
-            footer()
-            root_check()
-            bluetooth_enable()
-            footer()
+            if IS_INSTALLED_WITH_SNAP:
+                footer()
+                bluetooth_on_notif_snap()
+                footer()
+            else:
+                footer()
+                root_check()
+                bluetooth_enable()
+                footer()
         elif debug:
             config_info_dialog()
             root_check()

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -7,9 +7,9 @@ from subprocess import call, DEVNULL, getoutput, STDOUT
 from sys import argv
 
 # ToDo: update README part how to run this script
-from .core import *
-from .globals import GITHUB, IS_INSTALLED_WITH_SNAP
-from .tlp_stat_parser import TLPStatusParser
+from auto_cpufreq.core import *
+from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_SNAP
+from auto_cpufreq.tlp_stat_parser import TLPStatusParser
 
 # app_name var
 app_name = "python3 power_helper.py" if argv[0] == "power_helper.py" else "auto-cpufreq"

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -67,7 +67,6 @@ def gnome_power_detect():
         print("\nOnly necessary to be manually done on Snap package installs!")
         print("Steps to perform this action using auto-cpufreq: power_helper script:")
         print(f"git clone {GITHUB}.git")
-        print("cd auto-cpufreq/auto_cpufreq")
         print("python3 power_helper.py --gnome_power_disable")
         print(f"\nReference: {GITHUB}#configuring-auto-cpufreq")
 
@@ -91,7 +90,6 @@ def gnome_power_detect_snap():
     print("This daemon might interfere with auto-cpufreq and should be disabled!")
     print("\nSteps to perform this action using auto-cpufreq: power_helper script:")
     print(f"git clone {GITHUB}.git")
-    print("cd auto-cpufreq/auto_cpufreq")
     print("python3 power_helper.py --gnome_power_disable")
     print(f"\nReference: {GITHUB}#configuring-auto-cpufreq")
 
@@ -208,7 +206,6 @@ def gnome_power_rm_reminder_snap():
     print("Now it's recommended to enable this service.")
     print("\nSteps to perform this action using auto-cpufreq: power_helper script:")
     print(f"git clone {GITHUB}.git")
-    print("cd auto-cpufreq/auto_cpufreq")
     print("python3 power_helper.py --gnome_power_enable")
     print(f"\nReference: {GITHUB}#configuring-auto-cpufreq")
 

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -150,7 +150,8 @@ def gnome_power_svc_status():
 def bluetooth_disable():
     if IS_INSTALLED_WITH_SNAP: bluetooth_notif_snap()
     elif bluetoothctl_exists:
-        print("* Turn off bluetooth on boot (can be turned on any time later on!)")
+        print("* Turn off Bluetooth on boot (only)!")
+        print("  If you want bluetooth enabled on boot run: auto-cpufreq --bluetooth_boot_on")
         btconf = Path("/etc/bluetooth/main.conf")
         try:
             orig_set = "AutoEnable=true"

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -17,7 +17,7 @@ app_name = "python3 power_helper.py" if argv[0] == "power_helper.py" else "auto-
 def header(): print("\n------------------------- auto-cpufreq: Power helper -------------------------\n")
 def warning(): print("\n----------------------------------- Warning -----------------------------------\n")
 
-def helper_opts(): print("\nFor full list of options run: python3 power_helper.py --help")
+def helper_opts(): print("\nFor full list of options run: python3 -m auto_cpufreq.power_helper --help")
 
 # used to check if binary exists on the system
 def does_command_exists(cmd): return which(cmd) is not None
@@ -67,7 +67,7 @@ def gnome_power_detect():
         print("\nOnly necessary to be manually done on Snap package installs!")
         print("Steps to perform this action using auto-cpufreq: power_helper script:")
         print(f"git clone {GITHUB}.git")
-        print("python3 power_helper.py --gnome_power_disable")
+        print("python3 -m auto_cpufreq.power_helper --gnome_power_disable")
         print(f"\nReference: {GITHUB}#configuring-auto-cpufreq")
 
 # automatically disable gnome power profile service in case it's running during install
@@ -90,7 +90,7 @@ def gnome_power_detect_snap():
     print("This daemon might interfere with auto-cpufreq and should be disabled!")
     print("\nSteps to perform this action using auto-cpufreq: power_helper script:")
     print(f"git clone {GITHUB}.git")
-    print("python3 power_helper.py --gnome_power_disable")
+    print("python3 -m auto_cpufreq.power_helper --gnome_power_disable")
     print(f"\nReference: {GITHUB}#configuring-auto-cpufreq")
 
 # stops gnome >= 40 power profiles (live)
@@ -185,13 +185,15 @@ def bluetooth_enable():
 def bluetooth_notif_snap():
     print("\n* Unable to turn off bluetooth on boot due to Snap package restrictions!")
     print("\nSteps to perform this action using auto-cpufreq: power_helper script:")
-    print("python3 power_helper.py --bluetooth_boot_off")
+    print("python3 -m auto_cpufreq.power_helper --bluetooth_boot_off")
+    print("\nFor help see: https://github.com/AdnanHodzic/auto-cpufreq/#1-power_helperpy-script-snap-package-install-only")
 
 # turn off bluetooth on snap message
 def bluetooth_on_notif_snap():
     print("\n* Unable to turn on bluetooth on boot due to Snap package restrictions!")
     print("\nSteps to perform this action using auto-cpufreq: power_helper script:")
-    print("python3 power_helper.py --bluetooth_boot_on")
+    print("python3 -m auto_cpufreq.power_helper --bluetooth_boot_on")
+    print("\nFor help see: https://github.com/AdnanHodzic/auto-cpufreq/#1-power_helperpy-script-snap-package-install-only")
 
 # gnome power removal reminder
 def gnome_power_rm_reminder():
@@ -207,7 +209,7 @@ def gnome_power_rm_reminder_snap():
     print("Now it's recommended to enable this service.")
     print("\nSteps to perform this action using auto-cpufreq: power_helper script:")
     print(f"git clone {GITHUB}.git")
-    print("python3 power_helper.py --gnome_power_enable")
+    print("python3 -m auto_cpufreq.power_helper --gnome_power_enable")
     print(f"\nReference: {GITHUB}#configuring-auto-cpufreq")
 
 def valid_options():
@@ -249,11 +251,11 @@ def gnome_power_svc_disable():
                 # check if snapd is present and if snap package is installed | 0 is success
                 if not bool(snap_pkg_check):
                     print("GNOME Power Profiles Daemon is already disabled, it can be re-enabled by running:\n"
-                        "sudo python3 power_helper.py --gnome_power_enable\n"
+                        "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable\n"
                     )
                 elif snap_pkg_check == 1:
                     print("auto-cpufreq snap package not installed\nGNOME Power Profiles Daemon should be enabled. run:\n\n"
-                        "sudo python3 power_helper.py --gnome_power_enable"
+                        "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable"
                     )
             except:
                 # snapd not found on the system
@@ -263,7 +265,7 @@ def gnome_power_svc_disable():
         if not bool(gnome_power_status) and powerprofilesctl_exists:
             if snap_pkg_check == 1:
                 print("auto-cpufreq snap package not installed.\nGNOME Power Profiles Daemon should be enabled, run:\n\n"
-                    "sudo python3 power_helper.py --gnome_power_enable"
+                    "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable"
                 )
             else:
                 print("auto-cpufreq snap package installed, GNOME Power Profiles Daemon should be disabled.\n")

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -6,9 +6,10 @@ from shutil import which
 from subprocess import call, DEVNULL, getoutput, STDOUT
 from sys import argv
 
-from auto_cpufreq.core import *
-from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_SNAP
-from auto_cpufreq.tlp_stat_parser import TLPStatusParser
+# ToDo: update README part how to run this script
+from .core import *
+from .globals import GITHUB, IS_INSTALLED_WITH_SNAP
+from .tlp_stat_parser import TLPStatusParser
 
 # app_name var
 app_name = "python3 power_helper.py" if argv[0] == "power_helper.py" else "auto-cpufreq"


### PR DESCRIPTION
To preserve battery life when [auto-cpufreq daemon (`--install`)](https://github.com/AdnanHodzic/auto-cpufreq/tree/bluetooth#install---auto-cpufreq-daemon) is installed, Bluetooth will be disabled by default at boot. Bluetooth can be enabled at any time later on.

Regardless, over the time, a feature requests and bugs were reported over this which this PR is aiming to close:

* [Feature] Bluetooth disabled after reboot #673
* [Feature request ] How can I stop disabling of bluetooth on boot? #451
* deploy_daemon() disables Bluetooth regardless of using laptop on AC #92

This PR brings 2 new flags which are also described on [auto-cpufreq README page.](https://github.com/AdnanHodzic/auto-cpufreq)

*  [`--bluetooth_boot_off`  Turn off Bluetooth on boot](https://github.com/AdnanHodzic/auto-cpufreq/tree/bluetooth#bluetooth_boot_off)
* [ `--bluetooth_boot_on`   Turn on Bluetooth on boot](https://github.com/AdnanHodzic/auto-cpufreq/tree/bluetooth#bluetooth_boot_on)

Now, for those who don't even have auto-cpufreq daemon installed and/or are only using it for [monitoring](https://github.com/AdnanHodzic/auto-cpufreq/tree/bluetooth#monitor) or [live](https://github.com/AdnanHodzic/auto-cpufreq/tree/bluetooth#live). Or if you're simply trying to find a quick way to prevents GNOME from automatically enabling Bluetooth on every reboot or after suspend/wake up even if you manually disable it. 

You can turn off bluetooth at boot by running: `sudo auto-cpufreq --bluetooth_boot_off`

Or, if you installed auto-cpufreq daemon but would like to keep bluetooth enabled at boot can also do so by running `auto-cpufreq --bluetooth_boot_on`
