### PR TITLE
improve installer script

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -221,7 +221,7 @@ tool_remove() {
 
   # run uninstall in case of installed daemon
   if [[ -f "$srv_remove" || -f "$AUTO_CPUFREQ_FILE" ]]; then
-    "$AUTO_CPUFREQ_FILE" --remove || exit 1
+    "$AUTO_CPUFREQ_FILE" --remove || echo -e "\nWARNING: Removal of auto-cpufreq binary failed (exit status $?).\n Continuing..." >&2
   else
     echo; echo "Couldn't remove the auto-cpufreq daemon, [$srv_remove] does not exist."
   fi


### PR DESCRIPTION
- replace tabs w/ spaces
- quote vars
- replase dash syntax with that of bash (e.g. [[ "$a" || "$b" ]]) as opposed to [ $a -o $ b ]
- fail wast where command returns non-zero 
