### PR TITLE
Verify and report effective power and frequency settings

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -473,14 +473,101 @@ def get_load():
 
 def display_system_load_avg(): print(" (load average: {:.2f}, {:.2f}, {:.2f})".format(*os.getloadavg()))
 
+CPU_SYSFS_ROOT = Path("/sys/devices/system/cpu")
+EPB_TARGET_VALUES = {
+    "performance": "0",
+    "balance_performance": "4",
+    "default": "6",
+    "balance_power": "8",
+    "power": "15",
+}
+EPB_VALUE_NAMES = {value: name for name, value in EPB_TARGET_VALUES.items()}
+
+
+def get_cpu_setting_state(relative_path):
+    paths = list(CPU_SYSFS_ROOT.glob(f"cpu[0-9]*/{relative_path}"))
+    if not paths:
+        return None
+
+    values = set()
+    for path in paths:
+        try:
+            values.add(path.read_text().strip())
+        except OSError:
+            return None
+
+    if len(values) > 1:
+        return "mixed"
+    return values.pop()
+
+
+def normalize_epb_target(value):
+    value = str(value).strip()
+    if value.isdigit() and 0 <= int(value) <= 15:
+        return str(int(value))
+    return EPB_TARGET_VALUES.get(value)
+
+
+def format_epb_state(value):
+    if value is None:
+        return "unknown"
+    if value == "mixed":
+        return value
+    return EPB_VALUE_NAMES.get(value, value)
+
+
+def get_frequency_request_state(freq_type, target):
+    policy_paths = sorted((CPU_SYSFS_ROOT / "cpufreq").glob("policy[0-9]*"))
+    if not policy_paths:
+        policy_paths = sorted(CPU_SYSFS_ROOT.glob("cpu[0-9]*/cpufreq"))
+    if not policy_paths:
+        return None, []
+
+    values = []
+    in_effect = True
+
+    for policy in policy_paths:
+        try:
+            current = int((policy / freq_type).read_text().strip())
+            hw_min = int((policy / "cpuinfo_min_freq").read_text().strip())
+            hw_max = int((policy / "cpuinfo_max_freq").read_text().strip())
+
+            if freq_type == "scaling_max_freq":
+                expected = min(max(target, hw_min), hw_max)
+            else:
+                current_max = int(
+                    (policy / "scaling_max_freq").read_text().strip()
+                )
+                expected = min(max(target, hw_min), current_max)
+        except (OSError, ValueError):
+            return None, []
+
+        values.append(current)
+        if current != expected:
+            in_effect = False
+
+    return in_effect, values
+
+
+def format_frequency_effective(values):
+    if not values:
+        return "unknown"
+
+    minimum = round(min(values) / 1000)
+    maximum = round(max(values) / 1000)
+
+    if minimum == maximum:
+        return f"{minimum} MHz"
+    return f"{minimum}-{maximum} MHz across CPU policies"
+
+
 # set minimum and maximum CPU frequencies
 def set_frequencies(power_supply):
     """
-    Sets frequencies:
-     - if option is used in auto-cpufreq.conf: use configured value
-     - if option is disabled/no conf file used: set default frequencies
-    Frequency setting is validated on each run and only applied when needed
-    Caller passes the active profile ("battery" or "charger").
+    Set configured frequency limits.
+
+    Effective values are checked per CPUFreq policy because heterogeneous
+    policies may clamp the same request to different hardware limits.
     """
     frequency = {
         "scaling_max_freq": {
@@ -492,46 +579,117 @@ def set_frequencies(power_supply):
             "minmax": "minimum",
         },
     }
-    set_frequencies.max_limit = int(getoutput(f"cpufreqctl.auto-cpufreq --frequency-max-limit"))
-    set_frequencies.min_limit = int(getoutput(f"cpufreqctl.auto-cpufreq --frequency-min-limit"))
+
+    set_frequencies.max_limit = int(
+        getoutput("cpufreqctl.auto-cpufreq --frequency-max-limit")
+    )
+    set_frequencies.min_limit = int(
+        getoutput("cpufreqctl.auto-cpufreq --frequency-min-limit")
+    )
 
     conf = config.get_config()
+    targets = {}
 
-    for freq_type in frequency.keys():
-        if freq_type == "scaling_max_freq":
-            curr_freq = int(getoutput(f"cpufreqctl.auto-cpufreq --frequency-max"))
-            value = set_frequencies.max_limit
-        else:
-            curr_freq = int(getoutput(f"cpufreqctl.auto-cpufreq --frequency-min"))
-            value = set_frequencies.min_limit
+    for freq_type in frequency:
+        default = (
+            set_frequencies.max_limit
+            if freq_type == "scaling_max_freq"
+            else set_frequencies.min_limit
+        )
 
         try:
-            if conf.has_option(power_supply, freq_type):
-                raw_value = conf[power_supply][freq_type].strip()
-                frequency[freq_type]["value"] = int(raw_value)
-            else:
-                frequency[freq_type]["value"] = value
+            raw_value = (
+                conf[power_supply][freq_type].strip()
+                if conf.has_option(power_supply, freq_type)
+                else str(default)
+            )
+            target = int(raw_value)
         except ValueError:
             print(f"Invalid value for '{freq_type}': {raw_value}")
             exit(1)
 
-        if not set_frequencies.min_limit <= frequency[freq_type]["value"] <= set_frequencies.max_limit:
+        if not set_frequencies.min_limit <= target <= set_frequencies.max_limit:
             print(
-                f"Given value for '{freq_type}' is not within the allowed frequencies {set_frequencies.min_limit}-{set_frequencies.max_limit} kHz"
+                f"Given value for '{freq_type}' is not within the allowed "
+                f"frequencies {set_frequencies.min_limit}-"
+                f"{set_frequencies.max_limit} kHz"
             )
             exit(1)
 
-        if curr_freq == frequency[freq_type]["value"]: continue
+        targets[freq_type] = target
 
-        print(f'Setting {frequency[freq_type]["minmax"]} CPU frequency to {round(frequency[freq_type]["value"]/1000)} Mhz')
-        # set the frequency
-        run(f"cpufreqctl.auto-cpufreq {frequency[freq_type]['cmdargs']} --set={frequency[freq_type]['value']}", shell=True)
+    if targets["scaling_min_freq"] > targets["scaling_max_freq"]:
+        print(
+            "Given value for 'scaling_min_freq' "
+            f"({targets['scaling_min_freq']} kHz) exceeds "
+            "'scaling_max_freq' "
+            f"({targets['scaling_max_freq']} kHz)"
+        )
+        exit(1)
+
+    # Keep maximum before minimum. Lowering max may clamp the current minimum,
+    # while raising max first allows a higher requested minimum to be applied.
+    for freq_type, details in frequency.items():
+        target = targets[freq_type]
+        target_mhz = round(target / 1000)
+
+        in_effect, before = get_frequency_request_state(freq_type, target)
+        if in_effect is True:
+            if auto_cpufreq_stats_file is None:
+                print(
+                    f'{details["minmax"].capitalize()} CPU frequency request '
+                    f"{target_mhz} MHz already in effect "
+                    f"(effective: {format_frequency_effective(before)}, no change)"
+                )
+            continue
+
+        result = run([
+            "cpufreqctl.auto-cpufreq",
+            details["cmdargs"],
+            f"--set={target}",
+        ])
+
+        in_effect, after = get_frequency_request_state(freq_type, target)
+        effective = format_frequency_effective(after)
+
+        if in_effect is True:
+            if result.returncode != 0:
+                print(
+                    f'{details["minmax"].capitalize()} CPU frequency request '
+                    f"{target_mhz} MHz is in effect "
+                    f"(effective: {effective}, "
+                    f"cpufreqctl status: {result.returncode})"
+                )
+            elif before == after:
+                print(
+                    f'{details["minmax"].capitalize()} CPU frequency request '
+                    f"{target_mhz} MHz accepted "
+                    f"(effective: {effective}, no change)"
+                )
+            else:
+                print(
+                    f'Applied {details["minmax"]} CPU frequency request '
+                    f"{target_mhz} MHz (effective: {effective})"
+                )
+        elif result.returncode != 0:
+            print(
+                f'Failed to apply {details["minmax"]} CPU frequency request '
+                f"{target_mhz} MHz (effective: {effective}, "
+                f"cpufreqctl status: {result.returncode})"
+            )
+        else:
+            print(
+                f'{details["minmax"].capitalize()} CPU frequency request '
+                f"{target_mhz} MHz returned success, but the effective state "
+                f"could not be verified (current: {effective})"
+            )
 
 def set_platform_profile(conf, profile):
     if not conf.has_option(profile, "platform_profile"):
         return
 
-    if not Path("/sys/firmware/acpi/platform_profile").exists():
+    platform_profile_path = Path("/sys/firmware/acpi/platform_profile")
+    if not platform_profile_path.exists():
         print('Not setting Platform Profile (not supported by system)')
         return
 
@@ -559,12 +717,33 @@ def set_platform_profile(conf, profile):
     ):
         return
 
-    print(f'Setting to use: "{pp}" Platform Profile')
-    result = run(f"cpufreqctl.auto-cpufreq --pp --set={pp}", shell=True)
-    if result.returncode != 0:
-        print(f"Failed to set platform profile to {pp}")
+    try:
+        current = platform_profile_path.read_text().strip()
+    except OSError:
+        current = None
+
+    if current == pp:
+        print(f'Platform Profile already set to "{pp}" (no change)')
+        set_platform_profile.last_applied_platform_profile[profile] = pp
         return
-    set_platform_profile.last_applied_platform_profile[profile] = pp
+
+    result = run(["cpufreqctl.auto-cpufreq", "--pp", f"--set={pp}"])
+
+    try:
+        current = platform_profile_path.read_text().strip()
+    except OSError:
+        current = None
+
+    if current == pp:
+        print(f'Set Platform Profile to "{pp}"')
+        set_platform_profile.last_applied_platform_profile[profile] = pp
+        return
+
+    current_display = current if current is not None else "unknown"
+    print(
+        f'Failed to set Platform Profile to "{pp}" '
+        f'(current: "{current_display}", cpufreqctl status: {result.returncode})'
+    )
 
 def set_energy_perf_bias(conf, profile):
     if Path("/sys/devices/system/cpu/intel_pstate").exists() is False:
@@ -574,8 +753,46 @@ def set_energy_perf_bias(conf, profile):
     if conf.has_option(profile, "energy_perf_bias"):
         epb = conf[profile]["energy_perf_bias"]
 
-    run(f"cpufreqctl.auto-cpufreq --epb --set={epb}", shell=True)
-    print(f'Setting to use: "{epb}" EPB')
+    target = normalize_epb_target(epb)
+    current = get_cpu_setting_state("power/energy_perf_bias")
+
+    if target is not None and current == target:
+        print(f'EPB already set to "{epb}" (no change)')
+        return
+
+    result = run(["cpufreqctl.auto-cpufreq", "--epb", f"--set={epb}"])
+    current = get_cpu_setting_state("power/energy_perf_bias")
+
+    if target is not None and current == target:
+        print(f'Set EPB to "{epb}"')
+    else:
+        print(
+            f'Failed to set EPB to "{epb}" '
+            f'(current: "{format_epb_state(current)}", cpufreqctl status: {result.returncode})'
+        )
+
+
+def set_energy_perf_preference(epp):
+    current = get_cpu_setting_state("cpufreq/energy_performance_preference")
+
+    if epp != "default" and current == epp:
+        print(f'EPP already set to "{epp}" (no change)')
+        return
+
+    result = run(["cpufreqctl.auto-cpufreq", "--epp", f"--set={epp}"])
+    current = get_cpu_setting_state("cpufreq/energy_performance_preference")
+
+    if epp == "default" and result.returncode == 0:
+        current_display = current if current is not None else "unknown"
+        print(f'Set EPP to "default" (current: "{current_display}")')
+    elif current == epp:
+        print(f'Set EPP to "{epp}"')
+    else:
+        current_display = current if current is not None else "unknown"
+        print(
+            f'Failed to set EPP to "{epp}" '
+            f'(current: "{current_display}", cpufreqctl status: {result.returncode})'
+        )
 
 
 HWP_DYNAMIC_BOOST_PATH = Path(
@@ -652,11 +869,9 @@ def set_powersave():
         else:
             if conf.has_option("battery", "energy_performance_preference"):
                 epp = conf["battery"]["energy_performance_preference"]
-                run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
-                print(f'Setting to use: "{epp}" EPP')
+                set_energy_perf_preference(epp)
             else:
-                run("cpufreqctl.auto-cpufreq --epp --set=balance_power", shell=True)
-                print('Setting to use: "balance_power" EPP')
+                set_energy_perf_preference("balance_power")
 
     if configured_dynboost is True:
         set_hwp_dynamic_boost(True)
@@ -746,15 +961,12 @@ def set_performance():
                         print('Overriding EPP to "performance"')
                         epp = "performance"
 
-                    run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
-                    print(f'Setting to use: "{epp}" EPP')
+                    set_energy_perf_preference(epp)
                 else:
                     if Path(intel_pstate_status_path).exists() and open(intel_pstate_status_path, 'r').read().strip() == "active":
-                        run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
-                        print('Setting to use: "performance" EPP')
+                        set_energy_perf_preference("performance")
                     else:
-                        run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
-                        print('Setting to use: "balance_performance" EPP')
+                        set_energy_perf_preference("balance_performance")
         elif Path("/sys/devices/system/cpu/amd_pstate").exists():
             amd_pstate_status_path = "/sys/devices/system/cpu/amd_pstate/status"
 
@@ -766,15 +978,12 @@ def set_performance():
                     print('Overriding EPP to "performance"')
                     epp = "performance"
 
-                run(f"cpufreqctl.auto-cpufreq --epp --set={epp}", shell=True)
-                print(f'Setting to use: "{epp}" EPP')
+                set_energy_perf_preference(epp)
             else:
                 if Path(amd_pstate_status_path).exists() and open(amd_pstate_status_path, 'r').read().strip() == "active":
-                    run("cpufreqctl.auto-cpufreq --epp --set=performance", shell=True)
-                    print('Setting to use: "performance" EPP')
+                    set_energy_perf_preference("performance")
                 else:
-                    run("cpufreqctl.auto-cpufreq --epp --set=balance_performance", shell=True)
-                    print('Setting to use: "balance_performance" EPP')
+                    set_energy_perf_preference("balance_performance")
 
     if configured_dynboost is True:
         set_hwp_dynamic_boost(True)

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -306,9 +306,6 @@ class CPUFreqScalingBox(Gtk.Box):
         self.header = Gtk.Label(label="-" * 20 + " CPU Frequency Scaling " + "-" * 20)
         self.header.set_halign(Gtk.Align.START)
 
-        self.governor_label = Gtk.Label(label="")
-        self.governor_label.set_halign(Gtk.Align.START)
-
         self.epp_label = Gtk.Label(label="")
         self.epp_label.set_halign(Gtk.Align.START)
 
@@ -317,7 +314,6 @@ class CPUFreqScalingBox(Gtk.Box):
         self.epb_label.set_no_show_all(True)
 
         self.pack_start(self.header, False, False, 0)
-        self.pack_start(self.governor_label, False, False, 0)
         self.pack_start(self.epp_label, False, False, 0)
         self.pack_start(self.epb_label, False, False, 0)
 
@@ -327,25 +323,21 @@ class CPUFreqScalingBox(Gtk.Box):
         try:
             report = system_info.generate_system_report()
 
-            gov = report.current_gov if report.current_gov else "Unknown"
-            self.governor_label.set_label(f'Setting to use: "{gov}" governor')
-
             if report.current_epp:
-                self.epp_label.set_label(f"EPP setting: {report.current_epp}")
+                self.epp_label.set_label(f"Current EPP: {report.current_epp}")
                 self.epp_label.show()
             else:
                 self.epp_label.set_label("Not setting EPP (not supported by system)")
                 self.epp_label.show()
 
             if report.current_epb:
-                self.epb_label.set_label(f'Setting to use: "{report.current_epb}" EPB')
+                self.epb_label.set_label(f"Current EPB: {report.current_epb}")
                 self.epb_label.show()
             else:
                 self.epb_label.hide()
 
         except Exception:
-            self.governor_label.set_label('Setting to use: "Unknown" governor')
-            self.epp_label.set_label("EPP setting: Unknown")
+            self.epp_label.set_label("Current EPP: Unknown")
             self.epb_label.hide()
 
 class SystemStatisticsBox(Gtk.Box):
@@ -752,12 +744,12 @@ class MonitorModeView(Gtk.Box):
             self.right_box.pack_start(self._suggestion(f'Suggesting use of: "{suggested_gov}" governor'), False, False, 0)
 
         if report.current_epp:
-            self.right_box.pack_start(self._label(f"EPP setting: {report.current_epp}"), False, False, 0)
+            self.right_box.pack_start(self._label(f"Current EPP: {report.current_epp}"), False, False, 0)
         else:
             self.right_box.pack_start(self._label("Not setting EPP (not supported by system)"), False, False, 0)
 
         if report.current_epb:
-            self.right_box.pack_start(self._label(f'Setting to use: "{report.current_epb}" EPB'), False, False, 0)
+            self.right_box.pack_start(self._label(f"Current EPB: {report.current_epb}"), False, False, 0)
 
         self.right_box.pack_start(self._label(""), False, False, 0)
 

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -148,24 +148,49 @@ class SystemInfo:
             return None
 
     @staticmethod
-    def current_epp(is_ac_plugged: bool) -> str | None:
-        epp_path = "/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference"
-        if not Path(epp_path).exists():
+    def current_epp(_is_ac_plugged: bool) -> str | None:
+        paths = list(Path("/sys/devices/system/cpu").glob(
+            "cpu[0-9]*/cpufreq/energy_performance_preference"
+        ))
+        if not paths:
             return None
-            
-        return config.get_config().get( 
-            "charger" if is_ac_plugged else "battery", "energy_performance_preference", fallback="balance_performance" if is_ac_plugged else "balance_power"
-        )
+
+        values = set()
+        for path in paths:
+            value = SystemInfo.read_file(str(path))
+            if value is None:
+                return None
+            values.add(value)
+
+        if len(values) > 1:
+            return "mixed"
+        return values.pop()
 
     @staticmethod
-    def current_epb(is_ac_plugged: bool) -> str | None:
-        epb_path = "/sys/devices/system/cpu/intel_pstate"
-        if not Path(epb_path).exists():
+    def current_epb(_is_ac_plugged: bool) -> str | None:
+        epb_names = {
+            "0": "performance",
+            "4": "balance_performance",
+            "6": "default",
+            "8": "balance_power",
+            "15": "power",
+        }
+        paths = list(Path("/sys/devices/system/cpu").glob(
+            "cpu[0-9]*/power/energy_perf_bias"
+        ))
+        if not paths:
             return None
 
-        return config.get_config().get(
-            "charger" if is_ac_plugged else "battery", "energy_perf_bias", fallback="balance_performance" if is_ac_plugged else "balance_power"
-        )
+        values = set()
+        for path in paths:
+            value = SystemInfo.read_file(str(path))
+            if value is None:
+                return None
+            values.add(epb_names.get(value, value))
+
+        if len(values) > 1:
+            return "mixed"
+        return values.pop()
 
     @staticmethod
     def cpu_usage() -> float:

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -7,6 +7,7 @@ FWROOT=/sys/firmware
 DRIVER=auto
 VERBOSE=0
 WRITE_ERROR=0
+WRITE_ERROR_REPORTED=0
 
 ## parse special options
 for i in "$@"; do
@@ -97,8 +98,15 @@ function driver () {
 }
 
 function write_value () {
-  if [ -w $FLNM ]; then
-    if ! echo $VALUE > $FLNM; then
+  local TARGET_VALUE="${1:-$VALUE}"
+
+  if [ -w "$FLNM" ]; then
+    if [ $WRITE_ERROR_REPORTED -eq 0 ]; then
+      if ! echo "$TARGET_VALUE" > "$FLNM"; then
+        WRITE_ERROR=1
+        WRITE_ERROR_REPORTED=1
+      fi
+    elif ! echo "$TARGET_VALUE" > "$FLNM" 2>/dev/null; then
       WRITE_ERROR=1
     fi
   fi
@@ -159,7 +167,7 @@ function set_frequency () {
   set_driver
   if [ $DRIVER = 'pstate' ]; then
     echo "Unavailable function for intel_pstate"
-    return
+    return 1
   fi
   if [ -z $CORE ]; then
     i=0
@@ -266,7 +274,7 @@ function get_energy_performance_bias () {
 function set_energy_performance_bias () {
   if [ `driver` != 'intel_pstate' ]; then
     verbose "EPB is not supported by a driver other than intel_pstate"
-    return
+    return 1
   fi
   local EPB_VALUE=6 # default value
   if [[ "$VALUE" =~ ^[0-9]+$ && $VALUE -ge 0 && $VALUE -le 15 ]]; then
@@ -280,8 +288,8 @@ function set_energy_performance_bias () {
       power) EPB_VALUE=15;;
       *)
         verbose "Invalid value provided for EPB"
-        verbose "Acceptable values: performance|balance-power|default|balance-power|power or a number in the range [0-15]"
-        return
+        verbose "Acceptable values: performance|balance_performance|default|balance_power|power or a number in the range [0-15]"
+        return 1
       ;;
     esac
   fi
@@ -290,11 +298,7 @@ function set_energy_performance_bias () {
     i=0
     while [ $i -ne $cpucount ]; do
       FLNM="$FLROOT/cpu"$i"/power/energy_perf_bias"
-      if [ -w $FLNM ]; then
-        if ! echo $EPB_VALUE > $FLNM; then
-          WRITE_ERROR=1
-        fi
-      fi
+      write_value "$EPB_VALUE"
       i=`expr $i + 1`
     done
   else echo $EPB_VALUE > $FLROOT/cpu$CORE/power/energy_perf_bias
@@ -421,14 +425,18 @@ case $OPTION in
     fi
   ;;
   --on)
-    if [ -z $CORE ]; then verbose "Should be specify --core=NUMBER"
+    if [ -z $CORE ]; then
+      verbose "Should be specify --core=NUMBER"
+      false
     else
       verbose "Power on CPU Core"$CORE
       echo "1" > $FLROOT/cpu"$CORE"/online
     fi
   ;;
   --off)
-    if [ -z $CORE ]; then verbose "Should be specify --core=NUMBER"
+    if [ -z $CORE ]; then
+      verbose "Should be specify --core=NUMBER"
+      false
     else
       verbose "Power off CPU Core$CORE"
       echo "0" > $FLROOT/cpu"$CORE"/online

--- a/scripts/cpufreqctl.sh
+++ b/scripts/cpufreqctl.sh
@@ -425,7 +425,7 @@ case $OPTION in
     fi
   ;;
   --on)
-    if [ -z $CORE ]; then
+    if [ -z "$CORE" ]; then
       verbose "Should be specify --core=NUMBER"
       false
     else
@@ -434,7 +434,7 @@ case $OPTION in
     fi
   ;;
   --off)
-    if [ -z $CORE ]; then
+    if [ -z "$CORE" ]; then
       verbose "Should be specify --core=NUMBER"
       false
     else


### PR DESCRIPTION
## Summary

Make auto-cpufreq verify and report the state that the kernel actually accepted after power and CPU frequency writes, instead of assuming that the requested value was applied.

This also makes the user-facing output more explicit about what happened. Settings that are already effective are reported as no-ops rather than being presented as newly applied, successful changes are confirmed from the resulting state, and failed or unverifiable writes include the effective/current state when available.

For example:

```text
EPP already set to "balance_performance" (no change)

Platform Profile already set to "balanced" (no change)

Maximum CPU frequency request 4500 MHz already in effect
(effective: 3300-4500 MHz across CPU policies, no change)
```

This started as follow-up testing after #958. While testing write-failure propagation on real hardware, I found several cases where the helper or Python layer could still report success, show the requested value as if it were current, or misinterpret legitimate CPUFreq clamping across heterogeneous policies.

## Findings

* Some rejected `cpufreqctl.auto-cpufreq` operations could still return success, including invalid EPB values and `--on` / `--off` without a core.
* EPP, EPB and Platform Profile paths could print the requested value even when the kernel rejected the write or the resulting state did not match it.
* EPP/EPB reporting sometimes reflected configured intent rather than the actual sysfs state.
* A single global frequency request can legitimately resolve to different effective values across CPUFreq policies. On the test system, the same 4500 MHz maximum request resulted in 4500 MHz on some policies and 3300 MHz on others because of their different hardware limits.
* Comparing only one CPU or expecting one global frequency value can therefore report a valid write as failed and can cause unnecessary repeated writes.
* Partial sysfs reads should not be treated as a verified global state.
* The main GUI repeated the current governor in two adjacent places, while EPP/EPB labels did not clearly distinguish current state from configured intent.

## What this PR changes

### cpufreqctl helper

* Return non-zero for rejected operations that previously fell through as success.
* Preserve failure status across multi-CPU writes while continuing to attempt the remaining CPUs.
* Report the first repeated kernel write error per helper invocation while still returning failure.
* Validate EPB named and numeric values consistently.

### Effective state verification

* Read back EPP, EPB and Platform Profile after writes before reporting success.
* Distinguish between settings that were already in effect, settings that were applied, and settings that failed.
* Report `mixed` when per-CPU EPP/EPB values differ.
* Treat an unreadable member of a multi-CPU state as unverified instead of silently ignoring it.
* Keep EPP `default` handling compatible with the kernel exposing a concrete resulting preference.

### CPU frequency limits

* Verify frequency limits per CPUFreq policy instead of assuming every policy has the same hardware ceiling.
* Account for policy-specific clamping against `cpuinfo_min_freq` / `cpuinfo_max_freq`.
* Preserve maximum-before-minimum write ordering so transitions remain valid when the kernel clamps one limit against the other.
* Reject configurations where `scaling_min_freq > scaling_max_freq` before writing anything.
* Report the effective range when heterogeneous policies resolve the same request differently.
* Suppress normal frequency no-op messages from daemon stats while keeping interactive output informative.
* Use argv-based invocation for frequency writes.

### Reporting / GUI

* Read current EPP and EPB from sysfs for system reports.
* Show `Current EPP` and `Current EPB` in the GUI.
* Remove the duplicate governor line from the main CPU Frequency Scaling box because the current governor is already shown directly above it.

## Validation

Tested on an Intel Core i3-1315U system with `intel_pstate` active, EPP available, and separate CPUFreq policies for all 8 logical CPUs.

Real hardware tests covered:

* EPP already set / changed / rejected / `default`
* EPB already set / changed / rejected
* Platform Profile already set / changed / restored / rejected
* heterogeneous CPU frequency limits
* minimum/maximum kernel clamping in both directions
* rejection of configured `min > max`
* `intel_pstate/no_turbo=1`
* daemon execution through the installed project venv
* GUI reporting after the state-reading changes

The daemon smoke test showed no repeated frequency no-op messages and no failed writes in the normal profile:

```text
frequency no-op: 0
frequency apply: 0
failed:          0
write errors:    0
```

Synthetic tests also covered helper failure status, effective-state verification, heterogeneous policy clamping, helper failure with a final correct state, and partial sysfs reads.

Static checks:

```text
git diff --check: PASS
python3 -m compileall -q auto_cpufreq: PASS
bash -n scripts/cpufreqctl.sh: PASS
```

CI passes both `Linux Build` and `Nix Flake`.

## Related work

This PR is based directly on the current `master`. Potential overlap with #959, #960 and #961 is documented in the follow-up PR comment so that any of them can merge first and this branch can be rebased without changing the intended behavior.

Related: #958, #959, #960, #961.