### PR TITLE
Add Dbus support

### DIFF
--- a/auto_cpufreq/dbus/__init__.py
+++ b/auto_cpufreq/dbus/__init__.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+D-Bus support for auto-cpufreq.
+
+This package provides a drop-in replacement for power-profiles-daemon,
+implementing the org.freedesktop.UPower.PowerProfiles D-Bus interface.
+This allows desktop environments like GNOME and KDE to control CPU
+performance through their native power management interfaces.
+"""
+
+from .service import PowerProfilesService, PowerProfilesInterface
+from .profile_manager import ProfileHoldManager, ProfileHold
+from .constants import (
+    DBUS_SERVICE_NAME,
+    DBUS_OBJECT_PATH,
+    DBUS_INTERFACE_NAME,
+    PROFILE_POWER_SAVER,
+    PROFILE_BALANCED,
+    PROFILE_PERFORMANCE,
+    VALID_PROFILES,
+)
+
+__all__ = [
+    # Main service
+    "PowerProfilesService",
+    "PowerProfilesInterface",
+    # Profile management
+    "ProfileHoldManager",
+    "ProfileHold",
+    # Constants
+    "DBUS_SERVICE_NAME",
+    "DBUS_OBJECT_PATH",
+    "DBUS_INTERFACE_NAME",
+    "PROFILE_POWER_SAVER",
+    "PROFILE_BALANCED",
+    "PROFILE_PERFORMANCE",
+    "VALID_PROFILES",
+]

--- a/auto_cpufreq/dbus/constants.py
+++ b/auto_cpufreq/dbus/constants.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+D-Bus constants for power-profiles-daemon compatibility.
+
+This module provides the D-Bus service names, object paths, and interface
+constants required to implement the org.freedesktop.UPower.PowerProfiles
+interface as a drop-in replacement for power-profiles-daemon.
+"""
+
+# D-Bus service identification
+DBUS_SERVICE_NAME = "org.freedesktop.UPower.PowerProfiles"
+DBUS_OBJECT_PATH = "/org/freedesktop/UPower/PowerProfiles"
+DBUS_INTERFACE_NAME = "org.freedesktop.UPower.PowerProfiles"
+
+# Profile names matching power-profiles-daemon specification
+PROFILE_POWER_SAVER = "power-saver"
+PROFILE_BALANCED = "balanced"
+PROFILE_PERFORMANCE = "performance"
+
+# Valid profiles list (ordered from lowest to highest power)
+VALID_PROFILES = [PROFILE_POWER_SAVER, PROFILE_BALANCED, PROFILE_PERFORMANCE]
+
+# Profile priority for hold resolution (higher index = higher priority)
+PROFILE_PRIORITY = {
+    PROFILE_POWER_SAVER: 0,
+    PROFILE_BALANCED: 1,
+    PROFILE_PERFORMANCE: 2,
+}
+
+# Mapping from D-Bus profiles to auto-cpufreq override values
+PROFILE_TO_OVERRIDE = {
+    PROFILE_PERFORMANCE: "performance",
+    PROFILE_BALANCED: "default",  # "default" means auto-switch based on AC/battery
+    PROFILE_POWER_SAVER: "powersave",
+}
+
+# Mapping from auto-cpufreq override values to D-Bus profiles
+OVERRIDE_TO_PROFILE = {
+    "performance": PROFILE_PERFORMANCE,
+    "default": PROFILE_BALANCED,
+    "powersave": PROFILE_POWER_SAVER,
+}
+
+# Turbo settings per profile
+PROFILE_TURBO_SETTINGS = {
+    PROFILE_PERFORMANCE: "always",
+    PROFILE_BALANCED: "auto",
+    PROFILE_POWER_SAVER: "never",
+}
+
+# Service version (matches auto-cpufreq version)
+SERVICE_VERSION = "3.0.0"

--- a/auto_cpufreq/dbus/profile_manager.py
+++ b/auto_cpufreq/dbus/profile_manager.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Profile hold management for power-profiles-daemon D-Bus compatibility.
+
+This module handles the HoldProfile/ReleaseProfile mechanism that allows
+applications to temporarily request a specific power profile.
+"""
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Callable
+
+from .constants import (
+    PROFILE_PRIORITY,
+    PROFILE_BALANCED,
+    VALID_PROFILES,
+)
+
+
+@dataclass
+class ProfileHold:
+    """Represents a single profile hold request from an application."""
+    cookie: int
+    profile: str
+    reason: str
+    application_id: str
+    sender: str  # D-Bus unique name for tracking disconnections
+    timestamp: float = field(default_factory=time.time)
+
+
+class ProfileHoldManager:
+    """
+    Manages profile holds with cookie-based tracking.
+
+    Profile holds allow applications to temporarily request a specific
+    power profile. When multiple holds are active, the highest-priority
+    profile wins (performance > balanced > power-saver).
+    """
+
+    def __init__(self, on_effective_profile_changed: Optional[Callable[[str], None]] = None):
+        """
+        Initialize the profile hold manager.
+
+        Args:
+            on_effective_profile_changed: Callback invoked when the effective
+                profile changes due to holds being added/removed.
+        """
+        self._holds: Dict[int, ProfileHold] = {}
+        self._next_cookie: int = 1
+        self._lock = threading.Lock()
+        self._on_effective_profile_changed = on_effective_profile_changed
+        self._last_effective_profile: Optional[str] = None
+
+    def hold_profile(
+        self,
+        profile: str,
+        reason: str,
+        application_id: str,
+        sender: str
+    ) -> int:
+        """
+        Create a new profile hold.
+
+        Args:
+            profile: The profile to hold ("power-saver", "balanced", "performance")
+            reason: Human-readable reason for the hold
+            application_id: Application identifier (e.g., "org.gnome.Settings")
+            sender: D-Bus unique name of the requesting client
+
+        Returns:
+            Cookie (unique identifier) for this hold
+
+        Raises:
+            ValueError: If the profile is not valid
+        """
+        if profile not in VALID_PROFILES:
+            raise ValueError(f"Invalid profile: {profile}. Must be one of {VALID_PROFILES}")
+
+        with self._lock:
+            cookie = self._next_cookie
+            self._next_cookie += 1
+
+            self._holds[cookie] = ProfileHold(
+                cookie=cookie,
+                profile=profile,
+                reason=reason,
+                application_id=application_id,
+                sender=sender,
+            )
+
+            self._check_effective_profile_change()
+            return cookie
+
+    def release_profile(self, cookie: int) -> bool:
+        """
+        Release a profile hold by its cookie.
+
+        Args:
+            cookie: The cookie returned by hold_profile()
+
+        Returns:
+            True if the hold was found and released, False otherwise
+        """
+        with self._lock:
+            if cookie in self._holds:
+                del self._holds[cookie]
+                self._check_effective_profile_change()
+                return True
+            return False
+
+    def cleanup_sender_holds(self, sender: str) -> List[int]:
+        """
+        Remove all holds from a disconnected D-Bus client.
+
+        Args:
+            sender: D-Bus unique name of the disconnected client
+
+        Returns:
+            List of cookies that were released (for emitting ProfileReleased signals)
+        """
+        with self._lock:
+            to_remove = [
+                cookie for cookie, hold in self._holds.items()
+                if hold.sender == sender
+            ]
+            for cookie in to_remove:
+                del self._holds[cookie]
+
+            if to_remove:
+                self._check_effective_profile_change()
+
+            return to_remove
+
+    def get_effective_profile(self, base_profile: str) -> str:
+        """
+        Determine the effective profile based on active holds.
+
+        The effective profile is the highest-priority profile among all
+        active holds. If no holds are active, returns the base profile.
+
+        Priority order: performance > balanced > power-saver
+
+        Args:
+            base_profile: The profile to use if no holds are active
+
+        Returns:
+            The effective profile name
+        """
+        with self._lock:
+            if not self._holds:
+                return base_profile
+
+            # Find the highest-priority hold
+            max_priority = -1
+            effective = base_profile
+
+            for hold in self._holds.values():
+                priority = PROFILE_PRIORITY.get(hold.profile, 0)
+                if priority > max_priority:
+                    max_priority = priority
+                    effective = hold.profile
+
+            return effective
+
+    def get_active_holds(self) -> List[Dict]:
+        """
+        Get information about all active holds.
+
+        Returns:
+            List of dictionaries with hold information for D-Bus ActiveProfileHolds property
+        """
+        with self._lock:
+            return [
+                {
+                    "ApplicationId": hold.application_id,
+                    "Profile": hold.profile,
+                    "Reason": hold.reason,
+                }
+                for hold in self._holds.values()
+            ]
+
+    def has_holds(self) -> bool:
+        """Check if there are any active holds."""
+        with self._lock:
+            return len(self._holds) > 0
+
+    def _check_effective_profile_change(self):
+        """
+        Check if the effective profile has changed and invoke callback.
+
+        Must be called with _lock held.
+        """
+        if self._on_effective_profile_changed is None:
+            return
+
+        # Calculate current effective profile
+        if not self._holds:
+            current = PROFILE_BALANCED  # Default when no holds
+        else:
+            max_priority = -1
+            current = PROFILE_BALANCED
+            for hold in self._holds.values():
+                priority = PROFILE_PRIORITY.get(hold.profile, 0)
+                if priority > max_priority:
+                    max_priority = priority
+                    current = hold.profile
+
+        if current != self._last_effective_profile:
+            self._last_effective_profile = current
+            # Release lock before callback to avoid deadlocks
+            callback = self._on_effective_profile_changed
+            # Schedule callback outside of lock
+            threading.Thread(
+                target=callback,
+                args=(current,),
+                daemon=True
+            ).start()

--- a/auto_cpufreq/dbus/service.py
+++ b/auto_cpufreq/dbus/service.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+D-Bus service implementing org.freedesktop.UPower.PowerProfiles interface.
+
+This module provides a drop-in replacement for power-profiles-daemon,
+allowing desktop environments like GNOME and KDE to control CPU performance
+through the standard D-Bus interface.
+"""
+
+import logging
+from typing import List, Dict
+
+from dasbus.connection import SystemMessageBus
+from dasbus.identifier import DBusServiceIdentifier
+from dasbus.loop import EventLoop
+from dasbus.server.interface import dbus_interface, dbus_signal
+from dasbus.server.template import PropertiesInterface
+from dasbus.server.property import emits_properties_changed
+from dasbus.server.publishable import Publishable
+from dasbus.typing import Str, Bool, UInt32, Variant, get_variant
+from dasbus.structure import DBusData
+from gi.repository import GLib
+
+from .constants import (
+    DBUS_SERVICE_NAME,
+    DBUS_OBJECT_PATH,
+    DBUS_INTERFACE_NAME,
+    PROFILE_POWER_SAVER,
+    PROFILE_BALANCED,
+    PROFILE_PERFORMANCE,
+    VALID_PROFILES,
+    PROFILE_TO_OVERRIDE,
+    OVERRIDE_TO_PROFILE,
+    PROFILE_TURBO_SETTINGS,
+    SERVICE_VERSION,
+)
+from .profile_manager import ProfileHoldManager
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+# D-Bus service identifier
+POWER_PROFILES = DBusServiceIdentifier(
+    namespace=("org", "freedesktop", "UPower"),
+    service_version=1,
+    message_bus=SystemMessageBus()
+)
+
+
+@dbus_interface(DBUS_INTERFACE_NAME)
+class PowerProfilesInterface(Publishable, PropertiesInterface):
+    """
+    Implementation of the org.freedesktop.UPower.PowerProfiles D-Bus interface.
+
+    This interface is compatible with power-profiles-daemon and allows desktop
+    environments to control CPU performance profiles.
+    """
+
+    def __init__(self):
+        """Initialize the power profiles interface."""
+        super().__init__()
+        self._hold_manager = ProfileHoldManager(
+            on_effective_profile_changed=self._on_hold_effective_change
+        )
+        self._battery_aware = True
+        self._bus = None
+        self._connected_clients: Dict[str, bool] = {}
+
+        # Import core functions (delayed to avoid circular imports)
+        from auto_cpufreq.core import (
+            get_override,
+            set_override,
+            get_turbo_override,
+            set_turbo_override,
+        )
+        self._get_override = get_override
+        self._set_override = set_override
+        self._get_turbo_override = get_turbo_override
+        self._set_turbo_override = set_turbo_override
+
+    def for_publication(self):
+        """Return this object for D-Bus publication."""
+        return self
+
+    def set_bus(self, bus):
+        """Set the D-Bus connection for signal emission."""
+        self._bus = bus
+
+    def _on_hold_effective_change(self, new_profile: str):
+        """Called when holds cause the effective profile to change."""
+        self._apply_profile(new_profile)
+
+    def _get_current_profile(self) -> str:
+        """Get the current profile based on override state."""
+        override = self._get_override()
+        return OVERRIDE_TO_PROFILE.get(override, PROFILE_BALANCED)
+
+    def _apply_profile(self, profile: str):
+        """
+        Apply a profile by setting the appropriate overrides.
+
+        Args:
+            profile: One of "power-saver", "balanced", "performance"
+        """
+        if profile not in VALID_PROFILES:
+            log.warning(f"Invalid profile: {profile}")
+            return
+
+        # Map profile to override value
+        override = PROFILE_TO_OVERRIDE.get(profile, "default")
+
+        # Set governor override
+        if override == "default":
+            self._set_override("reset")
+        else:
+            self._set_override(override)
+
+        # Set turbo override
+        turbo = PROFILE_TURBO_SETTINGS.get(profile, "auto")
+        self._set_turbo_override(turbo)
+
+        log.info(f"Applied profile: {profile} (override={override}, turbo={turbo})")
+
+    # ==================== D-Bus Methods ====================
+
+    def HoldProfile(self, profile: Str, reason: Str, application_id: Str) -> UInt32:
+        """
+        Hold a power profile temporarily.
+
+        Applications can request to hold a specific profile. When multiple
+        holds are active, the highest-priority profile wins.
+
+        Args:
+            profile: Profile to hold ("power-saver", "balanced", "performance")
+            reason: Human-readable reason for the hold
+            application_id: Application identifier
+
+        Returns:
+            Cookie to use when releasing the hold
+        """
+        # Get the sender's unique bus name
+        # Note: In production, this would come from the D-Bus message context
+        # For now, use application_id as a fallback
+        sender = application_id
+
+        log.info(f"HoldProfile: profile={profile}, reason={reason}, app={application_id}")
+
+        if profile not in VALID_PROFILES:
+            raise ValueError(f"Invalid profile: {profile}")
+
+        cookie = self._hold_manager.hold_profile(
+            profile=profile,
+            reason=reason,
+            application_id=application_id,
+            sender=sender,
+        )
+
+        # Apply the effective profile
+        effective = self._hold_manager.get_effective_profile(self._get_current_profile())
+        self._apply_profile(effective)
+
+        log.info(f"HoldProfile: assigned cookie {cookie}")
+        return cookie
+
+    def ReleaseProfile(self, cookie: UInt32):
+        """
+        Release a previously held profile.
+
+        Args:
+            cookie: Cookie returned by HoldProfile
+        """
+        log.info(f"ReleaseProfile: cookie={cookie}")
+
+        if self._hold_manager.release_profile(cookie):
+            # Emit ProfileReleased signal
+            self.ProfileReleased(cookie)
+
+            # Revert to base profile if no more holds
+            if not self._hold_manager.has_holds():
+                base_profile = self._get_current_profile()
+                self._apply_profile(base_profile)
+                log.info(f"No more holds, reverted to base profile: {base_profile}")
+        else:
+            log.warning(f"ReleaseProfile: cookie {cookie} not found")
+
+    def SetActionEnabled(self, action: Str, enabled: Bool):
+        """
+        Enable or disable an action.
+
+        Currently not implemented as Actions are empty for initial release.
+
+        Args:
+            action: Action name
+            enabled: Whether to enable the action
+        """
+        log.info(f"SetActionEnabled: action={action}, enabled={enabled}")
+        # Actions not implemented in initial release
+        pass
+
+    # ==================== D-Bus Properties ====================
+
+    @property
+    def ActiveProfile(self) -> Str:
+        """
+        The currently active power profile.
+
+        Returns one of: "power-saver", "balanced", "performance"
+        """
+        # If there are active holds, return the effective profile
+        if self._hold_manager.has_holds():
+            base = self._get_current_profile()
+            return self._hold_manager.get_effective_profile(base)
+
+        return self._get_current_profile()
+
+    @ActiveProfile.setter
+    @emits_properties_changed
+    def ActiveProfile(self, profile: Str):
+        """
+        Set the active power profile.
+
+        Args:
+            profile: One of "power-saver", "balanced", "performance"
+        """
+        log.info(f"Setting ActiveProfile to: {profile}")
+
+        if profile not in VALID_PROFILES:
+            raise ValueError(f"Invalid profile: {profile}. Must be one of {VALID_PROFILES}")
+
+        self._apply_profile(profile)
+
+    @property
+    def PerformanceInhibited(self) -> Str:
+        """
+        Reason why performance profile is inhibited.
+
+        Returns empty string if performance is not inhibited.
+        """
+        # Performance is not inhibited in auto-cpufreq
+        return ""
+
+    @property
+    def PerformanceDegraded(self) -> Str:
+        """
+        Reason why performance is degraded.
+
+        Returns a string like "high-operating-temperature" if performance
+        is degraded due to thermal throttling, empty string otherwise.
+        """
+        # Could integrate with temperature monitoring in the future
+        # For now, return empty
+        return ""
+
+    @property
+    def Profiles(self) -> List[Dict[Str, Variant]]:
+        """
+        List of available profiles with metadata.
+
+        Returns array of dictionaries with profile information.
+        """
+        return [
+            {
+                "Profile": get_variant(Str, PROFILE_POWER_SAVER),
+                "CpuDriver": get_variant(Str, "auto-cpufreq"),
+                "Driver": get_variant(Str, "auto-cpufreq"),
+            },
+            {
+                "Profile": get_variant(Str, PROFILE_BALANCED),
+                "CpuDriver": get_variant(Str, "auto-cpufreq"),
+                "Driver": get_variant(Str, "auto-cpufreq"),
+            },
+            {
+                "Profile": get_variant(Str, PROFILE_PERFORMANCE),
+                "CpuDriver": get_variant(Str, "auto-cpufreq"),
+                "Driver": get_variant(Str, "auto-cpufreq"),
+            },
+        ]
+
+    @property
+    def Actions(self) -> List[Str]:
+        """
+        List of available actions.
+
+        Empty for initial implementation.
+        """
+        return []
+
+    @property
+    def ActionsInfo(self) -> List[Dict[Str, Variant]]:
+        """
+        Detailed information about available actions.
+
+        Empty for initial implementation.
+        """
+        return []
+
+    @property
+    def ActiveProfileHolds(self) -> List[Dict[Str, Variant]]:
+        """
+        List of active profile holds.
+
+        Returns array of dictionaries with hold information.
+        """
+        holds = self._hold_manager.get_active_holds()
+        # Convert to D-Bus variant format
+        return [
+            {
+                "ApplicationId": get_variant(Str, h["ApplicationId"]),
+                "Profile": get_variant(Str, h["Profile"]),
+                "Reason": get_variant(Str, h["Reason"]),
+            }
+            for h in holds
+        ]
+
+    @property
+    def Version(self) -> Str:
+        """Service version string."""
+        return SERVICE_VERSION
+
+    @property
+    def BatteryAware(self) -> Bool:
+        """
+        Whether the daemon automatically adjusts based on battery state.
+
+        When True, "balanced" profile auto-switches between performance
+        (on AC) and power-saver (on battery) settings.
+        """
+        return self._battery_aware
+
+    @BatteryAware.setter
+    @emits_properties_changed
+    def BatteryAware(self, value: Bool):
+        """Set whether the daemon is battery-aware."""
+        self._battery_aware = value
+        log.info(f"BatteryAware set to: {value}")
+
+    # ==================== D-Bus Signals ====================
+
+    @dbus_signal
+    def ProfileReleased(self, cookie: UInt32):
+        """
+        Signal emitted when a profile hold is released.
+
+        Args:
+            cookie: The cookie of the released hold
+        """
+        pass
+
+
+class PowerProfilesService:
+    """
+    Main service class that manages the D-Bus connection and lifecycle.
+    """
+
+    def __init__(self):
+        """Initialize the power profiles service."""
+        self._bus = SystemMessageBus()
+        self._interface = PowerProfilesInterface()
+        self._interface.set_bus(self._bus)
+        self._loop = None
+        self._registered = False
+
+    def start(self):
+        """
+        Start the D-Bus service.
+
+        Registers the service on the system bus and starts handling requests.
+        """
+        if self._registered:
+            log.warning("Service already registered")
+            return
+
+        log.info(f"Registering D-Bus service: {DBUS_SERVICE_NAME}")
+
+        # Publish the interface on the bus
+        self._bus.publish_object(
+            DBUS_OBJECT_PATH,
+            self._interface
+        )
+
+        # Request the well-known name
+        self._bus.register_service(DBUS_SERVICE_NAME)
+
+        self._registered = True
+        log.info("D-Bus service registered successfully")
+
+    def stop(self):
+        """
+        Stop the D-Bus service.
+
+        Unregisters from the system bus.
+        """
+        if not self._registered:
+            return
+
+        log.info("Stopping D-Bus service")
+
+        try:
+            self._bus.disconnect()
+        except Exception as e:
+            log.error(f"Error disconnecting from D-Bus: {e}")
+
+        self._registered = False
+
+    def get_event_loop(self) -> EventLoop:
+        """
+        Get the event loop for running the service.
+
+        Returns:
+            EventLoop instance that can be used to run the D-Bus service
+        """
+        if self._loop is None:
+            self._loop = EventLoop()
+        return self._loop
+
+    @property
+    def interface(self) -> PowerProfilesInterface:
+        """Get the interface instance for direct access."""
+        return self._interface

--- a/poetry.lock
+++ b/poetry.lock
@@ -352,6 +352,18 @@ test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "dasbus"
+version = "1.7"
+description = "DBus library in Python 3"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "dasbus-1.7-py3-none-any.whl", hash = "sha256:0a9433e9e72c2c865fa2d5ef824ac4ef49b540cf57f6396e515c2f314e5c14cd"},
+    {file = "dasbus-1.7.tar.gz", hash = "sha256:a8850d841adfe8ee5f7bb9f82cf449ab9b4950dc0633897071718e0d0036b6f6"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 description = "Distribution utilities"
@@ -1398,4 +1410,4 @@ gui = ["PyGObject"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9, <4.0"
-content-hash = "1a320a80a46edec0b309fb95b6e046e307f83196c7d962f96ea390223529243f"
+content-hash = "4c1129d4385bf2b4bed0fc8893423f23b7f5db69ab870d49c41072dfbd1dd6b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ PyGObject = {version="^3.50.0", optional=true}
 urwid = "^3.0.2"
 pyinotify = {git = "https://github.com/shadeyg56/pyinotify-3.12"}
 pyasyncore = "^1.0.4"
+dasbus = "^1.7"
 
 [tool.poetry.extras]
 gui = ["PyGObject"]

--- a/scripts/auto-cpufreq-install.sh
+++ b/scripts/auto-cpufreq-install.sh
@@ -94,3 +94,18 @@ case "$(ps h -o comm 1)" in
     echo -e "\n* Please open an issue on https://github.com/AdnanHodzic/auto-cpufreq\n"
   ;;
 esac
+
+# Deploy D-Bus configuration for power-profiles-daemon compatibility
+echo -e "\n* Installing D-Bus configuration for power-profiles-daemon compatibility"
+if [ -d /usr/share/dbus-1/system.d ]; then
+    cp /usr/local/share/auto-cpufreq/scripts/org.freedesktop.UPower.PowerProfiles.conf /usr/share/dbus-1/system.d/
+    echo "  - Installed D-Bus bus policy"
+
+    # Reload D-Bus to pick up new configuration
+    if command -v systemctl &> /dev/null && systemctl is-active dbus &> /dev/null; then
+        systemctl reload dbus 2>/dev/null || true
+        echo "  - Reloaded D-Bus configuration"
+    fi
+else
+    echo "  - Warning: /usr/share/dbus-1/system.d not found, skipping D-Bus configuration"
+fi

--- a/scripts/auto-cpufreq-remove.sh
+++ b/scripts/auto-cpufreq-remove.sh
@@ -69,3 +69,18 @@ case "$(ps h -o comm 1)" in
     echo -e "\n* Please open an issue on https://github.com/AdnanHodzic/auto-cpufreq\n"
   ;;
 esac
+
+# Remove D-Bus configuration
+echo -e "\n* Removing D-Bus configuration for power-profiles-daemon compatibility"
+if [ -f /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf ]; then
+    rm /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf
+    echo "  - Removed D-Bus bus policy"
+
+    # Reload D-Bus to pick up configuration changes
+    if command -v systemctl &> /dev/null && systemctl is-active dbus &> /dev/null; then
+        systemctl reload dbus 2>/dev/null || true
+        echo "  - Reloaded D-Bus configuration"
+    fi
+else
+    echo "  - D-Bus configuration not found, skipping"
+fi

--- a/scripts/org.freedesktop.UPower.PowerProfiles.conf
+++ b/scripts/org.freedesktop.UPower.PowerProfiles.conf
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!--
+    D-Bus policy for auto-cpufreq power-profiles-daemon compatibility.
+
+    This policy allows auto-cpufreq to provide the org.freedesktop.UPower.PowerProfiles
+    interface, enabling desktop environments like GNOME and KDE to control CPU
+    performance through their native power management interfaces.
+  -->
+
+  <!-- Only root can own the service (auto-cpufreq daemon runs as root) -->
+  <policy user="root">
+    <allow own="org.freedesktop.UPower.PowerProfiles"/>
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"/>
+    <allow receive_sender="org.freedesktop.UPower.PowerProfiles"/>
+  </policy>
+
+  <!-- Allow any user to interact with the service -->
+  <policy context="default">
+    <!-- Allow introspection -->
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <!-- Allow reading properties -->
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="Get"/>
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="GetAll"/>
+
+    <!-- Allow setting properties (ActiveProfile, BatteryAware) -->
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="Set"/>
+
+    <!-- Allow calling HoldProfile and ReleaseProfile methods -->
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.UPower.PowerProfiles"
+           send_member="HoldProfile"/>
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.UPower.PowerProfiles"
+           send_member="ReleaseProfile"/>
+    <allow send_destination="org.freedesktop.UPower.PowerProfiles"
+           send_interface="org.freedesktop.UPower.PowerProfiles"
+           send_member="SetActionEnabled"/>
+
+    <!-- Allow receiving signals -->
+    <allow receive_sender="org.freedesktop.UPower.PowerProfiles"/>
+  </policy>
+</busconfig>


### PR DESCRIPTION
Very initial work done here, using the existing DBUS interface used by KDE and GNOME following `org.freedesktop.UPower.PowerProfiles` this is meant to be a drop-in replacement for power-profiles-daemon. I have done some initial testing with the KDE systemsettings application and it is working there for the few settings I tested.  Will need to do significantly more testing, especially with the Gnome settings.