### PR TITLE
fix: use scaling_max_freq for accurate max CPU clock detection

### DIFF
--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -208,7 +208,7 @@ function get_frequency_min_limit () {
 
 function get_frequency_max_limit () {
   if [ -z $CORE ]; then CORE=0; fi
-  cat $FLROOT/cpu$CORE/cpufreq/cpuinfo_max_freq
+  cat $FLROOT/cpu$CORE/cpufreq/scaling_max_freq
 }
 
 function get_energy_performance_preference () {


### PR DESCRIPTION
### Background

In some systems, the two CPU frequency values — from `cpuinfo_max_freq` and `scaling_max_freq` — return different results. This discrepancy causes the application to pick a lower maximum frequency, which leads to incorrect behavior, such as disabling Turbo Boost and causing the GUI to malfunction.

### What this change does

This update makes the application use the value from `scaling_max_freq` to determine the CPU's maximum frequency. By doing so, it fixes the detection issue on affected systems.

### Impact

For users whose systems do not have this discrepancy, this change should have no impact and will continue working as before.

With this fix, the GUI is able to function normally again, reflecting the correct CPU maximum frequency.

### Screenshot
Tested on my system, working fine!

![GUI working correctly now](https://github.com/user-attachments/assets/bf978e47-880a-4d26-b8da-25fcc32f0d6e)

---

Closes issue #737.