### PR TITLE
Fix: replace assert with explicit check + narrow bare excepts

### DIFF
--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -116,7 +116,9 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                     while True:
                         time.sleep(1)
                         set_autofreq()
-                except:
+                except KeyboardInterrupt:
+                    raise
+                except Exception:
                     pass
             
             def live_daemon_off():

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -992,7 +992,7 @@ def is_running(program, argument):
     # and find the one with name and args passed to the function
     for p in psutil.process_iter():
         try: cmd = p.cmdline()
-        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError): continue
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError): continue
         for s in filter(lambda x: program in x, cmd):
             if argument in cmd: return True
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -992,7 +992,7 @@ def is_running(program, argument):
     # and find the one with name and args passed to the function
     for p in psutil.process_iter():
         try: cmd = p.cmdline()
-        except: continue
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError): continue
         for s in filter(lambda x: program in x, cmd):
             if argument in cmd: return True
 

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -847,7 +847,8 @@ class DaemonNotRunningView(Gtk.Box):
                 kwargs = {"shell": True, "stdout": PIPE, "stderr": PIPE}
                 future = executor.submit(run, "pkexec auto-cpufreq --install", **kwargs)
                 result = future.result()
-            assert result.returncode not in (126, 127), Exception("Authorization was cancelled")
+            if result.returncode in (126, 127):
+                raise RuntimeError("Authorization was cancelled")
             # enable for debug. causes issues if kept
             # elif result.stderr is not None:
             #     raise Exception(result.stderr.decode())

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -140,7 +140,7 @@ class SystemInfo:
                 "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor", "r"
             ) as f:
                 return f.read().strip()
-        except:
+        except OSError:
             return None
 
     @staticmethod

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -29,6 +29,7 @@ tlp_stat_exists = does_command_exists("tlp-stat")
 tuned_stat_exists = does_command_exists("tuned")
 
 # detect if gnome power profile service is running
+gnome_power_status = None
 if not IS_INSTALLED_WITH_SNAP:
     if systemctl_exists:
         try: gnome_power_status = call(["systemctl", "is-active", "--quiet", "power-profiles-daemon"])

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -32,7 +32,7 @@ tuned_stat_exists = does_command_exists("tuned")
 if not IS_INSTALLED_WITH_SNAP:
     if systemctl_exists:
         try: gnome_power_status = call(["systemctl", "is-active", "--quiet", "power-profiles-daemon"])
-        except:
+        except (OSError, FileNotFoundError):
             print("\nUnable to determine init system")
             print("If this causes any problems, please submit an issue:")
             print(GITHUB+"/issues")
@@ -119,7 +119,7 @@ def gnome_power_svc_enable():
             print("* Enabling GNOME power profiles\n")
             call(["systemctl", "unmask", "power-profiles-daemon"])
             call(["systemctl", "enable", "--now", "power-profiles-daemon"])
-        except:
+        except (OSError, FileNotFoundError):
             print("\nUnable to enable GNOME power profiles")
             print("If this causes any problems, please submit an issue:")
             print(GITHUB+"/issues")
@@ -130,7 +130,7 @@ def tuned_svc_enable():
             print("* Enabling TuneD\n")
             call(["systemctl", "unmask", "tuned"])
             call(["systemctl", "enable", "--now", "tuned"])
-        except:
+        except (OSError, FileNotFoundError):
             print("\nUnable to enable TuneD daemon")
             print("If this causes any problems, please submit an issue:")
             print(GITHUB+"/issues")
@@ -141,7 +141,7 @@ def gnome_power_svc_status():
         try:
             print("* GNOME power profiles status")
             call(["systemctl", "status", "power-profiles-daemon"])
-        except:
+        except (OSError, FileNotFoundError):
             print("\nUnable to see GNOME power profiles status")
             print("If this causes any problems, please submit an issue:")
             print(GITHUB+"/issues")
@@ -295,7 +295,7 @@ def gnome_power_svc_disable():
                     print("auto-cpufreq snap package not installed\nGNOME Power Profiles Daemon should be enabled. run:\n\n"
                         "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable"
                     )
-            except:
+            except (OSError, FileNotFoundError):
                 # snapd not found on the system
                 print("There was a problem, couldn't determine GNOME Power Profiles Daemon")
                 snap_pkg_check = 0


### PR DESCRIPTION
fix: replace assert with explicit check + narrow bare excepts

- gui/objects.py: Replace `assert ... Exception(...)` with explicit
  if/raise RuntimeError. Using assert for control flow is dangerous
  because `python -O` removes all assert statements, silently skipping
  the authorization check.
- power_helper.py: Narrow 6 bare `except:` to `except (OSError, FileNotFoundError)`
  for subprocess and systemctl calls
- core.py: Narrow bare `except:` to `except (psutil.AccessDenied, psutil.NoSuchProcess, OSError)`
- bin/auto_cpufreq.py: Re-raise KeyboardInterrupt, catch only Exception
- modules/system_info.py: Narrow bare `except:` to `except OSError`