### PR TITLE
fix: wrong EPP and EBP fallback profiles in auto-cpufreq --stats

### DIFF
--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -150,7 +150,7 @@ class SystemInfo:
             return None
             
         return config.get_config().get( 
-            "charger" if is_ac_plugged else "battery", "energy_performance_preference", fallback="performance" if is_ac_plugged else "balance_power"
+            "charger" if is_ac_plugged else "battery", "energy_performance_preference", fallback="balance_performance" if is_ac_plugged else "balance_power"
         )
 
     @staticmethod


### PR DESCRIPTION
When running the interactive auto-cpufreq --stats and EPP and EBP are not configured in the config file, the wrong fallback was sometimes used, as it did not depend on the ac status. Please check if the fallback is now correct.