### PR TITLE
feat: allow users to specify battery device in config

### DIFF
--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -51,6 +51,10 @@ turbo = auto
 
 # settings for when using battery power
 [battery]
+# Specify which battery device to use for reading battery information. see available batteries by running: ls /sys/class/power_supply/
+# If not set, auto-cpufreq will automatically detect and use the first battery found
+# battery_device = BAT1
+
 # see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
 # preferred governor
 governor = powersave

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -53,6 +53,10 @@ services.auto-cpufreq.settings = {
 
   # settings for when using battery power
   battery = {
+    # Specify which battery device to use for reading battery information. see available batteries by running: ls /sys/class/power_supply/
+    # If not set, auto-cpufreq will automatically detect and use the first battery found
+    # battery_device = BAT1
+
     # see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
     # preferred governor
     governor = "powersave";

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -228,6 +228,21 @@ class SystemInfo:
     @staticmethod
     def get_battery_path() -> Optional[str]:
 
+        # Check if user has specified a custom battery device in config
+        if config.has_config():
+            conf = config.get_config()
+            if conf.has_option("battery", "battery_device"):
+                battery_device = conf.get("battery", "battery_device").strip()
+                if battery_device:
+                    custom_path = os.path.join(POWER_SUPPLY_DIR, battery_device)
+                    type_path = os.path.join(custom_path, "type")
+                    # Validate that the specified device exists and is a battery
+                    if os.path.isfile(type_path):
+                        content = SystemInfo.read_file(type_path)
+                        if content and content.lower() == "battery":
+                            return custom_path
+
+        # Fall back to auto-detection if no custom device specified or if it's invalid
         try:
             for entry in os.listdir(POWER_SUPPLY_DIR):
                 path = os.path.join(POWER_SUPPLY_DIR, entry)


### PR DESCRIPTION
Prior, there was no way for users encountering incorrect battery detection via `get_battery_path()` had no option to manually set the desired battery. On my Minisforum V3 tablet I have 3 devices listed in `/sys/class/power_supply/`. The battery detection was selecting the device that resulted in the battery status never changing, and the percentage to always show as 0%. These changes allow the user to specify, via the config, a device from `/sys/class/power_supply` they wish to have auto-cpufreq use. This is done by:

1. Adding `battery_device = {some batt}` as a valid setting in the config file
2. Adding an if statement to `get_battery_path()` to check for the config value above and return the user set device's path if it is a valid device