### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/build-nix.yaml
+++ b/.github/workflows/build-nix.yaml
@@ -15,10 +15,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install Nix ❄️"
-        uses: cachix/install-nix-action@v25
+        uses: nixbuild/nix-quick-install-action@v30
 
-      - name: "Nix Cache"
-        uses: DeterminateSystems/magic-nix-cache-action@v3
+      - name: "Nix Cache ❄️"
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
       - name: "Build Nix Flake ❄️"
         run: nix build


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `cachix/install-nix-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.
