### PR TITLE
Fix variable name for virtual environment removal

### DIFF
--- a/auto-cpufreq-installer
+++ b/auto-cpufreq-installer
@@ -238,7 +238,7 @@ function tool_remove {
   update-desktop-database $APPLICATIONS_PATH
 
   # remove python virtual environment
-  remove_directory $venv_path
+  remove_directory $VENV_PATH
 
   echo; echo "auto-cpufreq tool and all its supporting files successfully removed"; echo
 }


### PR DESCRIPTION
Fix: wrong variable name venv_path → VENV_PATH in script

Because the environment variable was misspelled (venv_path instead of VENV_PATH), the script never detected the directory and therefore failed to remove the folder. This commit fixes the variable name so the directory is correctly deleted.