### PR TITLE
fix: rectify window icon under Wayland

### DIFF
--- a/auto_cpufreq/bin/auto_cpufreq_gtk.py
+++ b/auto_cpufreq/bin/auto_cpufreq_gtk.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, GLib
 from auto_cpufreq.gui.app import ToolWindow
 
 def main():
-    GLib.set_prgname("auto-cpufreq")
+    GLib.set_prgname("auto-cpufreq-gtk")
     win = ToolWindow()
     win.connect("destroy", Gtk.main_quit)
     win.show_all()


### PR DESCRIPTION
Set the correct desktop filename to fix window icon under Wayland.