### PR TITLE
Fix battery detection on multi-interface power supply systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,22 +692,27 @@ This is a special mode which limits the maximum charge level of the battery to a
 
 ### Ignoring power supplies
 
-you may have a controler or headphones and when ever they may be on battery they might cause auto-cpufreq
-to limit preformence to ignore them add to you config file the name of the power supply, under `[power_supply_ignore_list]`
+During automatic detection, auto-cpufreq ignores power supplies marked with
+`scope = Device` when selecting the system battery or determining whether
+the system is externally powered. This prevents peripherals such as controllers
+or headphones from affecting power-profile decisions when the kernel exposes
+their scope correctly.
 
-the name of the power supply can be found with  `ls /sys/class/power_supply/`
+If a power supply that should be ignored does not expose `scope = Device`, or
+if you want to exclude it explicitly, add its name under
+`[power_supply_ignore_list]`.
+
+Available power supplies can be listed with:
+
+```shell
+ls /sys/class/power_supply/
+```
+
+For example:
 
 ```ini
 [power_supply_ignore_list]
-
-name1 = this
-name2 = is 
-name3 = an
-name4 = example
-
-# like this
-xboxctrl = {the xbox controler power supply name}
-
+peripheral = power_supply_name
 ```
 
 ## Troubleshooting

--- a/auto-cpufreq.conf-example
+++ b/auto-cpufreq.conf-example
@@ -62,8 +62,10 @@ turbo = auto
 
 # settings for when using battery power
 [battery]
-# Specify which battery device to use for reading battery information. see available batteries by running: ls /sys/class/power_supply/
-# If not set, auto-cpufreq will automatically detect and use the first battery found
+# Specify which battery device to use for reading battery information.
+# See available power supplies with: ls /sys/class/power_supply/
+# If not set, auto-cpufreq prefers a battery with scope = System and otherwise
+# falls back to another battery that is not marked with scope = Device.
 # battery_device = BAT1
 
 # see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors

--- a/auto-cpufreq.conf-example.nix
+++ b/auto-cpufreq.conf-example.nix
@@ -63,8 +63,10 @@ services.auto-cpufreq.settings = {
 
   # settings for when using battery power
   battery = {
-    # Specify which battery device to use for reading battery information. see available batteries by running: ls /sys/class/power_supply/
-    # If not set, auto-cpufreq will automatically detect and use the first battery found
+    # Specify which battery device to use for reading battery information.
+    # See available power supplies with: ls /sys/class/power_supply/
+    # If not set, auto-cpufreq prefers a battery with scope = System and otherwise
+    # falls back to another battery that is not marked with scope = Device.
     # battery_device = BAT1
 
     # see available governors by running: cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -265,8 +265,8 @@ def charging():
     """Return whether the system should use the charger profile."""
     from auto_cpufreq.modules.system_info import SystemInfo
 
-    is_ac_plugged = SystemInfo.battery_info().is_ac_plugged
-    return True if is_ac_plugged is None else is_ac_plugged
+    is_ac_plugged = SystemInfo.external_power_state()
+    return is_ac_plugged is not False
 
 def get_current_gov():
     return print(

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -262,42 +262,11 @@ def get_power_supply_ignore_list():
 
 
 def charging():
-    """
-    get charge state: is battery charging or discharging
-    """
-    # sort it so AC is 'always' first
-    if os.path.exists(Path(POWER_SUPPLY_DIR)):
-        power_supplies = sorted(os.listdir(Path(POWER_SUPPLY_DIR)))
-    else: return True # no sysfs entries, nothing to do.
-    POWER_SUPPLY_IGNORELIST = get_power_supply_ignore_list()
+    """Return whether the system should use the charger profile."""
+    from auto_cpufreq.modules.system_info import SystemInfo
 
-    # check if we found power supplies. on a desktop these are not found and we assume we are on a powercable.
-    if len(power_supplies) == 0: return True # nothing found, so nothing to check
-
-    # we found some power supplies, lets check their state
-    for supply in power_supplies:
-        # Check if supply is in ignore list, if found in ignore list, skip it.
-        if any(item in supply for item in POWER_SUPPLY_IGNORELIST): continue
-
-        power_supply_type_path = Path(POWER_SUPPLY_DIR + supply + "/type")
-        if not power_supply_type_path.exists(): continue
-        with open(power_supply_type_path) as f: supply_type = f.read()[:-1]
-
-        if supply_type == "Mains":
-            # we found an AC
-            power_supply_online_path = Path(POWER_SUPPLY_DIR + supply + "/online")
-            if not power_supply_online_path.exists(): continue
-            with open(power_supply_online_path) as f:
-                if int(f.read()[:-1]) == 1: return True # we are definitely charging
-        elif supply_type == "Battery":
-            # we found a battery, check if its being discharged
-            power_supply_status_path = Path(POWER_SUPPLY_DIR + supply + "/status")
-            if not power_supply_status_path.exists(): continue
-            with open(power_supply_status_path) as f:
-                # we found a discharging battery
-                if str(f.read()[:-1]) == "Discharging": return False
-
-    return True # we cannot determine discharging state, assume we are on powercable
+    is_ac_plugged = SystemInfo.battery_info().is_ac_plugged
+    return True if is_ac_plugged is None else is_ac_plugged
 
 def get_current_gov():
     return print(

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -273,14 +273,33 @@ class SystemInfo:
 
         # Fall back to auto-detection if no custom device specified or if it's invalid
         try:
-            for entry in os.listdir(POWER_SUPPLY_DIR):
+            ignore_list = get_power_supply_ignore_list()
+            batteries = []
+            for entry in sorted(os.listdir(POWER_SUPPLY_DIR)):
+                if any(item in entry for item in ignore_list):
+                    continue
+
                 path = os.path.join(POWER_SUPPLY_DIR, entry)
                 type_path = os.path.join(path, "type")
-                if os.path.isfile(type_path):
-                    content = SystemInfo.read_file(type_path)
-                    if content and content.lower() == "battery":
-                        return path
-        except Exception:
+                if not os.path.isfile(type_path):
+                    continue
+
+                content = SystemInfo.read_file(type_path)
+                if not content or content.lower() != "battery":
+                    continue
+
+                scope = SystemInfo.read_file(os.path.join(path, "scope"))
+                if scope and scope.lower() == "system":
+                    priority = 0
+                elif scope and scope.lower() == "device":
+                    priority = 2
+                else:
+                    priority = 1
+                batteries.append((priority, entry, path))
+
+            if batteries:
+                return min(batteries)[2]
+        except OSError:
             return None
         return None
 
@@ -309,17 +328,40 @@ class SystemInfo:
                 power_consumption=None,
             )
 
-        # Reading AC info (Hands)
-        for supply in os.listdir(POWER_SUPPLY_DIR):
-            supply_path = os.path.join(POWER_SUPPLY_DIR, supply)
-            supply_type = SystemInfo.read_file(os.path.join(supply_path, "type"))
-            if supply_type == "Mains":
-                online = SystemInfo.read_file(os.path.join(supply_path, "online"))
-                is_ac_plugged = online == "1"
-
         # Reading battery information
         battery_status = SystemInfo.read_file(os.path.join(battery_path, "status"))
         battery_capacity = SystemInfo.read_file(os.path.join(battery_path, "capacity"))
+
+        # Read all usable external power sources. This includes USB/USB-PD
+        # interfaces and avoids letting an offline source overwrite an online one.
+        external_power_states = []
+        ignore_list = get_power_supply_ignore_list()
+        try:
+            for supply in sorted(os.listdir(POWER_SUPPLY_DIR)):
+                if any(item in supply for item in ignore_list):
+                    continue
+
+                supply_path = os.path.join(POWER_SUPPLY_DIR, supply)
+                supply_type = SystemInfo.read_file(os.path.join(supply_path, "type"))
+                if not supply_type or supply_type.lower() == "battery":
+                    continue
+
+                scope = SystemInfo.read_file(os.path.join(supply_path, "scope"))
+                if scope and scope.lower() == "device":
+                    continue
+
+                online = SystemInfo.read_file(os.path.join(supply_path, "online"))
+                if online in ("0", "1"):
+                    external_power_states.append(online == "1")
+        except OSError:
+            external_power_states = []
+
+        if external_power_states:
+            is_ac_plugged = any(external_power_states)
+        elif battery_status:
+            is_ac_plugged = battery_status.lower() != "discharging"
+        else:
+            is_ac_plugged = None
 
         # first check for wattage in power_now
         # this is not found on all laptops

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -41,8 +41,10 @@ class BatteryInfo:
     def __repr__(self) -> str:
         if self.is_charging:
             return "charging"
-        elif not self.is_ac_plugged:
+        if self.is_ac_plugged is False:
             return f"discharging {('(' + '{:.2f}'.format(self.power_consumption) + ' W)') if self.power_consumption != None else ''}"
+        if self.is_ac_plugged is None:
+            return "Unknown"
         return "Not Charging"
 
 
@@ -289,18 +291,75 @@ class SystemInfo:
                     continue
 
                 scope = SystemInfo.read_file(os.path.join(path, "scope"))
-                if scope and scope.lower() == "system":
-                    priority = 0
-                elif scope and scope.lower() == "device":
-                    priority = 2
-                else:
-                    priority = 1
+                if scope and scope.lower() == "device":
+                    continue
+
+                priority = 0 if scope and scope.lower() == "system" else 1
                 batteries.append((priority, entry, path))
 
             if batteries:
                 return min(batteries)[2]
         except OSError:
             return None
+        return None
+
+    @staticmethod
+    def external_power_state(
+        battery_path: Optional[str] = None,
+    ) -> bool | None:
+        """Return external-power state without collecting battery telemetry."""
+        if battery_path is None:
+            battery_path = SystemInfo.get_battery_path()
+
+        # Preserve the historical desktop fallback: without a usable system
+        # battery, assume the system is externally powered.
+        if not battery_path:
+            return True
+
+        external_power_states = []
+        ignore_list = get_power_supply_ignore_list()
+
+        try:
+            for supply in sorted(os.listdir(POWER_SUPPLY_DIR)):
+                if any(item in supply for item in ignore_list):
+                    continue
+
+                supply_path = os.path.join(POWER_SUPPLY_DIR, supply)
+                supply_type = SystemInfo.read_file(
+                    os.path.join(supply_path, "type")
+                )
+                if not supply_type or supply_type.lower() == "battery":
+                    continue
+
+                scope = SystemInfo.read_file(
+                    os.path.join(supply_path, "scope")
+                )
+                if scope and scope.lower() == "device":
+                    continue
+
+                online = SystemInfo.read_file(
+                    os.path.join(supply_path, "online")
+                )
+                if online in ("0", "1", "2"):
+                    external_power_states.append(online != "0")
+        except OSError:
+            external_power_states = []
+
+        if external_power_states:
+            return any(external_power_states)
+
+        battery_status = SystemInfo.read_file(
+            os.path.join(battery_path, "status")
+        )
+        if not battery_status:
+            return None
+
+        battery_status = battery_status.lower()
+        if battery_status == "discharging":
+            return False
+        if battery_status in ("charging", "not charging", "full"):
+            return True
+
         return None
 
     @staticmethod
@@ -332,36 +391,7 @@ class SystemInfo:
         battery_status = SystemInfo.read_file(os.path.join(battery_path, "status"))
         battery_capacity = SystemInfo.read_file(os.path.join(battery_path, "capacity"))
 
-        # Read all usable external power sources. This includes USB/USB-PD
-        # interfaces and avoids letting an offline source overwrite an online one.
-        external_power_states = []
-        ignore_list = get_power_supply_ignore_list()
-        try:
-            for supply in sorted(os.listdir(POWER_SUPPLY_DIR)):
-                if any(item in supply for item in ignore_list):
-                    continue
-
-                supply_path = os.path.join(POWER_SUPPLY_DIR, supply)
-                supply_type = SystemInfo.read_file(os.path.join(supply_path, "type"))
-                if not supply_type or supply_type.lower() == "battery":
-                    continue
-
-                scope = SystemInfo.read_file(os.path.join(supply_path, "scope"))
-                if scope and scope.lower() == "device":
-                    continue
-
-                online = SystemInfo.read_file(os.path.join(supply_path, "online"))
-                if online in ("0", "1"):
-                    external_power_states.append(online == "1")
-        except OSError:
-            external_power_states = []
-
-        if external_power_states:
-            is_ac_plugged = any(external_power_states)
-        elif battery_status:
-            is_ac_plugged = battery_status.lower() != "discharging"
-        else:
-            is_ac_plugged = None
+        is_ac_plugged = SystemInfo.external_power_state(battery_path)
 
         # first check for wattage in power_now
         # this is not found on all laptops
@@ -416,7 +446,8 @@ class SystemInfo:
 
     @staticmethod
     def governor_suggestion() -> str:
-        if SystemInfo.battery_info().is_ac_plugged:
+        is_ac_plugged = SystemInfo.external_power_state()
+        if is_ac_plugged is not False:
             return AVAILABLE_GOVERNORS_SORTED[0]
         return AVAILABLE_GOVERNORS_SORTED[-1]
 


### PR DESCRIPTION
## Summary

Fix battery and external-power detection on laptops that expose multiple
entries under `/sys/class/power_supply`, such as a system battery,
peripheral HID batteries, a barrel-jack AC source, and USB-C/USB-PD sources.

This addresses the topology reported in #949 without hardcoding device
names such as `BAT0`.

## Problem

`SystemInfo.get_battery_path()` currently returns the first entry whose
`type` is `Battery`. On systems that also expose a peripheral battery,
that can select the wrong device and report its capacity (for example
`0%`) instead of the laptop battery.

External-power detection also only considers `type = Mains`, and each
matching entry overwrites the previous state. This can miss USB-C/USB-PD
power sources and can report the wrong result on systems with multiple
power inputs.

## Changes

- Preserve an explicitly configured `battery_device` as the highest priority.
- Reuse the existing `power_supply_ignore_list` during automatic detection.
- Make fallback battery selection deterministic.
- Prefer `scope = System` batteries over other non-Device batteries and exclude
  `scope = Device` peripherals from automatic battery selection.
- Detect external power from non-battery power-supply entries exposing a
  valid `online` state, including USB/USB-PD and `online = 2` programmable
  supplies.
- Ignore `scope = Device` sources when determining system external power.
- Aggregate multiple sources so an offline source cannot overwrite one
  that is online.
- Fall back to the selected battery status when no usable external source
  exposes an `online` state.
- Keep external-power detection separate from full battery telemetry so
  `core.charging()` and governor selection avoid unnecessary sysfs reads.
- Treat an undetermined power state consistently for profile decisions while
  preserving `Unknown` for reporting.
  
## Validation

Validated with synthetic `/sys/class/power_supply` topologies covering:

- `BAT0`: `Battery`, `scope=System`, capacity `83%`
- HID/peripheral batteries with `scope=Device`
- `AC0`: `Mains`, offline/online states
- USB-C/USB-PD sources, including `online=2`
- Multiple external sources with mixed online states
- Missing and `Unknown` battery status
- Systems without a usable system battery
- Explicit `battery_device` configuration precedence

The system battery is selected correctly, peripheral batteries are excluded
from autodetection, external-power state is aggregated consistently, and the
daemon profile path no longer collects full battery telemetry.


Fixes #949