### PR TITLE
Fix PyGObject installation on Pop!_OS

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -111,7 +111,7 @@ function tool_install {
     echo "$LIB_GI_REPO needs to be installed for version $VERSION"
     echo '---- '
     apt install -y python3-dev python3-pip python3-venv python3-setuptools dmidecode \
-    "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc ps
+    "$LIB_GI_REPO" libcairo2-dev libgtk-3-dev gcc python3-gi
 
   elif [ -f /etc/redhat-release ]; then
     detected_distro "RedHat based"


### PR DESCRIPTION
Issue
Installation fails on Pop!_OS 22.04 and similar Ubuntu systems because PyGObject tries to compile against girepository-2.0, which isn't available #833 . These systems only have libgirepository1.0-dev and already include a working python3-gi package.

Changes
- Create venv with --system-site-packages flag to access system Python packages
- Install python3-gi system package in apt dependencies

Tested on Pop!_OS 22.04 LTS. 