### PR TITLE
fix: display actual EPP and EPB values in stats output

### DIFF
--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -149,19 +149,36 @@ class SystemInfo:
         if not Path(epp_path).exists():
             return None
             
-        return config.get_config().get( 
-            "charger" if is_ac_plugged else "battery", "energy_performance_preference", fallback="balance_power"
-        )
+        try:
+            with open(epp_path, "r") as f:
+                return f.read().strip()
+        except:
+            return None
 
     @staticmethod
     def current_epb(is_ac_plugged: bool) -> str | None:
-        epb_path = "/sys/devices/system/cpu/intel_pstate"
+        epb_path = "/sys/devices/system/cpu/cpu0/power/energy_perf_bias"
         if not Path(epb_path).exists():
             return None
 
-        return config.get_config().get(
-            "charger" if is_ac_plugged else "battery", "energy_perf_bias", fallback="balance_power"
-        )
+        try:
+            with open(epb_path, "r") as f:
+                value = int(f.read().strip())
+                # Convert numeric value to string representation
+                if value == 0:
+                    return "performance"
+                elif value == 4:
+                    return "balance_performance"
+                elif value == 6:
+                    return "default"
+                elif value == 8:
+                    return "balance_power"
+                elif value == 15:
+                    return "power"
+                else:
+                    return str(value)
+        except:
+            return None
 
     @staticmethod
     def cpu_usage() -> float:


### PR DESCRIPTION
Previously, the stats output was showing values from the config file instead of actual system values. This fixes the issue by:

1. Reading EPP directly from /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
2. Reading EPB from /sys/devices/system/cpu/cpu0/power/energy_perf_bias and converting numeric values to string representations

This ensures that the displayed values reflect the actual current system settings rather than the configured values.
I am new in PR culture, so any suggestion are welcome.