### PR TITLE
Fixed python packages names in installing script for OpenSuse Tumbleweed

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -138,7 +138,7 @@ elif [ -f /etc/os-release ];then
       ;;
       opensuse-tumbleweed)
         detected_distro "OpenSUSE"
-        zypper install -y python3 python3-pip python311-setuptools python3-devel gcc dmidecode gobject-introspection-devel python3-cairo-devel gtk3 gtk3-devel
+        zypper install -y python313 python313-pip python311-setuptools python313-devel gcc dmidecode gobject-introspection-devel python313-pycairo-devel libgtk-3-0 gtk3-devel
       ;;
       void)
         detected_distro "Void Linux"


### PR DESCRIPTION
I changed the python packages names in the zypper command on opensuse tumbleweed in installer. Of course it is rather cosmetic change, because even python3 package is not proper, zypper automatically choose python313. Please let me know if preffered version is 3.11 (for me it works with 3.13). Sorry for not creating separate branch, but I am unexperienced a little bit yet. I ran this script once again and all packages names was proper.