### PR TITLE
Enable Intel HWP Dynamic Boost by default on AC power

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Example of `auto-cpufreq --stats` CLI output
   - [stats](#stats)
   - [bluetooth_boot_off](#bluetooth_boot_off)
   - [bluetooth_boot_on](#bluetooth_boot_on)
+- [Intel HWP Dynamic Boost](#intel-hwp-dynamic-boost)
 - [Battery charging thresholds](#battery-charging-thresholds)
   - [Supported Devices](#supported-devices)
   - [Battery config](#battery-config)
@@ -624,6 +625,14 @@ It prevents GNOME from automatically enabling Bluetooth on every reboot or after
 ### bluetooth_boot_on
 
 Useful if you prefer Bluetooth to be enabled at boot time, especially after installing the auto-cpufreq daemon, which will disable it by default.
+
+## Intel HWP Dynamic Boost
+
+On typical non-server Intel systems, the Linux `intel_pstate` driver starts HWP Dynamic Boost disabled. When `hwp_dynamic_boost` is not explicitly configured, auto-cpufreq keeps it disabled on battery power and enables it on AC/charger power on supported systems. Current upstream kernels may enable Dynamic Boost automatically on systems using the ACPI Enterprise Server or Performance Server profiles.
+
+Dynamic Boost is detected through `/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost`; systems that do not expose this interface are left unchanged.
+
+When disabling Dynamic Boost, auto-cpufreq applies that state before changing EPP. When enabling Dynamic Boost, EPP is applied first. To override the default policy, configure `hwp_dynamic_boost` in the charger and/or battery profiles; see [4: auto-cpufreq config file](#4-auto-cpufreq-config-file).
 
 ## Battery charging thresholds
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -798,7 +798,13 @@ def get_configured_hwp_dynamic_boost(conf, profile):
 def get_hwp_dynamic_boost_target(conf, profile):
     if conf.has_option(profile, "hwp_dynamic_boost"):
         configured = get_configured_hwp_dynamic_boost(conf, profile)
-        if configured is None or not HWP_DYNAMIC_BOOST_PATH.exists():
+        if configured is None:
+            return None
+        if not HWP_DYNAMIC_BOOST_PATH.exists():
+            print(
+                f'Not setting HWP dynamic boost for [{profile}] '
+                '(not supported by system)'
+            )
             return None
         return configured
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -826,6 +826,19 @@ def get_configured_hwp_dynamic_boost(conf, profile):
         return None
 
 
+def get_hwp_dynamic_boost_target(conf, profile):
+    if conf.has_option(profile, "hwp_dynamic_boost"):
+        configured = get_configured_hwp_dynamic_boost(conf, profile)
+        if configured is None or not HWP_DYNAMIC_BOOST_PATH.exists():
+            return None
+        return configured
+
+    if not HWP_DYNAMIC_BOOST_PATH.exists():
+        return None
+
+    return profile == "charger"
+
+
 def get_hwp_dynamic_boost():
     """Return the current HWP Dynamic Boost state, or None if unavailable."""
     try:
@@ -843,11 +856,11 @@ def get_hwp_dynamic_boost():
 def set_hwp_dynamic_boost(enabled):
     if not HWP_DYNAMIC_BOOST_PATH.exists():
         print("Not setting HWP dynamic boost (not supported by system)")
-        return
+        return False
 
     current_value = get_hwp_dynamic_boost()
     if current_value == enabled:
-        return
+        return True
 
     value = "1" if enabled else "0"
 
@@ -855,9 +868,14 @@ def set_hwp_dynamic_boost(enabled):
         HWP_DYNAMIC_BOOST_PATH.write_text(f"{value}\n")
     except OSError as error:
         print(f"Failed to set HWP dynamic boost to {value}: {error}")
-        return
+        return False
+
+    if get_hwp_dynamic_boost() != enabled:
+        print(f"Failed to verify HWP dynamic boost state after setting to {value}")
+        return False
 
     print(f"Setting HWP dynamic boost to: {value}")
+    return True
 
 
 def set_powersave():
@@ -878,9 +896,10 @@ def set_powersave():
         footer()
         return
 
-    configured_dynboost = get_configured_hwp_dynamic_boost(conf, "battery")
-    if configured_dynboost is False:
-        set_hwp_dynamic_boost(False)
+    target_dynboost = get_hwp_dynamic_boost_target(conf, "battery")
+    hwp_disable_failed = False
+    if target_dynboost is False and HWP_DYNAMIC_BOOST_PATH.exists():
+        hwp_disable_failed = not set_hwp_dynamic_boost(False)
 
     if Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists() is False:
         print('Not setting EPP (not supported by system)')
@@ -888,7 +907,9 @@ def set_powersave():
         dynboost_enabled = get_hwp_dynamic_boost()
         pstate_active = intel_pstate_active()
 
-        if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
+        if hwp_disable_failed:
+            print('Not setting EPP (HWP dynamic boost could not be disabled)')
+        elif dynboost_enabled and target_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
         elif pstate_active and gov == "performance":
             print('Not setting EPP (intel_pstate performance governor controls EPP as "performance")')
         else:
@@ -898,7 +919,7 @@ def set_powersave():
             else:
                 set_energy_perf_preference("balance_power")
 
-    if configured_dynboost is True:
+    if target_dynboost is True:
         set_hwp_dynamic_boost(True)
 
     set_energy_perf_bias(conf, "battery")
@@ -975,9 +996,10 @@ def set_performance():
         footer()
         return
 
-    configured_dynboost = get_configured_hwp_dynamic_boost(conf, "charger")
-    if configured_dynboost is False:
-        set_hwp_dynamic_boost(False)
+    target_dynboost = get_hwp_dynamic_boost_target(conf, "charger")
+    hwp_disable_failed = False
+    if target_dynboost is False and HWP_DYNAMIC_BOOST_PATH.exists():
+        hwp_disable_failed = not set_hwp_dynamic_boost(False)
 
     if not Path("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference").exists():
         print('Not setting EPP (not supported by system)')
@@ -986,7 +1008,9 @@ def set_performance():
             dynboost_enabled = get_hwp_dynamic_boost()
             pstate_active = intel_pstate_active()
 
-            if dynboost_enabled and configured_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
+            if hwp_disable_failed:
+                print('Not setting EPP (HWP dynamic boost could not be disabled)')
+            elif dynboost_enabled and target_dynboost is None: print('Not setting EPP (dynamic boosting is enabled)')
             elif pstate_active and gov == "performance":
                 print('Not setting EPP (intel_pstate performance governor controls EPP as "performance")')
             else:
@@ -1016,7 +1040,7 @@ def set_performance():
                 else:
                     set_energy_perf_preference("balance_performance")
 
-    if configured_dynboost is True:
+    if target_dynboost is True:
         set_hwp_dynamic_boost(True)
     
     set_energy_perf_bias(conf, "charger")

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -313,9 +313,14 @@ class CPUFreqScalingBox(Gtk.Box):
         self.epb_label.set_halign(Gtk.Align.START)
         self.epb_label.set_no_show_all(True)
 
+        self.hwp_dynamic_boost_label = Gtk.Label(label="")
+        self.hwp_dynamic_boost_label.set_halign(Gtk.Align.START)
+        self.hwp_dynamic_boost_label.set_no_show_all(True)
+
         self.pack_start(self.header, False, False, 0)
         self.pack_start(self.epp_label, False, False, 0)
         self.pack_start(self.epb_label, False, False, 0)
+        self.pack_start(self.hwp_dynamic_boost_label, False, False, 0)
 
         self.refresh()
 
@@ -336,9 +341,19 @@ class CPUFreqScalingBox(Gtk.Box):
             else:
                 self.epb_label.hide()
 
+            if report.current_hwp_dynamic_boost is not None:
+                state = "on" if report.current_hwp_dynamic_boost else "off"
+                self.hwp_dynamic_boost_label.set_label(
+                    f"Intel HWP Dynamic Boost: {state}"
+                )
+                self.hwp_dynamic_boost_label.show()
+            else:
+                self.hwp_dynamic_boost_label.hide()
+
         except Exception:
             self.epp_label.set_label("Current EPP: Unknown")
             self.epb_label.hide()
+            self.hwp_dynamic_boost_label.hide()
 
 class SystemStatisticsBox(Gtk.Box):
     def __init__(self):
@@ -750,6 +765,15 @@ class MonitorModeView(Gtk.Box):
 
         if report.current_epb:
             self.right_box.pack_start(self._label(f"Current EPB: {report.current_epb}"), False, False, 0)
+
+        if report.current_hwp_dynamic_boost is not None:
+            state = "on" if report.current_hwp_dynamic_boost else "off"
+            self.right_box.pack_start(
+                self._label(f"Intel HWP Dynamic Boost: {state}"),
+                False,
+                False,
+                0,
+            )
 
         self.right_box.pack_start(self._label(""), False, False, 0)
 


### PR DESCRIPTION
## Summary

On typical non-server systems, the upstream `intel_pstate` driver starts HWP Dynamic Boost disabled while exposing the feature for userspace control. When enabled, Dynamic Boost can temporarily raise the minimum P-state for tasks waking after I/O, a mechanism intended by the kernel to improve performance during those short bursts.

This follow-up makes auto-cpufreq use that capability by default on supported systems when no explicit configuration is provided:

- AC power: enabled
- Battery: disabled

Explicit `hwp_dynamic_boost` configuration continues to take precedence.

This is a follow-up to #954, which added explicit configuration support for Intel HWP Dynamic Boost while intentionally preserving the existing default behavior.

## Behavior

When the system exposes Intel HWP Dynamic Boost and the user has not configured it explicitly, auto-cpufreq now applies the following default policy:

- AC power: `hwp_dynamic_boost = true`
- Battery: `hwp_dynamic_boost = false`

Explicit configuration always takes precedence.

For example:

```ini
[charger]
hwp_dynamic_boost = false

[battery]
hwp_dynamic_boost = true
```

continues to override the automatic defaults.

If an explicit value is invalid, auto-cpufreq warns about it and leaves HWP Dynamic Boost unmanaged rather than silently falling back to the automatic policy.

Systems that do not expose the HWP Dynamic Boost sysfs attribute remain unchanged.

Systems without a battery continue to follow auto-cpufreq's AC/charger profile, so HWP Dynamic Boost defaults to enabled when the feature is supported.

## Motivation

During the review of #954, enabling HWP Dynamic Boost by default on supported hardware was suggested as a follow-up, particularly while the system is on AC power.

#954 intentionally kept the existing default behavior unchanged and added only explicit configuration support. This follow-up introduces the default policy separately, keeping the configuration mechanism and the policy change as independent changes.

On typical non-server systems, the upstream `intel_pstate` driver starts HWP Dynamic Boost disabled. Current upstream kernels enable it automatically for ACPI Enterprise Server and Performance Server profiles, but it otherwise remains disabled unless userspace enables it.

When enabled, HWP Dynamic Boost allows `intel_pstate` to temporarily raise the minimum P-state when a task wakes after waiting on I/O. The kernel documentation describes this mechanism as intended to improve performance, making it useful for responsiveness during short I/O-driven bursts.

Using power-source defaults gives auto-cpufreq a predictable policy without requiring users to configure the feature manually:

- AC power enables Dynamic Boost by default.
- Battery disables the additional dynamic minimum-P-state boost by default.

Users who prefer different behavior can override either profile through the configuration introduced in #954.

## Implementation

The existing HWP Dynamic Boost support from #954 is reused.

A small policy helper determines the target state:

- explicit valid config -> use the configured value
- explicit invalid config -> leave unmanaged
- no config + supported system + AC power -> enable
- no config + supported system + battery -> disable
- unsupported system -> leave unmanaged

Support continues to be detected through the kernel's `hwp_dynamic_boost` sysfs attribute rather than CPU model-specific checks.

The existing EPP ordering is preserved:

- Dynamic Boost is disabled before applying EPP when the target is `false`
- EPP is applied before Dynamic Boost is enabled when the target is `true`

This also makes AC/battery transitions deterministic: a Dynamic Boost state enabled automatically on AC power is disabled again when switching to the battery profile unless the user explicitly configured otherwise.

## Validation

Tested on an Intel Core i3-1315U with `intel_pstate` active and HWP Dynamic Boost available.

Policy tests:

```text
PASS: no config + AC power + supported -> True
PASS: no config + battery + supported -> False
PASS: explicit charger=false -> False
PASS: explicit battery=true -> True
PASS: explicit config + unsupported system -> warning + unmanaged
PASS: invalid explicit value remains unmanaged -> None
PASS: unsupported system remains unmanaged -> None

```

Integration/order tests:

```text
PASS: AC power default enables HWP after EPP
PASS: battery default disables HWP before EPP
PASS: explicit charger=false overrides default
PASS: explicit battery=true overrides default
```

Real hardware transition test:

```text
AC power -> HWP Dynamic Boost True
battery -> HWP Dynamic Boost False
AC power -> HWP Dynamic Boost True
```

The original HWP Dynamic Boost state was restored after testing and the auto-cpufreq service was restarted successfully.

Additional checks:

```text
py_compile: PASS
diff-check: PASS
```

Follow-up to #954.