### PR TITLE
Add configurable Intel HWP dynamic boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ energy_performance_preference = balance_performance
 
 # Intel HWP Dynamic Boost.
 # Only available with intel_pstate in active mode and HWP enabled.
+# Alters value in: /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
+# Accepted values: true/false, yes/no, on/off, 1/0.
 # hwp_dynamic_boost = true
 
 # EPB (Energy Performance Bias) for the intel_pstate driver
@@ -419,6 +421,8 @@ turbo = always
 
 # Intel HWP Dynamic Boost.
 # Only available with intel_pstate in active mode and HWP enabled.
+# Alters value in: /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
+# Accepted values: true/false, yes/no, on/off, 1/0.
 # hwp_dynamic_boost = false
 
 # EPB (Energy Performance Bias) for the intel_pstate driver

--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = balance_performance
 
+# Intel HWP Dynamic Boost.
+# Only available with intel_pstate in active mode and HWP enabled.
+# hwp_dynamic_boost = true
+
 # EPB (Energy Performance Bias) for the intel_pstate driver
 # see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
 # available EPB options include a numeric value between 0-15
@@ -412,6 +416,10 @@ turbo = always
 
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 #energy_performance_preference = balance_power
+
+# Intel HWP Dynamic Boost.
+# Only available with intel_pstate in active mode and HWP enabled.
+# hwp_dynamic_boost = false
 
 # EPB (Energy Performance Bias) for the intel_pstate driver
 # see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -7,6 +7,11 @@ governor = performance
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = performance
 
+# Intel HWP dynamic boost.
+# Only available with intel_pstate in active mode and HWP enabled.
+# Accepted values: true/false, yes/no, on/off, 1/0.
+# hwp_dynamic_boost = true
+
 # EPB (Energy Performance Bias) for the intel_pstate driver
 # see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
 # available EPB options include a numeric value between 0-15
@@ -66,6 +71,11 @@ governor = powersave
 
 # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
 energy_performance_preference = power
+
+# Intel HWP dynamic boost.
+# Only available with intel_pstate in active mode and HWP enabled.
+# Accepted values: true/false, yes/no, on/off, 1/0.
+# hwp_dynamic_boost = false
 
 # EPB (Energy Performance Bias) for the intel_pstate driver
 # see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -9,6 +9,7 @@ energy_performance_preference = performance
 
 # Intel HWP dynamic boost.
 # Only available with intel_pstate in active mode and HWP enabled.
+# Alters value in: /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
 # Accepted values: true/false, yes/no, on/off, 1/0.
 # hwp_dynamic_boost = true
 
@@ -74,6 +75,7 @@ energy_performance_preference = power
 
 # Intel HWP dynamic boost.
 # Only available with intel_pstate in active mode and HWP enabled.
+# Alters value in: /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
 # Accepted values: true/false, yes/no, on/off, 1/0.
 # hwp_dynamic_boost = false
 

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -10,6 +10,10 @@ services.auto-cpufreq.settings = {
     # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
     energy_performance_preference = "performance";
 
+    # Intel HWP Dynamic Boost.
+    # Only available with intel_pstate in active mode and HWP enabled.
+    # hwp_dynamic_boost = true;
+
     # EPB (Energy Performance Bias) for the intel_pstate driver
     # see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html
     # available EPB options include a numeric value between 0-15
@@ -68,6 +72,10 @@ services.auto-cpufreq.settings = {
 
     # EPP: see available preferences by running: cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_available_preferences
     energy_performance_preference = "power";
+
+    # Intel HWP Dynamic Boost.
+    # Only available with intel_pstate in active mode and HWP enabled.
+    # hwp_dynamic_boost = false;
 
     # EPB (Energy Performance Bias) for the intel_pstate driver
     # see conversion info: https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -12,6 +12,7 @@ services.auto-cpufreq.settings = {
 
     # Intel HWP Dynamic Boost.
     # Only available with intel_pstate in active mode and HWP enabled.
+    # Alters value in: /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
     # hwp_dynamic_boost = true;
 
     # EPB (Energy Performance Bias) for the intel_pstate driver
@@ -75,6 +76,7 @@ services.auto-cpufreq.settings = {
 
     # Intel HWP Dynamic Boost.
     # Only available with intel_pstate in active mode and HWP enabled.
+    # Alters value in: /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost
     # hwp_dynamic_boost = false;
 
     # EPB (Energy Performance Bias) for the intel_pstate driver

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -598,18 +598,33 @@ def get_configured_hwp_dynamic_boost(conf, profile):
         return None
 
 
+def get_hwp_dynamic_boost():
+    """Return the current HWP Dynamic Boost state, or None if unavailable."""
+    try:
+        value = HWP_DYNAMIC_BOOST_PATH.read_text().strip()
+    except OSError:
+        return None
+
+    if value == "1":
+        return True
+    if value == "0":
+        return False
+    return None
+
+
 def set_hwp_dynamic_boost(enabled):
     if not HWP_DYNAMIC_BOOST_PATH.exists():
         print("Not setting HWP dynamic boost (not supported by system)")
         return
 
+    current_value = get_hwp_dynamic_boost()
+    if current_value == enabled:
+        return
+
     value = "1" if enabled else "0"
 
     try:
-        if HWP_DYNAMIC_BOOST_PATH.read_text().strip() == value:
-            return
-
-        HWP_DYNAMIC_BOOST_PATH.write_text(value)
+        HWP_DYNAMIC_BOOST_PATH.write_text(f"{value}\n")
     except OSError as error:
         print(f"Failed to set HWP dynamic boost to {value}: {error}")
         return
@@ -631,12 +646,7 @@ def set_powersave():
     if Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists() is False:
         print('Not setting EPP (not supported by system)')
     else:
-        dynboost_enabled = Path("/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").exists()
-
-        if dynboost_enabled:
-            dynboost_enabled = bool(int(
-                os.popen("cat /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").read()
-            ))
+        dynboost_enabled = get_hwp_dynamic_boost()
 
         if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
         else:
@@ -722,12 +732,7 @@ def set_performance():
         print('Not setting EPP (not supported by system)')
     else:
         if Path("/sys/devices/system/cpu/intel_pstate").exists():
-            dynboost_enabled = Path("/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").exists()
-
-            if dynboost_enabled:
-                dynboost_enabled = bool(int(
-                    os.popen("cat /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").read()
-                ))
+            dynboost_enabled = get_hwp_dynamic_boost()
 
             if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
             else:

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -578,12 +578,55 @@ def set_energy_perf_bias(conf, profile):
     print(f'Setting to use: "{epb}" EPB')
 
 
+HWP_DYNAMIC_BOOST_PATH = Path(
+    "/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost"
+)
+
+
+def get_configured_hwp_dynamic_boost(conf, profile):
+    if not conf.has_option(profile, "hwp_dynamic_boost"):
+        return None
+
+    try:
+        return conf.getboolean(profile, "hwp_dynamic_boost")
+    except ValueError:
+        raw_value = conf[profile].get("hwp_dynamic_boost", "")
+        print(
+            f'Invalid boolean value for "hwp_dynamic_boost" '
+            f'in [{profile}]: {raw_value!r}. Ignoring setting.'
+        )
+        return None
+
+
+def set_hwp_dynamic_boost(enabled):
+    if not HWP_DYNAMIC_BOOST_PATH.exists():
+        print("Not setting HWP dynamic boost (not supported by system)")
+        return
+
+    value = "1" if enabled else "0"
+
+    try:
+        if HWP_DYNAMIC_BOOST_PATH.read_text().strip() == value:
+            return
+
+        HWP_DYNAMIC_BOOST_PATH.write_text(value)
+    except OSError as error:
+        print(f"Failed to set HWP dynamic boost to {value}: {error}")
+        return
+
+    print(f"Setting HWP dynamic boost to: {value}")
+
+
 def set_powersave():
     conf = config.get_config()
     gov = conf["battery"]["governor"] if conf.has_option("battery", "governor") else AVAILABLE_GOVERNORS_SORTED[-1]
     print(f'Setting to use: "{gov}" governor')
     if get_override() != "default": print("Warning: governor overwritten using `--force` flag.")
     run(f"cpufreqctl.auto-cpufreq --governor --set={gov}", shell=True)
+
+    configured_dynboost = get_configured_hwp_dynamic_boost(conf, "battery")
+    if configured_dynboost is False:
+        set_hwp_dynamic_boost(False)
 
     if Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists() is False:
         print('Not setting EPP (not supported by system)')
@@ -595,7 +638,7 @@ def set_powersave():
                 os.popen("cat /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").read()
             ))
 
-        if dynboost_enabled: print('Not setting EPP (dynamic boosting is enabled)')
+        if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
         else:
             if conf.has_option("battery", "energy_performance_preference"):
                 epp = conf["battery"]["energy_performance_preference"]
@@ -604,6 +647,9 @@ def set_powersave():
             else:
                 run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
                 print('Setting to use: "balance_power" EPP')
+
+    if configured_dynboost is True:
+        set_hwp_dynamic_boost(True)
 
     set_energy_perf_bias(conf, "battery")
     set_platform_profile(conf, "battery")
@@ -668,6 +714,10 @@ def set_performance():
     if get_override() != "default": print("Warning: governor overwritten using `--force` flag.")
     run("cpufreqctl.auto-cpufreq --governor --set="+gov, shell=True)
 
+    configured_dynboost = get_configured_hwp_dynamic_boost(conf, "charger")
+    if configured_dynboost is False:
+        set_hwp_dynamic_boost(False)
+
     if not Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists():
         print('Not setting EPP (not supported by system)')
     else:
@@ -679,7 +729,7 @@ def set_performance():
                     os.popen("cat /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost").read()
                 ))
 
-            if dynboost_enabled: print('Not setting EPP (dynamic boosting is enabled)')
+            if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
             else:
                 intel_pstate_status_path = "/sys/devices/system/cpu/intel_pstate/status"
 
@@ -720,6 +770,9 @@ def set_performance():
                 else:
                     run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
                     print('Setting to use: "balance_performance" EPP')
+
+    if configured_dynboost is True:
+        set_hwp_dynamic_boost(True)
     
     set_energy_perf_bias(conf, "charger")
     set_platform_profile(conf, "charger")

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -8,7 +8,10 @@ import psutil
 import distro
 from pathlib import Path
 from auto_cpufreq.config.config import config
-from auto_cpufreq.core import get_power_supply_ignore_list
+from auto_cpufreq.core import (
+    get_hwp_dynamic_boost,
+    get_power_supply_ignore_list,
+)
 from auto_cpufreq.globals import (
     AVAILABLE_GOVERNORS_SORTED,
     CPU_TEMP_SENSOR_PRIORITY,
@@ -54,6 +57,7 @@ class SystemReport:
     current_gov: str | None
     current_epp: str | None
     current_epb: str | None
+    current_hwp_dynamic_boost: bool | None
     cpu_driver: str
     cpu_fan_speed: int | None
     cpu_usage: float
@@ -363,6 +367,7 @@ class SystemInfo:
             current_gov=self.current_gov(),
             current_epp=self.current_epp(battery_info.is_ac_plugged),
             current_epb=self.current_epb(battery_info.is_ac_plugged),
+            current_hwp_dynamic_boost=get_hwp_dynamic_boost(),
             cpu_fan_speed=self.cpu_fan_speed(),
             cpu_usage=self.cpu_usage(),
             cpu_max_freq=self.cpu_max_freq(),

--- a/auto_cpufreq/modules/system_monitor.py
+++ b/auto_cpufreq/modules/system_monitor.py
@@ -223,6 +223,13 @@ class SystemMonitor:
                 aligned_text("Not setting EPP (not supported by system)")
             )
 
+        if report.current_hwp_dynamic_boost is not None:
+            self.right_content.append(
+                aligned_text(
+                    f"Intel HWP Dynamic Boost: {'on' if report.current_hwp_dynamic_boost else 'off'}"
+                )
+            )
+
         if report.current_epb:
             self.right_content.append(
                 aligned_text(f'Setting to use: "{report.current_epb}" EPB')


### PR DESCRIPTION
## Summary

Adds optional configuration support for Intel HWP Dynamic Boost through
`hwp_dynamic_boost` in the `[charger]` and `[battery]` sections.

Example:

```ini
[charger]
hwp_dynamic_boost = true

[battery]
hwp_dynamic_boost = false
```

## Behavior

* If `hwp_dynamic_boost` is not configured, the existing behavior is preserved.
* If explicitly configured, auto-cpufreq manages
  `/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost`.
* When disabling Dynamic Boost, it is disabled before applying EPP.
* When enabling Dynamic Boost, EPP is applied first and Dynamic Boost is enabled afterwards.
* The sysfs value is only written when a state change is required.
* Invalid boolean values produce a warning and the setting is ignored.
* If the sysfs attribute is unavailable, the setting is ignored.
* On supported hardware, the current HWP Dynamic Boost state is shown in
  `--stats`, `--live`, and `--monitor`.

When Dynamic Boost is explicitly configured, auto-cpufreq also applies the
configured EPP instead of skipping EPP solely because Dynamic Boost is
currently enabled.

## Configuration

Accepted boolean values are those supported by Python's ConfigParser:

* `true` / `false`
* `yes` / `no`
* `on` / `off`
* `1` / `0`

The standard configuration example, README example, and Nix configuration
example have been updated accordingly.

## Testing

Tested on an Intel Core i3-1315U with `intel_pstate` in active/HWP mode.

Verified:

* Python syntax with `py_compile`
* clean `git diff --check`
* daemon startup
* charger → battery → charger transitions
* configured EPP applied correctly across power-source changes
* configured HWP Dynamic Boost state applied correctly across power-source changes
* existing configured Turbo behavior remained unchanged
* invalid boolean values fall back without terminating the process
* all documented boolean forms are parsed correctly
* HWP Dynamic Boost status display in charger and battery states

The feature is opt-in and does not change the current default behavior.