### PR TITLE
Adding gnome extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Example of `auto-cpufreq --stats` CLI output
   - [Supported Devices](#supported-devices)
   - [Battery config](#battery-config)
   - [Ignoring power supplies](#Ignoring-power-supplies)
+  - [🌐 Community Projects](#-community-projects)
 - [Troubleshooting](#troubleshooting)
   - [AUR](#aur)
 - [Discussion](#discussion)
@@ -661,6 +662,12 @@ name4 = example
 xboxctrl = {the xbox controler power supply name}
 
 ```
+
+### 🌐 Community Projects 
+
+If you're using auto‑cpufreq in desktop environments, you may find these community integrations helpful and useful:
+
+- GNOME Extension: [auto-cpufreq-swticher](https://extensions.gnome.org/extension/8320/auto-cpufreq-switcher/) (tray icon + governor switcher in quick settings)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adding reference to the Gnome Extension in the README with a link to the Gnome extension store as discussed in https://github.com/AdnanHodzic/auto-cpufreq/issues/729 