### PR TITLE
Fix: skip EPP writes when intel_pstate performance governor controls EPP

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -582,6 +582,17 @@ HWP_DYNAMIC_BOOST_PATH = Path(
     "/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost"
 )
 
+INTEL_PSTATE_STATUS_PATH = Path(
+    "/sys/devices/system/cpu/intel_pstate/status"
+)
+
+
+def intel_pstate_active():
+    try:
+        return INTEL_PSTATE_STATUS_PATH.read_text().strip() == "active"
+    except OSError:
+        return False
+
 
 def get_configured_hwp_dynamic_boost(conf, profile):
     if not conf.has_option(profile, "hwp_dynamic_boost"):
@@ -637,7 +648,18 @@ def set_powersave():
     gov = conf["battery"]["governor"] if conf.has_option("battery", "governor") else AVAILABLE_GOVERNORS_SORTED[-1]
     print(f'Setting to use: "{gov}" governor')
     if get_override() != "default": print("Warning: governor overwritten using `--force` flag.")
-    run(f"cpufreqctl.auto-cpufreq --governor --set={gov}", shell=True)
+    try:
+        result = run(
+            ["cpufreqctl.auto-cpufreq", "--governor", f"--set={gov}"]
+        )
+    except OSError as error:
+        print(f'Failed to set "{gov}" governor: {error}')
+        footer()
+        return
+    if result.returncode != 0:
+        print(f'Failed to set "{gov}" governor')
+        footer()
+        return
 
     configured_dynboost = get_configured_hwp_dynamic_boost(conf, "battery")
     if configured_dynboost is False:
@@ -647,8 +669,11 @@ def set_powersave():
         print('Not setting EPP (not supported by system)')
     else:
         dynboost_enabled = get_hwp_dynamic_boost()
+        pstate_active = intel_pstate_active()
 
         if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
+        elif pstate_active and gov == "performance":
+            print('Not setting EPP (intel_pstate performance governor controls EPP as "performance")')
         else:
             if conf.has_option("battery", "energy_performance_preference"):
                 epp = conf["battery"]["energy_performance_preference"]
@@ -722,7 +747,18 @@ def set_performance():
 
     print(f'Setting to use: "{gov}" governor')
     if get_override() != "default": print("Warning: governor overwritten using `--force` flag.")
-    run("cpufreqctl.auto-cpufreq --governor --set="+gov, shell=True)
+    try:
+        result = run(
+            ["cpufreqctl.auto-cpufreq", "--governor", f"--set={gov}"]
+        )
+    except OSError as error:
+        print(f'Failed to set "{gov}" governor: {error}')
+        footer()
+        return
+    if result.returncode != 0:
+        print(f'Failed to set "{gov}" governor')
+        footer()
+        return
 
     configured_dynboost = get_configured_hwp_dynamic_boost(conf, "charger")
     if configured_dynboost is False:
@@ -733,23 +769,19 @@ def set_performance():
     else:
         if Path("/sys/devices/system/cpu/intel_pstate").exists():
             dynboost_enabled = get_hwp_dynamic_boost()
+            pstate_active = intel_pstate_active()
 
             if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
+            elif pstate_active and gov == "performance":
+                print('Not setting EPP (intel_pstate performance governor controls EPP as "performance")')
             else:
-                intel_pstate_status_path = "/sys/devices/system/cpu/intel_pstate/status"
-
                 if conf.has_option("charger", "energy_performance_preference"):
                     epp = conf["charger"]["energy_performance_preference"]
-
-                    if Path(intel_pstate_status_path).exists() and open(intel_pstate_status_path, 'r').read().strip() == "active" and epp != "performance" and gov == "performance":
-                        print(f'Warning "{epp}" EPP cannot be used in performance governor')
-                        print('Overriding EPP to "performance"')
-                        epp = "performance"
 
                     run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
                     print(f'Setting to use: "{epp}" EPP')
                 else:
-                    if Path(intel_pstate_status_path).exists() and open(intel_pstate_status_path, 'r').read().strip() == "active":
+                    if pstate_active:
                         run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
                         print('Setting to use: "performance" EPP')
                     else:


### PR DESCRIPTION
## Summary

When `intel_pstate` is running in active mode with EPP available and the `performance` governor selected, the kernel controls EPP as `performance` and rejects incompatible EPP values.

auto-cpufreq currently performs an additional EPP write after selecting the governor. This PR skips that write and lets `intel_pstate` keep control of EPP in this specific state.

## Problem

With active `intel_pstate`, selecting the `performance` governor causes the driver to force EPP to `performance`.

Trying to set another EPP value afterwards is rejected by the kernel. Writing `performance` again succeeds but is unnecessary, since the driver has already selected it.

This means auto-cpufreq is trying to manage a value that is already
controlled by `intel_pstate` while the performance governor is active.

## Changes

Detect whether `intel_pstate` is in `active` mode.

When the `performance` governor is successfully selected, skip the additional EPP write and report:

    Not setting EPP (intel_pstate performance governor controls EPP as "performance")

Governor changes are now checked before making subsequent EPP decisions. If the governor write fails, profile application stops instead of continuing under the assumption that the requested governor was successfully applied.

Aside from this governor failure handling, all other paths keep their current behavior:

- `powersave` continues to apply the configured EPP
- passive/non-active `intel_pstate` continues to use the existing EPP logic
- AMD handling is unchanged
- unsupported systems are unchanged
- HWP Dynamic Boost handling is unchanged

## Validation

Tested on an Intel Core i3-1315U with `intel_pstate` active and EPP available.

The relevant behavior was reproduced on hardware: after selecting the `performance` governor, the driver reported EPP as `performance` without requiring a separate EPP write.

The standalone change was also tested with a command-capture harness that performs no sysfs writes:

```
PASS: active intel_pstate + performance skips EPP write
PASS: powersave still writes configured EPP
PASS: non-active intel_pstate preserves EPP handling
PASS: battery governor failure stops profile application
PASS: charger governor failure stops profile application
PASS: successful governor writes continue profile application
```

Additional checks:

```
py_compile: PASS
diff-check: PASS
```

Related: #958
