### PR TITLE
docs: remove --completions flag README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,6 @@ auto-cpufreq should be run with with one of the following options:
 - help
   - Shows all of the above options
 
-- completions=TEXT
-  - To support shell completions (current options are "bash", "zsh", or "fish")
-
 Running `auto-cpufreq --help` will print the same list of options as above. Read [auto-cpufreq modes and options](#auto-cpufreq-modes-and-options) for more details.
 
 ## auto-cpufreq modes and options


### PR DESCRIPTION
Removed in: f9b9fe42c90e176ec4104adcd3eb5e3b4d1823b6
