### PR TITLE
fix: cpuinfo and scaling min/max freqs not being used properly

### DIFF
--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -203,12 +203,12 @@ function set_frequency_max () {
 
 function get_frequency_min_limit () {
   if [ -z $CORE ]; then CORE=0; fi
-  cat $FLROOT/cpu$CORE/cpufreq/cpuinfo_min_freq
+  echo $(awk '{a[NR]=$1} END{if(a[1]<a[2]) print a[1]; else print a[2]}' $FLROOT/cpu$CORE/cpufreq/cpuinfo_min_freq $FLROOT/cpu$CORE/cpufreq/scaling_min_freq)
 }
 
 function get_frequency_max_limit () {
   if [ -z $CORE ]; then CORE=0; fi
-  cat $FLROOT/cpu$CORE/cpufreq/scaling_max_freq
+  echo $(awk '{a[NR]=$1} END{if(a[1]>a[2]) print a[1]; else print a[2]}' $FLROOT/cpu$CORE/cpufreq/cpuinfo_max_freq $FLROOT/cpu$CORE/cpufreq/scaling_max_freq)
 }
 
 function get_energy_performance_preference () {


### PR DESCRIPTION
related to:
- #866 
- #737

Bit of a copy paste because this is sort of a fix/revert of a previous issue but here we go:

### Background

In some systems, the two CPU frequency values from `cpuinfo_max_freq` and `scaling_max_freq` return different results. This discrepancy causes the application to pick a lower maximum frequency, which leads to incorrect behavior, such as not going back to the proper max frequency in certain cases.

### What this change does

This update makes the application use the value from `scaling_max_freq` OR `cpuinfo_max_freq` (whichever is bigger), to determine the CPU's maximum frequency. By doing so, it fixes the detection issue on affected systems. It seems that Intel and AMD cpu's work in the opposite way regarding these variables?

For sanity's sake, I also applied this in reverse to the min frequency.

### Impact

For users whose systems do not have this discrepancy, this change should have no impact and will continue working as before. 

For users with this discrepancy, this fixes frequency scaling again.