### PR TITLE
Allow for overriding the CPU turbo setting via CLI and GUI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ Example of `auto-cpufreq --stats` CLI output
 - [Configuring auto-cpufreq](#configuring-auto-cpufreq)
   - [1: power_helper.py script (Snap package install only)](#1-power_helperpy-script-snap-package-install-only)
   - [2: `--force` governor override](#2---force-governor-override)
-  - [3: auto-cpufreq config file](#3-auto-cpufreq-config-file)
+  - [3: `--turbo` mode override](#3---turbo-mode-override)
+  - [4: auto-cpufreq config file](#4-auto-cpufreq-config-file)
     - [Example config file contents](#example-config-file-contents)
 - [How to run auto-cpufreq](#how-to-run-auto-cpufreq)
 - [auto-cpufreq modes and options](#auto-cpufreq-modes-and-options)
   - [monitor](#monitor)
   - [live](#live)
   - [overriding governor](#overriding-governor)
+  - [overriding turbo mode](#overriding-turbo-mode)
   - [Install - auto-cpufreq daemon](#install---auto-cpufreq-daemon)
   - [Update - auto-cpufreq update](#update---auto-cpufreq-update)
   - [Remove - auto-cpufreq daemon](#remove---auto-cpufreq-daemon)
@@ -319,7 +321,15 @@ However, you can override this behaviour by switching to `performance` or `power
 
 See [`--force` flag](#overriding-governor) for more info.
 
-### 3: auto-cpufreq config file
+### 3: `--turbo` mode override
+
+By default, auto-cpufreq handles CPU turbo mode automatically, enabling it under load and disabling it otherwise to balance performance and efficiency.
+
+However, you can override this behavior by forcing CPU turbo's mode to `always` or `never`. Setting to `always` keeps turbo mode always enabled, allowing the CPU to reach its maximum frequency at the cost of higher energy use (battery consumption). `never`, on the other hand, keeps turbo mode always disabled, limiting the CPU's maximum frequency to extend battery life.
+
+See [`--turbo` flag](#overriding-turbo-mode) for more info.
+
+### 4: auto-cpufreq config file
 
 You can configure separate profiles for the battery and power supply. These profiles will let you pick which governor to use, as well as how and when turbo boost is enabled. The possible values for turbo boost behavior are `always`, `auto`, and `never`. The default behavior is `auto`, which only activates turbo during high load.
 
@@ -451,6 +461,9 @@ auto-cpufreq should be run with with one of the following options:
 - [force=TEXT](#overriding-governor)
   - Force use of either the "powersave" or "performance" governor, or set to "reset" to go back to normal mode
 
+- [turbo=TEXT](#overriding-turbo-mode)
+  - Force use of CPU turbo mode, if supported, with "never" or "always", or set to "auto" to automatically handle turbo mode
+
 - config=TEXT
   - Use config file at designated path
 
@@ -490,6 +503,13 @@ Necessary changes are temporarily made to the system over time, but this process
 `sudo auto-cpufreq --force=governor`
 
 Force use of either the "powersave" or "performance" governor, or set to "reset" to go back to normal mode.
+Please note that any set override will persist even after reboot.
+
+### Overriding Turbo mode
+
+`sudo auto-cpufreq --turbo=mode`
+
+Force use of CPU turbo mode, if supported, with "never" or "always", or set to "auto" to automatically handle turbo mode.
 Please note that any set override will persist even after reboot.
 
 ### Install - auto-cpufreq daemon

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -26,6 +26,7 @@ from threading import Thread
 @click.option("--update", is_flag=False, help="Update daemon and package for (permanent) automatic CPU optimizations", flag_value="--update")
 @click.option("--remove", is_flag=True, help="Remove daemon for (permanent) automatic CPU optimizations")
 @click.option("--force", is_flag=False, help="Force use of either \"powersave\" or \"performance\" governors. Setting to \"reset\" will go back to normal mode")
+@click.option("--turbo", is_flag=False, help="Force use of CPU turbo mode, if supported, with \"never\" or \"always\". Setting to \"auto\" automatically handles turbo mode")
 @click.option("--config", is_flag=False, required=False, help="Use config file at defined path",)
 @click.option("--stats", is_flag=True, help="View live stats of CPU optimizations made by daemon")
 @click.option("--get-state", is_flag=True, hidden=True)
@@ -34,7 +35,7 @@ from threading import Thread
 @click.option("--debug", is_flag=True, help="Show debug info (include when submitting bugs)")
 @click.option("--version", is_flag=True, help="Show currently installed version")
 @click.option("--donate", is_flag=True, help="Support the project")
-def main(monitor, live, daemon, install, update, remove, force, config, stats, get_state,
+def main(monitor, live, daemon, install, update, remove, force, turbo, config, stats, get_state,
           bluetooth_boot_off, bluetooth_boot_on, debug, version, donate):
     # display info if config file is used
     config_path = find_config_file(config)
@@ -58,6 +59,11 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
             not_running_daemon_check()
             root_check() # Calling root_check before set_override as it will require sudo access
             set_override(force) # Calling set override, only if force has some values
+        
+        if turbo is not None:
+            not_running_daemon_check()
+            root_check()
+            set_turbo_override(turbo)
 
         if monitor:
             root_check()

--- a/auto_cpufreq/gui/app.py
+++ b/auto_cpufreq/gui/app.py
@@ -9,7 +9,8 @@ from threading import Thread
 
 from auto_cpufreq.core import check_for_update, is_running
 from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_SNAP
-from auto_cpufreq.gui.objects import CPUFreqStatsLabel, CurrentGovernorBox, DaemonNotRunningView, DropDownMenu, RadioButtonView, SystemStatsLabel, UpdateDialog
+from auto_cpufreq.gui.objects import CPUFreqStatsLabel, CurrentGovernorBox, DaemonNotRunningView, DropDownMenu, RadioButtonView, CPUTurboOverride, SystemStatsLabel, UpdateDialog
+from auto_cpufreq.gui.objects import get_stats
 
 if IS_INSTALLED_WITH_SNAP:
     CSS_FILE = "/snap/auto-cpufreq/current/style.css"
@@ -48,6 +49,8 @@ class ToolWindow(Gtk.Window):
         self.currentgovernor = CurrentGovernorBox()
         self.vbox_right.pack_start(self.currentgovernor, False, False, 0)
         self.vbox_right.pack_start(RadioButtonView(), False, False, 0)
+        if "Warning: CPU turbo is not available" not in get_stats():
+            self.vbox_right.pack_start(CPUTurboOverride(), False, False, 0)
 
         self.cpufreqstats = CPUFreqStatsLabel()
         self.vbox_right.pack_start(self.cpufreqstats, False, False, 0)


### PR DESCRIPTION
As per feature request #604, this pull request implements the ability for the user to override the turbo setting, being able to set it to auto, never, or always. This exists both as a CLI flag and in the GUI (which is only visible if the turbo setting is supported by the CPU.) So far, the CLI flag and GUI setting "work on my machine", as it follows the same principle the performance override uses. Any thoughts, comments, or suggestions are greatly appreciated. :)