### PR TITLE
Avoid shell expansion for configured power settings

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -560,7 +560,7 @@ def set_platform_profile(conf, profile):
         return
 
     print(f'Setting to use: "{pp}" Platform Profile')
-    result = run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
+    result = run(["cpufreqctl.auto-cpufreq", "--pp", f"--set={pp}"])
     if result.returncode != 0:
         print(f"Failed to set platform profile to {pp}")
         return
@@ -574,7 +574,7 @@ def set_energy_perf_bias(conf, profile):
     if conf.has_option(profile, "energy_perf_bias"):
         epb = conf[profile]["energy_perf_bias"]
 
-    run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
+    run(["cpufreqctl.auto-cpufreq", "--epb", f"--set={epb}"])
     print(f'Setting to use: "{epb}" EPB')
 
 
@@ -652,7 +652,7 @@ def set_powersave():
         else:
             if conf.has_option("battery", "energy_performance_preference"):
                 epp = conf["battery"]["energy_performance_preference"]
-                run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
+                run(["cpufreqctl.auto-cpufreq", "--epp", f"--set={epp}"])
                 print(f'Setting to use: "{epp}" EPP')
             else:
                 run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
@@ -746,7 +746,7 @@ def set_performance():
                         print('Overriding EPP to "performance"')
                         epp = "performance"
 
-                    run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
+                    run(["cpufreqctl.auto-cpufreq", "--epp", f"--set={epp}"])
                     print(f'Setting to use: "{epp}" EPP')
                 else:
                     if Path(intel_pstate_status_path).exists() and open(intel_pstate_status_path, 'r').read().strip() == "active":
@@ -766,7 +766,7 @@ def set_performance():
                     print('Overriding EPP to "performance"')
                     epp = "performance"
 
-                run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
+                run(["cpufreqctl.auto-cpufreq", "--epp", f"--set={epp}"])
                 print(f'Setting to use: "{epp}" EPP')
             else:
                 if Path(amd_pstate_status_path).exists() and open(amd_pstate_status_path, 'r').read().strip() == "active":


### PR DESCRIPTION
## Summary

Avoid passing configuration-derived power settings through `shell=True`.

Platform Profile, Energy Performance Bias (EPB), and EPP values can be provided through `auto-cpufreq.conf`. These values were previously interpolated directly into shell command strings before being passed to `cpufreqctl.auto-cpufreq`.

This change passes the configuration-derived values as separate `argv` elements instead, ensuring they are treated as literal arguments rather than shell syntax.

## Problem

Some power settings were being read directly from the configuration file and passed to shell commands like:

```
run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
```
If a configuration value contained shell metacharacters, the shell could interpret part of that value as shell syntax instead of treating it as a literal configuration value.

This is particularly relevant because `auto-cpufreq` commonly runs with elevated privileges.

## Changes

Convert the remaining configuration-derived writes in `auto_cpufreq/core.py` to `argv`-based subprocess calls:

* Platform Profile
* Energy Performance Bias (EPB)
* Battery EPP
* Intel charger EPP
* AMD charger EPP

For example:

```python
run([
    "cpufreqctl.auto-cpufreq",
    "--epp",
    f"--set={epp}",
])
```

instead of constructing a command string and passing it with `shell=True`.

Static commands and values that are not derived from user configuration are intentionally left unchanged to keep this PR narrowly scoped.

Governor handling is also intentionally not duplicated here. The same issue for the configured governor is already addressed in #959, where the governor write also requires return-code handling before subsequent EPP/HWP decisions.

## Validation

Each affected configuration-derived path was tested with values containing shell syntax, such as:

```text
; touch /tmp/...
```

In every case, the configured value remained a single `argv` element and no shell payload was executed.

Tested paths:

* [x] Platform Profile cannot be interpreted as shell syntax
* [x] Energy Performance Bias cannot be interpreted as shell syntax
* [x] Battery EPP cannot be interpreted as shell syntax
* [x] Intel charger EPP cannot be interpreted as shell syntax
* [x] AMD charger EPP cannot be interpreted as shell syntax

I also verified on real hardware that `cpufreqctl.auto-cpufreq` accepts `argv`-based invocation for the corresponding options.


Additional checks:

* `compileall`: PASS
* `diff-check`: PASS

The change was also tested together with #959 and #960, including real governor/EPP/HWP transitions.

The original CPU state was restored after testing, and the `auto-cpufreq` service restarted successfully.

Related: #959
