### PR TITLE
Fix GTK config initialization

### DIFF
--- a/auto_cpufreq/bin/auto_cpufreq_gtk.py
+++ b/auto_cpufreq/bin/auto_cpufreq_gtk.py
@@ -3,9 +3,11 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
 
+from auto_cpufreq.config.config import config, find_config_file
 from auto_cpufreq.gui.app import ToolWindow
 
 def main():
+    config.set_path(find_config_file(None))
     GLib.set_prgname("auto-cpufreq-gtk")
     win = ToolWindow()
     win.connect("destroy", Gtk.main_quit)


### PR DESCRIPTION
## Summary

Fix the GTK frontend so it loads the auto-cpufreq configuration before
constructing the window.

The GUI currently creates `ToolWindow()` without first calling the same
`find_config_file()` / `config.set_path()` initialization used by the CLI.
As a result, `SystemInfo.current_epp()` and `current_epb()` read from an
empty `ConfigParser` and can display the AC/battery fallback values instead
of values from the user's configuration.

This change initializes the config in the GTK entrypoint before creating
the window.

## Validation

Tested on Linux Mint 22.3 with an Intel Core i3-1315U.

Validation covered:

- GTK initialization order: config resolution and `set_path()` happen before
  `ToolWindow()` creation;
- user config precedence through `$XDG_CONFIG_HOME`;
- fallback to `/etc/auto-cpufreq.conf` when no user config exists;
- `SystemInfo.current_epp()` / `current_epb()` returning non-default values
  from a temporary config;
- real GTK rendering showing `EPP setting: performance` and
  `Setting to use: "power" EPB` from that temporary config;
- `py_compile` and `git diff --check`.

The change is limited to two added lines in the GTK entrypoint and does not
alter EPP/EPB application logic or sysfs writes.

Fixes #934