### PR TITLE
feat: add `enforce_platform_profile` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ energy_performance_preference = performance
 
 # Controls strict enforcement of the platform profile.
 # - true: Constantly enforces the platform profile defined above.
-# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g., Fn+Q on Legion laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
@@ -426,7 +426,7 @@ energy_performance_preference = power
 
 # Controls strict enforcement of the platform profile.
 # - true: Constantly enforces the platform profile defined above.
-# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g., Fn+Q on Legion laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)

--- a/README.md
+++ b/README.md
@@ -378,6 +378,9 @@ energy_performance_preference = performance
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = performance
+# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
+# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+# enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
@@ -418,6 +421,9 @@ energy_performance_preference = power
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = low-power
+# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
+# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+# enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/README.md
+++ b/README.md
@@ -378,8 +378,10 @@ energy_performance_preference = performance
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = performance
-# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
-# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+
+# Controls strict enforcement of the platform profile.
+# - true: Constantly enforces the platform profile defined above.
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
@@ -421,8 +423,10 @@ energy_performance_preference = power
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = low-power
-# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
-# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+
+# Controls strict enforcement of the platform profile.
+# - true: Constantly enforces the platform profile defined above.
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -22,6 +22,9 @@ energy_performance_preference = performance
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = performance
+# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
+# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+# enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
@@ -77,6 +80,9 @@ energy_performance_preference = power
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = low-power
+# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
+# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+# enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
 # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -22,8 +22,10 @@ energy_performance_preference = performance
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = performance
-# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
-# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+
+# Controls strict enforcement of the platform profile.
+# - true: Constantly enforces the platform profile defined above.
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
@@ -80,8 +82,10 @@ energy_performance_preference = power
 # See available options by running:
 # cat /sys/firmware/acpi/platform_profile_choices
 # platform_profile = low-power
-# Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
-# but allow manual overrides like Legion Fn+Q to persist until the next state change.
+
+# Controls strict enforcement of the platform profile.
+# - true: Constantly enforces the platform profile defined above.
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -25,7 +25,7 @@ energy_performance_preference = performance
 
 # Controls strict enforcement of the platform profile.
 # - true: Constantly enforces the platform profile defined above.
-# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g., Fn+Q on Legion laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)
@@ -85,7 +85,7 @@ energy_performance_preference = power
 
 # Controls strict enforcement of the platform profile.
 # - true: Constantly enforces the platform profile defined above.
-# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+# - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g., Fn+Q on Legion laptops).
 # enforce_platform_profile = true
 
 # minimum cpu frequency (in kHz)

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -25,6 +25,9 @@ services.auto-cpufreq.settings = {
     # See available options by running:
     # cat /sys/firmware/acpi/platform_profile_choices
     # platform_profile = "performance";
+    # Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
+    # but allow manual overrides like Legion Fn+Q to persist until the next state change.
+    # enforce_platform_profile = true
 
     # minimum cpu frequency (in kHz)
     # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
@@ -79,6 +82,9 @@ services.auto-cpufreq.settings = {
     # See available options by running:
     # cat /sys/firmware/acpi/platform_profile_choices
     # platform_profile = "low-power";
+    # Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
+    # but allow manual overrides like Legion Fn+Q to persist until the next state change.
+    # enforce_platform_profile = true
 
     # minimum cpu frequency (in kHz)
     # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -25,9 +25,11 @@ services.auto-cpufreq.settings = {
     # See available options by running:
     # cat /sys/firmware/acpi/platform_profile_choices
     # platform_profile = "performance";
-    # Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
-    # but allow manual overrides like Legion Fn+Q to persist until the next state change.
-    # enforce_platform_profile = true
+
+    # Controls strict enforcement of the platform profile.
+    # - true: Constantly enforces the platform profile defined above.
+    # - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+    # enforce_platform_profile = true;
 
     # minimum cpu frequency (in kHz)
     # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000
@@ -82,9 +84,11 @@ services.auto-cpufreq.settings = {
     # See available options by running:
     # cat /sys/firmware/acpi/platform_profile_choices
     # platform_profile = "low-power";
-    # Set this to false if you want auto-cpufreq to apply the profile on AC/battery changes,
-    # but allow manual overrides like Legion Fn+Q to persist until the next state change.
-    # enforce_platform_profile = true
+
+    # Controls strict enforcement of the platform profile.
+    # - true: Constantly enforces the platform profile defined above.
+    # - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+    # enforce_platform_profile = true;
 
     # minimum cpu frequency (in kHz)
     # example: for 800 MHz = 800000 kHz --> scaling_min_freq = 800000

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -28,7 +28,7 @@ services.auto-cpufreq.settings = {
 
     # Controls strict enforcement of the platform profile.
     # - true: Constantly enforces the platform profile defined above.
-    # - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+    # - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g., Fn+Q on Legion laptops).
     # enforce_platform_profile = true;
 
     # minimum cpu frequency (in kHz)
@@ -87,7 +87,7 @@ services.auto-cpufreq.settings = {
 
     # Controls strict enforcement of the platform profile.
     # - true: Constantly enforces the platform profile defined above.
-    # - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g Fn + Q on Legion Laptops).
+    # - false: Sets profile only on AC/Battery changes, allowing manual overrides (e.g., Fn+Q on Legion laptops).
     # enforce_platform_profile = true;
 
     # minimum cpu frequency (in kHz)

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -540,9 +540,15 @@ def set_platform_profile(conf, profile):
     if not hasattr(set_platform_profile, "last_applied_platform_profile"):
         set_platform_profile.last_applied_platform_profile = {}
 
+    def is_platform_profile_enforced():
+        try: 
+            return conf.getboolean(profile, "enforce_platform_profile", fallback=True)
+        except ValueError:
+            return True
+
     global last_applied_config_section
     if (
-        not conf.getboolean(profile, "enforce_platform_profile", fallback=True)
+        not is_platform_profile_enforced()
         and last_applied_config_section == profile
         and set_platform_profile.last_applied_platform_profile.get(profile) == pp
     ):

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -541,9 +541,14 @@ def set_platform_profile(conf, profile):
         set_platform_profile.last_applied_platform_profile = {}
 
     def is_platform_profile_enforced():
-        try: 
+        try:
             return conf.getboolean(profile, "enforce_platform_profile", fallback=True)
         except ValueError:
+            raw_value = conf[profile].get("enforce_platform_profile", "")
+            print(
+                f"Invalid boolean value for 'enforce_platform_profile' in profile '{profile}': "
+                f"{raw_value!r}. Using default value True."
+            )
             return True
 
     global last_applied_config_section

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -530,18 +530,27 @@ def set_frequencies(power_supply):
 def set_platform_profile(conf, profile):
     if not conf.has_option(profile, "platform_profile"):
         return
-    
+
     if not Path("/sys/firmware/acpi/platform_profile").exists():
         print('Not setting Platform Profile (not supported by system)')
         return
-    
-    global last_applied_config_section
-    if not conf.getboolean(profile, "enforce_platform_profile", fallback=True) and last_applied_config_section == profile:
-        return
 
     pp = conf[profile]["platform_profile"]
+
+    if not hasattr(set_platform_profile, "last_applied_platform_profile"):
+        set_platform_profile.last_applied_platform_profile = {}
+
+    global last_applied_config_section
+    if (
+        not conf.getboolean(profile, "enforce_platform_profile", fallback=True)
+        and last_applied_config_section == profile
+        and set_platform_profile.last_applied_platform_profile.get(profile) == pp
+    ):
+        return
+
     print(f'Setting to use: "{pp}" Platform Profile')
     run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
+    set_platform_profile.last_applied_platform_profile[profile] = pp
 
 def set_energy_perf_bias(conf, profile):
     if Path("/sys/devices/system/cpu/intel_pstate").exists() is False:

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -555,7 +555,10 @@ def set_platform_profile(conf, profile):
         return
 
     print(f'Setting to use: "{pp}" Platform Profile')
-    run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
+    result = run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
+    if result.returncode != 0:
+        print(f"Failed to set platform profile to {pp}")
+        return
     set_platform_profile.last_applied_platform_profile[profile] = pp
 
 def set_energy_perf_bias(conf, profile):

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -57,6 +57,8 @@ else:
     governor_override_state = Path("/opt/auto-cpufreq/override.pickle")
     turbo_override_state    = Path("/opt/auto-cpufreq/turbo-override.pickle")
 
+last_applied_config_section = None
+
 def file_stats():
     global auto_cpufreq_stats_file
     auto_cpufreq_stats_file = open(auto_cpufreq_stats_path, "w")
@@ -526,13 +528,20 @@ def set_frequencies(power_supply):
         run(f"cpufreqctl.auto-cpufreq {frequency[freq_type]['cmdargs']} --set={frequency[freq_type]['value']}", shell=True)
 
 def set_platform_profile(conf, profile):
-    if conf.has_option(profile, "platform_profile"):
-        if not Path("/sys/firmware/acpi/platform_profile").exists():
-            print('Not setting Platform Profile (not supported by system)')
-        else:
-            pp = conf[profile]["platform_profile"]
-            print(f'Setting to use: "{pp}" Platform Profile')
-            run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
+    if not conf.has_option(profile, "platform_profile"):
+        return
+    
+    if not Path("/sys/firmware/acpi/platform_profile").exists():
+        print('Not setting Platform Profile (not supported by system)')
+        return
+    
+    global last_applied_config_section
+    if not conf.getboolean(profile, "enforce_platform_profile", fallback=True) and last_applied_config_section == profile:
+        return
+
+    pp = conf[profile]["platform_profile"]
+    print(f'Setting to use: "{pp}" Platform Profile')
+    run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
 
 def set_energy_perf_bias(conf, profile):
     if Path("/sys/devices/system/cpu/intel_pstate").exists() is False:
@@ -575,6 +584,9 @@ def set_powersave():
 
     set_energy_perf_bias(conf, "battery")
     set_platform_profile(conf, "battery")
+    global last_applied_config_section
+    last_applied_config_section = "battery"
+
 
     cpuload, load1m= get_load()
 
@@ -688,6 +700,8 @@ def set_performance():
     
     set_energy_perf_bias(conf, "charger")
     set_platform_profile(conf, "charger")
+    global last_applied_config_section
+    last_applied_config_section = "charger"
 
     cpuload, load1m = get_load()
     auto = conf["charger"]["turbo"] if conf.has_option("charger", "turbo") else "auto"

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -332,8 +332,11 @@ case $OPTION in
       verbose "Getting Platform Profile"
       cat $FWROOT/acpi/platform_profile
     else
-      verbose "Getting Platform Profile to "$VALUE
-      echo $VALUE > $FWROOT/acpi/platform_profile
+      verbose "Setting Platform Profile to $VALUE"
+      current_profile=$(cat "$FWROOT/acpi/platform_profile")
+      if [ "$current_profile" != "$VALUE" ]; then 
+        echo "$VALUE" > "$FWROOT/acpi/platform_profile"
+      fi
     fi
   ;;
   -f|--frequency)


### PR DESCRIPTION
## Problem
Users with certain laptops (e.g., Lenovo Legion) can manually override the platform profile using hardware shortcuts (Fn+Q). Currently, auto-cpufreq re-enforces the configured platform profile on every daemon loop (every 2 seconds), immediately reverting any manual overrides. This prevents users from having fine-grained, temporary control over their system's power profile.

## Solution
Introduce a new configurable boolean option `enforce_platform_profile` (defaults to `true` to keep the current behavior) that controls whether auto-cpufreq continuously re-applies the platform profile or only sets it during power-state transitions (`AC <-> battery`).

**Behavior:**
- `enforce_platform_profile = true` (default): Preserves current behavior; platform profile is enforced on every daemon loop.
- `enforce_platform_profile = false`: Platform profile is applied only when the power state changes (`battery <-> charger`). Manual overrides persist until the next transition.

This is a per-profile setting, so battery and charger sections can be configured independently.

## Configuration Example
```conf
[charger]
platform_profile = performance
enforce_platform_profile = true

[battery]
platform_profile = low-power
# Set to false to allow manual overrides (e.g., Legion Fn+Q) to persist
enforce_platform_profile = false