### PR TITLE
Unify system reporting and GTK runtime state

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Example of `auto-cpufreq --stats` CLI output
 - [auto-cpufreq modes and options](#auto-cpufreq-modes-and-options)
   - [monitor](#monitor)
   - [live](#live)
+  - [GUI](#gui)
   - [overriding governor](#overriding-governor)
   - [overriding turbo mode](#overriding-turbo-mode)
   - [Install - auto-cpufreq daemon](#install---auto-cpufreq-daemon)
@@ -470,7 +471,7 @@ turbo = always
 ```
 
 ## How to run auto-cpufreq
-auto-cpufreq should be run with with one of the following options:
+auto-cpufreq can be used through the following CLI modes and the GTK interface:
 
 - [monitor](#monitor)
   - Monitor and see suggestions for CPU optimizations
@@ -481,8 +482,8 @@ auto-cpufreq should be run with with one of the following options:
 - [install](#install---auto-cpufreq-daemon) / [remove](#remove---auto-cpufreq-daemon)
   - Install/remove daemon for (permanent) automatic CPU optimizations
  
-- [install (GUI)](#install---auto-cpufreq-daemon)
-  - Install daemon via GUI for (permanent) automatic CPU optimizations
+- [GUI](#gui)
+  - View live system and power state, manage supported controls, or preview recommendations
 
 - [update](#update---auto-cpufreq-update)
   - Update auto-cpufreq to the latest release
@@ -518,9 +519,9 @@ auto-cpufreq should be run with with one of the following options:
   - To support the project
 
 - help
-  - Shows all of the above options
+  - Shows the available CLI options
 
-Running `auto-cpufreq --help` will print the same list of options as above. Read [auto-cpufreq modes and options](#auto-cpufreq-modes-and-options) for more details.
+Running `auto-cpufreq --help` will list the available CLI options. Read [auto-cpufreq modes and options](#auto-cpufreq-modes-and-options) for more details.
 
 ## auto-cpufreq modes and options
 
@@ -530,11 +531,23 @@ Running `auto-cpufreq --help` will print the same list of options as above. Read
 
 No changes are made to the system. This is solely to demonstrate what auto-cpufreq could do for your system.
 
+This is the terminal Monitor mode. A read-only Monitor Mode is also available from the GUI when the daemon is not running.
+
 ### Live
 
 `sudo auto-cpufreq --live`
 
 Necessary changes are temporarily made to the system over time, but this process and its changes are lost at system reboot. This mode is provided to evaluate how the system would behave with auto-cpufreq permanently running on the system.
+
+### GUI
+
+The GTK interface can be opened from the auto-cpufreq desktop entry.
+
+When the daemon is running, the GUI provides a live overview of system, CPU, battery and power state, together with controls for supported auto-cpufreq overrides and settings.
+
+The dashboard refresh interval can be changed from the menu between 1, 2 and 5 seconds.
+
+If the daemon is not running, the GUI allows you to either install it for persistent automatic optimization or open Monitor Mode to preview system state and auto-cpufreq recommendations without applying changes.
 
 ### Overriding governor
 
@@ -565,23 +578,7 @@ Installing the auto-cpufreq daemon using CLI is as simple as running the followi
 
 After the daemon is installed, `auto-cpufreq` is available as a binary and runs in the background. Its stats can be viewed by running: `auto-cpufreq --stats`
 
-*Please note:* if the daemon is installed within a desktop environment, then its stats and options can be accessed via CLI or GUI. See "Install the daemon using GUI" below for more details.
-
-**Install the daemon using GUI**
-
-Starting with >= v2.0 [after installing auto-cpufreq](#installing-auto-cpufreq), an auto-cpufreq desktop entry (icon) is available, i.e.:
-
-<img src="https://github.com/user-attachments/assets/f426d62b-00b0-4fa5-a72e-b352016ed448" width="640" alt="Example of auto-cpufreq desktop entry (icon)"/>
-
-After selecting it to open the GUI, the auto-cpufreq daemon can be installed by clicking the "Install" button:
-
-<img src="https://github.com/user-attachments/assets/5af47e5e-8b9e-4ff6-9ffc-e78acb623ce4" width="480" alt="The auto-cpufreq GUI's 'Install' button"/>
-
-After that, the full auto-cpufreq GUI is available:
-
-<img src="https://github.com/user-attachments/assets/9c7715c4-16b7-4a5c-86be-4c390276d9e8" width="640" alt="The full auto-cpufreq GUI"/>
-
-*Please note:* after the daemon is installed (by any method), its stats and options are accessible via both CLI and GUI.
+The daemon can also be installed from the GTK interface. See [GUI](#gui).
 
 **auto-cpufreq daemon service**
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,9 @@ Necessary changes are temporarily made to the system over time, but this process
 `sudo auto-cpufreq --force=governor`
 
 Force use of either the "powersave" or "performance" governor, or set to "reset" to go back to normal mode.
+
+This overrides only the CPU governor. Other charger/battery profile settings continue to follow the detected power source.
+
 Please note that any set override will persist even after reboot.
 
 ### Overriding Turbo mode

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -13,6 +13,7 @@ from auto_cpufreq.battery_scripts.battery import *
 from auto_cpufreq.config.config import config as conf, find_config_file
 from auto_cpufreq.core import *
 from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_AUR, IS_INSTALLED_WITH_SNAP
+from auto_cpufreq.modules.system_info import print_system_report
 from auto_cpufreq.modules.system_monitor import ViewType, SystemMonitor
 # import everything from power_helper, including bluetooth_disable and bluetooth_enable
 from auto_cpufreq.power_helper import *
@@ -149,8 +150,7 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                     footer()
                     gov_check()
                     cpufreqctl()
-                    distro_info()
-                    sysinfo()
+                    print_system_report()
                     set_autofreq()
                     countdown(2)
                 except KeyboardInterrupt: break
@@ -177,12 +177,12 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                 if arg.startswith("--update="):
                     custom_dir = arg.split("=")[1]
                     sys.argv.remove(arg)
-                    
+
             if "--update" in sys.argv:
                 update = True
                 sys.argv.remove("--update")
                 if len(sys.argv) == 2: custom_dir = sys.argv[1] 
-                    
+
             if IS_INSTALLED_WITH_SNAP:
                 print("Detected auto-cpufreq was installed using snap")
                 # refresh snap directly using this command
@@ -272,8 +272,7 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
             battery_get_thresholds()
             cpufreqctl()
             footer()
-            distro_info()
-            sysinfo()
+            print_system_report()
             print()
             app_version()
             print()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -223,15 +223,15 @@ def turbo(value: bool = None):
         print("Warning: CPU turbo is not available")
         return False
     
-    turbo_override = get_turbo_override()
-    if turbo_override != "auto":
-        # Set the value in respect to if turbo override is enabled or not.
-        if turbo_override == "always":
-            value = True
-        elif turbo_override == "never":
-            value = False
-
     if value is not None:
+        turbo_override = get_turbo_override()
+        if turbo_override != "auto":
+            # Set the value in respect to if turbo override is enabled or not.
+            if turbo_override == "always":
+                value = True
+            elif turbo_override == "never":
+                value = False
+
         try: f.write_text(f"{int(value ^ inverse)}\n")
         except PermissionError:
             print("Warning: Changing CPU turbo is not supported. Skipping.")
@@ -855,9 +855,14 @@ def set_hwp_dynamic_boost(enabled):
 
 def set_powersave():
     conf = config.get_config()
-    gov = conf["battery"]["governor"] if conf.has_option("battery", "governor") else AVAILABLE_GOVERNORS_SORTED[-1]
+    override = get_override()
+    gov = override if override in ("powersave", "performance") else (
+        conf["battery"]["governor"]
+        if conf.has_option("battery", "governor")
+        else AVAILABLE_GOVERNORS_SORTED[-1]
+    )
     print(f'Setting to use: "{gov}" governor')
-    if get_override() != "default": print("Warning: governor overwritten using `--force` flag.")
+    if override != "default": print("Warning: governor overwritten using `--force` flag.")
     try:
         result = run(
             ["cpufreqctl.auto-cpufreq", "--governor", f"--set={gov}"]
@@ -954,10 +959,15 @@ def mon_powersave():
 
 def set_performance():
     conf = config.get_config()
-    gov = conf["charger"]["governor"] if conf.has_option("charger", "governor") else AVAILABLE_GOVERNORS_SORTED[0]
+    override = get_override()
+    gov = override if override in ("powersave", "performance") else (
+        conf["charger"]["governor"]
+        if conf.has_option("charger", "governor")
+        else AVAILABLE_GOVERNORS_SORTED[0]
+    )
 
     print(f'Setting to use: "{gov}" governor')
-    if get_override() != "default": print("Warning: governor overwritten using `--force` flag.")
+    if override != "default": print("Warning: governor overwritten using `--force` flag.")
     try:
         result = run(
             ["cpufreqctl.auto-cpufreq", "--governor", f"--set={gov}"]
@@ -1118,11 +1128,8 @@ def set_autofreq():
     """
     print("\n" + "-" * 28 + " CPU frequency scaling " + "-" * 28 + "\n")
 
-    # determine which governor should be used
-    override = get_override()
-    if override == "powersave": set_powersave()
-    elif override == "performance": set_performance()
-    elif charging():
+    # determine which power profile should be used
+    if charging():
         print("Battery is: charging\n")
         set_performance()
     else:
@@ -1292,6 +1299,32 @@ def is_running(program, argument):
         except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError): continue
         for s in filter(lambda x: program in x, cmd):
             if argument in cmd: return True
+
+
+def daemon_is_running():
+    """Return whether the auto-cpufreq daemon is currently active."""
+    if is_running("auto-cpufreq", "--daemon"):
+        return True
+
+    if IS_INSTALLED_WITH_SNAP:
+        return SNAP_DAEMON_CHECK == "enabled"
+
+    if not Path("/run/systemd/system").is_dir():
+        return False
+
+    try:
+        return call(
+            [
+                "systemctl",
+                "is-active",
+                "--quiet",
+                "auto-cpufreq.service",
+            ],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        ) == 0
+    except OSError:
+        return False
 
 def daemon_running_msg():
     print("\n" + "-" * 24 + " auto-cpufreq running " + "-" * 30 + "\n")

--- a/auto_cpufreq/gui/app.py
+++ b/auto_cpufreq/gui/app.py
@@ -1,16 +1,21 @@
 import gi
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GdkPixbuf, Gio, GLib, Gtk
 
 from contextlib import redirect_stdout
 from io import StringIO
+from os.path import isfile
 from subprocess import PIPE, run
 from threading import Thread
 
-from auto_cpufreq.core import check_for_update, is_running
+from auto_cpufreq.config.config import config, find_config_file
+from auto_cpufreq.core import check_for_update, daemon_is_running
 from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_SNAP
-from auto_cpufreq.gui.objects import BatteryInfoBox, BluetoothBootControl, CPUFreqScalingBox, CurrentGovernorBox, DaemonNotRunningView, DropDownMenu, MonitorModeView, RadioButtonView, CPUTurboOverride, SystemStatsLabel, SystemStatisticsBox, UpdateDialog
+from auto_cpufreq.gui.objects import BluetoothBootControl, DaemonNotRunningView, DropDownMenu, MonitorModeView, RadioButtonView, CPUTurboOverride, UpdateDialog
 from auto_cpufreq.gui.objects import get_stats
+from auto_cpufreq.modules.system_info import system_info
 from auto_cpufreq.power_helper import bluetoothctl_exists
 
 if IS_INSTALLED_WITH_SNAP:
@@ -21,52 +26,705 @@ else:
     ICON_FILE = "/usr/local/share/auto-cpufreq/images/icon.png"
 
 HBOX_PADDING = 20
+CONTROL_OPTION_MARGIN = 8
+SECTION_SPACING = 12
+
+DEFAULT_REFRESH_INTERVAL = 2
+REFRESH_INTERVALS = (1, 2, 5)
+
+# The daemon normally applies overrides on its next ~2 second cycle.
+# Keep the affected state hidden until a later, fresh report is collected.
+CONTROL_APPLY_DELAY_SECONDS = 3
+
+
+def _new_section(title):
+    frame = Gtk.Frame()
+    heading = Gtk.Label(label=title, name="bold")
+    heading.set_halign(Gtk.Align.START)
+    frame.set_label_widget(heading)
+
+    grid = Gtk.Grid()
+    grid.set_column_spacing(18)
+    grid.set_row_spacing(4)
+    grid.set_margin_top(8)
+    grid.set_margin_bottom(8)
+    grid.set_margin_start(10)
+    grid.set_margin_end(10)
+    frame.add(grid)
+    return frame, grid
+
+
+def _add_row(grid, row, name):
+    name_label = Gtk.Label(label=name)
+    name_label.set_halign(Gtk.Align.START)
+    name_label.set_xalign(0)
+
+    value_label = Gtk.Label(label="—")
+    value_label.set_halign(Gtk.Align.START)
+    value_label.set_xalign(0)
+    value_label.set_hexpand(True)
+
+    grid.attach(name_label, 0, row, 1, 1)
+    grid.attach(value_label, 1, row, 1, 1)
+    return name_label, value_label
+
+
+def _set_row_visible(grid, row, visible):
+    for column in (0, 1):
+        child = grid.get_child_at(column, row)
+        if child is None:
+            continue
+        child.set_no_show_all(True)
+        if visible:
+            child.show()
+        else:
+            child.hide()
+
+
+def _battery_status(battery):
+    if battery is None:
+        return "Unavailable"
+    if battery.is_charging is True:
+        return "Charging"
+    if battery.is_ac_plugged is False:
+        return "Discharging"
+    if battery.is_ac_plugged is True:
+        return "Not charging"
+    return "Unknown"
+
+
+def _governor_status(report):
+    return report.current_gov or "Unavailable"
+
+
+def _turbo_status(report):
+    enabled, driver_managed = report.is_turbo_on
+
+    if enabled is None:
+        if driver_managed is True:
+            return "Driver managed"
+        return "Unavailable"
+
+    return "On" if enabled else "Off"
+
+
+class SystemReportView(Gtk.Box):
+    """Shared read-only presentation of SystemReport."""
+
+    def __init__(self):
+        super().__init__(
+            orientation=Gtk.Orientation.VERTICAL,
+        )
+
+        self.columns = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=HBOX_PADDING,
+        )
+        self.left_column = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=SECTION_SPACING,
+        )
+        self.left_column.set_valign(Gtk.Align.START)
+        self.columns.pack_start(self.left_column, True, True, 0)
+
+        system_frame, system_grid = _new_section("System Information")
+        self.system_values = {}
+        for row, (key, name) in enumerate(
+            (
+                ("distro", "Linux distro"),
+                ("kernel", "Linux kernel"),
+                ("processor", "Processor"),
+                ("cores", "Logical CPUs"),
+                ("architecture", "Architecture"),
+                ("driver", "CPU driver"),
+            )
+        ):
+            _, self.system_values[key] = _add_row(system_grid, row, name)
+        self.left_column.pack_start(system_frame, False, False, 0)
+
+        self.config_label = Gtk.Label(label="")
+        self.config_label.set_halign(Gtk.Align.START)
+        self.config_label.set_xalign(0)
+        self.config_label.set_line_wrap(True)
+        self.left_column.pack_start(self.config_label, False, False, 0)
+
+        cpu_frame = Gtk.Frame()
+        cpu_heading = Gtk.Label(label="CPU Statistics", name="bold")
+        cpu_heading.set_halign(Gtk.Align.START)
+        cpu_frame.set_label_widget(cpu_heading)
+
+        self.cpu_box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=8,
+        )
+        self.cpu_box.set_margin_top(8)
+        self.cpu_box.set_margin_bottom(8)
+        self.cpu_box.set_margin_start(10)
+        self.cpu_box.set_margin_end(10)
+        cpu_frame.add(self.cpu_box)
+
+        limits_grid = Gtk.Grid()
+        limits_grid.set_column_spacing(18)
+        limits_grid.set_row_spacing(4)
+        _, self.max_freq_value = _add_row(
+            limits_grid, 0, "Maximum frequency"
+        )
+        _, self.min_freq_value = _add_row(
+            limits_grid, 1, "Minimum frequency"
+        )
+        self.cpu_box.pack_start(limits_grid, False, False, 0)
+
+        self.cores_grid = Gtk.Grid()
+        self.cores_grid.set_column_spacing(18)
+        self.cores_grid.set_row_spacing(3)
+        self.cpu_box.pack_start(self.cores_grid, False, False, 0)
+
+        self.fan_label = Gtk.Label(label="")
+        self.fan_label.set_halign(Gtk.Align.START)
+        self.fan_label.set_xalign(0)
+        self.fan_label.set_no_show_all(True)
+        self.cpu_box.pack_start(self.fan_label, False, False, 0)
+
+        self.left_column.pack_start(cpu_frame, False, False, 0)
+
+        self.right_column = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=SECTION_SPACING,
+        )
+        self.right_column.set_valign(Gtk.Align.START)
+        self.columns.pack_start(self.right_column, True, True, 0)
+
+        power_frame, self.power_grid = _new_section("CPU Power State")
+        self.power_values = {}
+        for row, (key, name) in enumerate(
+            (
+                ("governor", "Governor"),
+                ("epp", "EPP"),
+                ("epb", "EPB"),
+                ("hwp", "HWP Dynamic Boost"),
+                ("turbo", "Turbo Boost"),
+            )
+        ):
+            _, self.power_values[key] = _add_row(
+                self.power_grid, row, name
+            )
+        _set_row_visible(self.power_grid, 3, False)
+        self.right_column.pack_start(power_frame, False, False, 0)
+
+        battery_frame, self.battery_grid = _new_section("Battery")
+        self.battery_values = {}
+        for row, (key, name) in enumerate(
+            (
+                ("status", "Status"),
+                ("charge", "Charge"),
+                ("ac", "AC power"),
+                ("start", "Start threshold"),
+                ("stop", "Stop threshold"),
+                ("power", "Power draw"),
+            )
+        ):
+            _, self.battery_values[key] = _add_row(
+                self.battery_grid, row, name
+            )
+        self.right_column.pack_start(battery_frame, False, False, 0)
+
+        stats_frame, stats_grid = _new_section("System Statistics")
+        self.stats_values = {}
+        for row, (key, name) in enumerate(
+            (
+                ("usage", "CPU usage"),
+                ("load", "System load"),
+                ("load_avg", "Load average (1 / 5 / 15 min)"),
+                ("temp", "Average CPU temperature"),
+            )
+        ):
+            _, self.stats_values[key] = _add_row(stats_grid, row, name)
+        self.right_column.pack_start(stats_frame, False, False, 0)
+
+        self.pack_start(self.columns, True, True, 0)
+
+    def prepend_right(self, widget):
+        self.right_column.pack_start(
+            widget, False, False, 0
+        )
+        self.right_column.reorder_child(widget, 0)
+
+    def _refresh_core_rows(self, cores):
+        for child in self.cores_grid.get_children():
+            self.cores_grid.remove(child)
+
+        for column, text in enumerate(
+            ("CPU", "Usage", "Temperature", "Frequency")
+        ):
+            label = Gtk.Label(label=text, name="bold")
+            label.set_halign(Gtk.Align.START)
+            label.set_xalign(0)
+            self.cores_grid.attach(label, column, 0, 1, 1)
+
+        for row, core in enumerate(cores, start=1):
+            values = (
+                f"CPU{core.id}",
+                f"{core.usage:.1f}%",
+                (
+                    f"{core.temperature:.0f} °C"
+                    if core.temperature > 0
+                    else "—"
+                ),
+                (
+                    f"{core.frequency:.0f} MHz"
+                    if core.frequency > 0
+                    else "—"
+                ),
+            )
+            for column, text in enumerate(values):
+                label = Gtk.Label(label=text)
+                label.set_halign(Gtk.Align.START)
+                label.set_xalign(0)
+                self.cores_grid.attach(label, column, row, 1, 1)
+
+        self.cores_grid.show_all()
+
+    def apply_report(self, report, pending_power_updates=()):
+        self.system_values["distro"].set_text(
+            f"{report.distro_name} {report.distro_ver}".strip()
+        )
+        self.system_values["kernel"].set_text(
+            report.kernel_version or "Unknown"
+        )
+        self.system_values["processor"].set_text(
+            report.processor_model or "Unknown"
+        )
+        self.system_values["cores"].set_text(
+            str(report.total_core)
+            if report.total_core is not None
+            else "Unknown"
+        )
+        self.system_values["architecture"].set_text(
+            report.arch or "Unknown"
+        )
+        self.system_values["driver"].set_text(
+            report.cpu_driver or "Unknown"
+        )
+
+        config_path = config.path if config.has_config() else find_config_file(None)
+        if config_path and isfile(config_path):
+            self.config_label.set_text(f"Configuration: {config_path}")
+            self.config_label.show()
+        else:
+            self.config_label.hide()
+
+        self.max_freq_value.set_text(
+            f"{report.cpu_max_freq:.0f} MHz"
+            if report.cpu_max_freq is not None
+            else "Unavailable"
+        )
+        self.min_freq_value.set_text(
+            f"{report.cpu_min_freq:.0f} MHz"
+            if report.cpu_min_freq is not None
+            else "Unavailable"
+        )
+        self._refresh_core_rows(report.cores_info)
+
+        if report.cpu_fan_speed:
+            self.fan_label.set_text(
+                f"CPU fan speed: {report.cpu_fan_speed} RPM"
+            )
+            self.fan_label.show()
+        else:
+            self.fan_label.hide()
+
+        if "governor" not in pending_power_updates:
+            self.power_values["governor"].set_text(
+                _governor_status(report)
+            )
+        self.power_values["epp"].set_text(
+            report.current_epp or "Unavailable"
+        )
+        self.power_values["epb"].set_text(
+            report.current_epb or "Unavailable"
+        )
+
+        hwp_available = report.current_hwp_dynamic_boost is not None
+        _set_row_visible(self.power_grid, 3, hwp_available)
+        if hwp_available:
+            self.power_values["hwp"].set_text(
+                "On" if report.current_hwp_dynamic_boost else "Off"
+            )
+
+        if "turbo" not in pending_power_updates:
+            self.power_values["turbo"].set_text(
+                _turbo_status(report)
+            )
+
+        battery = report.battery_info
+        self.battery_values["status"].set_text(
+            _battery_status(battery)
+        )
+        if battery is None:
+            for key in ("charge", "ac", "start", "stop", "power"):
+                self.battery_values[key].set_text("Unavailable")
+        else:
+            self.battery_values["charge"].set_text(
+                f"{battery.battery_level}%"
+                if battery.battery_level is not None
+                else "Unavailable"
+            )
+            self.battery_values["ac"].set_text(
+                "Connected"
+                if battery.is_ac_plugged is True
+                else "Disconnected"
+                if battery.is_ac_plugged is False
+                else "Unknown"
+            )
+            self.battery_values["start"].set_text(
+                str(battery.charging_start_threshold)
+                if battery.charging_start_threshold is not None
+                else "Unavailable"
+            )
+            self.battery_values["stop"].set_text(
+                str(battery.charging_stop_threshold)
+                if battery.charging_stop_threshold is not None
+                else "Unavailable"
+            )
+            self.battery_values["power"].set_text(
+                f"{battery.power_consumption:.2f} W"
+                if battery.power_consumption is not None
+                else "Unavailable"
+            )
+
+        self.stats_values["usage"].set_text(
+            f"{report.cpu_usage:.1f}%"
+        )
+        self.stats_values["load"].set_text(f"{report.load:.2f}")
+        if report.avg_load:
+            self.stats_values["load_avg"].set_text(
+                f"{report.avg_load[0]:.2f} / "
+                f"{report.avg_load[1]:.2f} / "
+                f"{report.avg_load[2]:.2f}"
+            )
+        else:
+            self.stats_values["load_avg"].set_text("Unavailable")
+
+        average_temp = report.cpu_avg_temp
+        if average_temp is None:
+            temperatures = [
+                core.temperature
+                for core in report.cores_info
+                if core.temperature > 0
+            ]
+            if temperatures:
+                average_temp = sum(temperatures) / len(temperatures)
+
+        self.stats_values["temp"].set_text(
+            f"{average_temp:.1f} °C"
+            if average_temp is not None
+            else "Unavailable"
+        )
+
 
 class ToolWindow(Gtk.Window):
     def __init__(self):
         super().__init__(title="auto-cpufreq")
-        self.set_default_size(600, 480)
+        self.set_default_size(920, 680)
         self.set_border_width(10)
-        self.set_resizable(False)
+        self.set_resizable(True)
+        self.refresh_in_progress = False
+        self.refresh_pending = False
+        self.refresh_interval = DEFAULT_REFRESH_INTERVAL
+        self.refresh_id = None
+        self.pending_power_updates = set()
+        self.pending_power_release = set()
+        self.power_apply_sources = {}
+        self.destroyed = False
+        self.connect("destroy", self._cleanup_refresh)
         self.load_css()
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(filename=ICON_FILE, width=500, height=500, preserve_aspect_ratio=True)
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+            filename=ICON_FILE,
+            width=500,
+            height=500,
+            preserve_aspect_ratio=True,
+        )
         self.set_icon(pixbuf)
         self.build()
 
     def main(self):
-        # Main HBOX
-        self.hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=HBOX_PADDING)
-       
-        self.systemstats = SystemStatsLabel()
-        self.hbox.pack_start(self.systemstats, False, False, 0)
-        self.add(self.hbox)
+        self.report_view = SystemReportView()
 
-        self.vbox_right = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
-        
+        controls_frame = Gtk.Frame()
+        controls_heading = Gtk.Label(label="Controls", name="bold")
+        controls_heading.set_halign(Gtk.Align.START)
+        controls_frame.set_label_widget(controls_heading)
+
+        controls_box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=10,
+        )
+        controls_box.set_margin_top(8)
+        controls_box.set_margin_bottom(8)
+        controls_box.set_margin_start(10)
+        controls_box.set_margin_end(10)
+        controls_frame.add(controls_box)
+
         self.menu = DropDownMenu(self)
-        self.hbox.pack_end(self.menu, False, False, 0)
-        
-        self.currentgovernor = CurrentGovernorBox()
-        self.vbox_right.pack_start(self.currentgovernor, False, False, 0)
-        self.vbox_right.pack_start(RadioButtonView(), False, False, 0)
+        self._add_refresh_interval_menu()
+        controls_box.pack_start(self.menu, False, False, 0)
+
+        self.governor_control = RadioButtonView()
+        self.governor_control.label.set_xalign(0.0)
+        self.governor_control.default.set_margin_start(CONTROL_OPTION_MARGIN)
+        controls_box.pack_start(self.governor_control, False, False, 0)
+
+        self.control_label_group = Gtk.SizeGroup(
+            mode=Gtk.SizeGroupMode.HORIZONTAL
+        )
+        self.control_label_group.add_widget(self.governor_control.label)
+        self.control_option_groups = [
+            Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
+            for _ in range(3)
+        ]
+        for group, button in zip(
+            self.control_option_groups,
+            (
+                self.governor_control.default,
+                self.governor_control.powersave,
+                self.governor_control.performance,
+            ),
+        ):
+            group.add_widget(button)
+            button.set_halign(Gtk.Align.START)
+
         if "Warning: CPU turbo is not available" not in get_stats():
-            self.vbox_right.pack_start(CPUTurboOverride(), False, False, 0)
-
-        self.batteryinfo = BatteryInfoBox()
-        self.vbox_right.pack_start(self.batteryinfo, False, False, 0)
-
-        self.cpufreqscaling = CPUFreqScalingBox()
-        self.vbox_right.pack_start(self.cpufreqscaling, False, False, 0)
-
-        self.systemstats_box = SystemStatisticsBox()
-        self.vbox_right.pack_start(self.systemstats_box, False, False, 0)
+            self.turbo_control = CPUTurboOverride()
+            self.turbo_control.label.set_xalign(0.0)
+            self.turbo_control.auto.set_margin_start(CONTROL_OPTION_MARGIN)
+            controls_box.pack_start(self.turbo_control, False, False, 0)
+            self.control_label_group.add_widget(self.turbo_control.label)
+            for group, button in zip(
+                self.control_option_groups,
+                (
+                    self.turbo_control.auto,
+                    self.turbo_control.never,
+                    self.turbo_control.always,
+                ),
+            ):
+                group.add_widget(button)
+                button.set_halign(Gtk.Align.START)
 
         if bluetoothctl_exists:
-            self.vbox_right.pack_start(BluetoothBootControl(), False, False, 0)
+            self.bluetooth_control = BluetoothBootControl()
+            self.bluetooth_control.label.set_xalign(0.0)
+            self.bluetooth_control.on_btn.set_margin_start(
+                CONTROL_OPTION_MARGIN
+            )
+            self.control_label_group.add_widget(
+                self.bluetooth_control.label
+            )
+            self.control_option_groups[0].add_widget(
+                self.bluetooth_control.on_btn
+            )
+            self.control_option_groups[1].add_widget(
+                self.bluetooth_control.off_btn
+            )
+            self.bluetooth_control.on_btn.set_halign(Gtk.Align.START)
+            self.bluetooth_control.off_btn.set_halign(Gtk.Align.START)
+            spacer = Gtk.Label()
+            self.control_option_groups[2].add_widget(spacer)
+            self.bluetooth_control.inner_box.pack_start(
+                spacer, True, True, 0
+            )
+            controls_box.pack_start(
+                self.bluetooth_control, False, False, 0
+            )
 
-        self.hbox.pack_start(self.vbox_right, False, False, 0)
+        self.report_view.prepend_right(controls_frame)
 
-        GLib.timeout_add_seconds(5, self.refresh_in_thread)
+        # Applying… continues to address the shared
+        # observed governor/Turbo rows directly.
+        self.power_values = self.report_view.power_values
+
+        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled.set_policy(
+            Gtk.PolicyType.NEVER,
+            Gtk.PolicyType.AUTOMATIC,
+        )
+        self.scrolled.set_can_focus(False)
+        self.scrolled.add(self.report_view)
+        self.add(self.scrolled)
+
+        self.refresh_in_thread()
+        self._schedule_refresh()
+
+    def begin_power_state_apply(self, key):
+        if (
+            self.destroyed
+            or key not in getattr(self, "power_values", {})
+        ):
+            return False
+
+        source_id = self.power_apply_sources.pop(key, None)
+        if source_id is not None:
+            GLib.source_remove(source_id)
+
+        # A newer action for this field supersedes any older
+        # release that was waiting behind an in-flight refresh.
+        self.pending_power_release.discard(key)
+        self.pending_power_updates.add(key)
+        self.power_values[key].set_text("Applying…")
+        return True
+
+    def finish_power_state_apply(self, key, success):
+        if (
+            self.destroyed
+            or key not in self.pending_power_updates
+        ):
+            return False
+
+        if not success:
+            self.pending_power_updates.discard(key)
+            self.pending_power_release.discard(key)
+            self.request_refresh()
+            return True
+
+        source_id = GLib.timeout_add_seconds(
+            CONTROL_APPLY_DELAY_SECONDS,
+            self._release_power_state_apply,
+            key,
+        )
+        self.power_apply_sources[key] = source_id
+        return True
+
+    def _release_power_state_apply(self, key):
+        self.power_apply_sources.pop(key, None)
+
+        if (
+            self.destroyed
+            or key not in self.pending_power_updates
+        ):
+            return False
+
+        # Never let a report that started before this point replace
+        # "Applying…". If one is already running, queue a fresh one.
+        if self.refresh_in_progress:
+            self.pending_power_release.add(key)
+            self.refresh_pending = True
+            return False
+
+        self.pending_power_updates.discard(key)
+        self.refresh_in_thread()
+        return False
+
+    def _add_refresh_interval_menu(self):
+        refresh_item = Gtk.MenuItem(
+            label="Refresh interval"
+        )
+        refresh_menu = Gtk.Menu()
+        group = None
+
+        for seconds in REFRESH_INTERVALS:
+            label = (
+                f"{seconds} second"
+                if seconds == 1
+                else f"{seconds} seconds"
+            )
+
+            item = Gtk.RadioMenuItem.new_with_label(
+                group,
+                label,
+            )
+
+            if group is None:
+                group = item.get_group()
+
+            item.set_active(
+                seconds == self.refresh_interval
+            )
+
+            item.connect(
+                "toggled",
+                self._on_refresh_interval_selected,
+                seconds,
+            )
+
+            refresh_menu.append(item)
+
+        refresh_item.set_submenu(refresh_menu)
+
+        self.menu.menu.prepend(
+            Gtk.SeparatorMenuItem()
+        )
+        self.menu.menu.prepend(refresh_item)
+        self.menu.menu.show_all()
+
+    def _on_refresh_interval_selected(
+        self,
+        item,
+        seconds,
+    ):
+        if item.get_active():
+            self.set_refresh_interval(seconds)
+
+    def set_refresh_interval(self, seconds):
+        if seconds not in REFRESH_INTERVALS:
+            return
+
+        if seconds == self.refresh_interval:
+            return
+
+        self.refresh_interval = seconds
+        self._schedule_refresh()
+        self.request_refresh()
+
+    def _schedule_refresh(self):
+        if self.refresh_id is not None:
+            GLib.source_remove(self.refresh_id)
+
+        self.refresh_id = GLib.timeout_add_seconds(
+            self.refresh_interval,
+            self.refresh_in_thread,
+        )
+
+    def request_refresh(self):
+        if self.destroyed:
+            return False
+
+        if self.refresh_in_progress:
+            self.refresh_pending = True
+            return True
+
+        return self.refresh_in_thread()
+
+    def _run_pending_refresh(self):
+        if (
+            not self.refresh_pending
+            or self.destroyed
+        ):
+            return
+
+        self.refresh_pending = False
+
+        # These fields waited for an older report to finish.
+        # The refresh started below is therefore the first report
+        # collected after their apply delay elapsed.
+        for key in self.pending_power_release:
+            self.pending_power_updates.discard(key)
+        self.pending_power_release.clear()
+
+        self.refresh_in_thread()
+
+    def _cleanup_refresh(self, *_args):
+        self.destroyed = True
+        self.refresh_in_progress = False
+        self.refresh_pending = False
+
+        if self.refresh_id is not None:
+            GLib.source_remove(self.refresh_id)
+            self.refresh_id = None
+
+        for source_id in self.power_apply_sources.values():
+            GLib.source_remove(source_id)
+        self.power_apply_sources.clear()
+        self.pending_power_updates.clear()
+        self.pending_power_release.clear()
 
     def snap(self):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, halign=Gtk.Align.CENTER, valign=Gtk.Align.CENTER)
@@ -109,12 +767,16 @@ class ToolWindow(Gtk.Window):
         self.add(self.box)
 
     def monitor_mode(self):
-        self.monitor_view = MonitorModeView(self)
+        self.monitor_view = MonitorModeView(
+            self,
+            SystemReportView(),
+            refresh_interval=self.refresh_interval,
+        )
         self.add(self.monitor_view)
 
     def build(self):
         if IS_INSTALLED_WITH_SNAP: self.snap()
-        elif is_running("auto-cpufreq", "--daemon"): self.main()
+        elif daemon_is_running(): self.main()
         else: self.daemon_not_running()
 
     def load_css(self):
@@ -125,12 +787,43 @@ class ToolWindow(Gtk.Window):
         self.gtk_provider.load_from_file(Gio.File.new_for_path(CSS_FILE))
 
     def refresh_in_thread(self):
-        Thread(target=self._refresh).start()
+        if self.destroyed:
+            return False
+        if self.refresh_in_progress:
+            return True
+
+        self.refresh_in_progress = True
+        Thread(target=self._refresh, daemon=True).start()
         return True
 
     def _refresh(self):
-        self.systemstats.refresh()
-        self.currentgovernor.refresh()
-        self.batteryinfo.refresh()
-        self.cpufreqscaling.refresh()
-        self.systemstats_box.refresh()
+        try:
+            report = system_info.generate_system_report()
+        except Exception:
+            if not self.destroyed:
+                GLib.idle_add(self._finish_refresh)
+            return
+
+        if not self.destroyed:
+            GLib.idle_add(self._apply_refresh, report)
+
+    def _apply_refresh(self, report):
+        if self.destroyed:
+            self.refresh_in_progress = False
+            return False
+
+        try:
+            self.report_view.apply_report(
+                report,
+                self.pending_power_updates,
+            )
+        finally:
+            self.refresh_in_progress = False
+            self._run_pending_refresh()
+
+        return False
+
+    def _finish_refresh(self):
+        self.refresh_in_progress = False
+        self._run_pending_refresh()
+        return False

--- a/auto_cpufreq/gui/app.py
+++ b/auto_cpufreq/gui/app.py
@@ -10,11 +10,10 @@ from os.path import isfile
 from subprocess import PIPE, run
 from threading import Thread
 
-from auto_cpufreq.config.config import config, find_config_file
+from auto_cpufreq.config.config import config
 from auto_cpufreq.core import check_for_update, daemon_is_running
 from auto_cpufreq.globals import GITHUB, IS_INSTALLED_WITH_SNAP
 from auto_cpufreq.gui.objects import BluetoothBootControl, DaemonNotRunningView, DropDownMenu, MonitorModeView, RadioButtonView, CPUTurboOverride, UpdateDialog
-from auto_cpufreq.gui.objects import get_stats
 from auto_cpufreq.modules.system_info import system_info
 from auto_cpufreq.power_helper import bluetoothctl_exists
 
@@ -306,7 +305,7 @@ class SystemReportView(Gtk.Box):
             report.cpu_driver or "Unknown"
         )
 
-        config_path = config.path if config.has_config() else find_config_file(None)
+        config_path = config.path
         if config_path and isfile(config_path):
             self.config_label.set_text(f"Configuration: {config_path}")
             self.config_label.show()
@@ -493,7 +492,8 @@ class ToolWindow(Gtk.Window):
             group.add_widget(button)
             button.set_halign(Gtk.Align.START)
 
-        if "Warning: CPU turbo is not available" not in get_stats():
+        turbo_state, _ = system_info.turbo_on()
+        if turbo_state is not None:
             self.turbo_control = CPUTurboOverride()
             self.turbo_control.label.set_xalign(0.0)
             self.turbo_control.auto.set_margin_start(CONTROL_OPTION_MARGIN)
@@ -542,14 +542,28 @@ class ToolWindow(Gtk.Window):
         # observed governor/Turbo rows directly.
         self.power_values = self.report_view.power_values
 
+        self.refresh_error_label = Gtk.Label(label="")
+        self.refresh_error_label.set_halign(Gtk.Align.START)
+        self.refresh_error_label.set_xalign(0)
+        self.refresh_error_label.set_no_show_all(True)
+
         self.scrolled = Gtk.ScrolledWindow()
         self.scrolled.set_policy(
             Gtk.PolicyType.NEVER,
             Gtk.PolicyType.AUTOMATIC,
         )
-        self.scrolled.set_can_focus(False)
+        self.scrolled.set_can_focus(True)
         self.scrolled.add(self.report_view)
-        self.add(self.scrolled)
+
+        main_box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=8,
+        )
+        main_box.pack_start(
+            self.refresh_error_label, False, False, 0
+        )
+        main_box.pack_start(self.scrolled, True, True, 0)
+        self.add(main_box)
 
         self.refresh_in_thread()
         self._schedule_refresh()
@@ -749,18 +763,76 @@ class ToolWindow(Gtk.Window):
         response = dialog.run()
         dialog.destroy()
         if response != Gtk.ResponseType.YES: return
-        updater = run(["pkexec", "auto-cpufreq", "--update"], input="y\n", encoding="utf-8", stderr=PIPE)
-        if updater.returncode in (126, 127):
-            error = Gtk.MessageDialog(self, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, "Error updating")
-            error.format_secondary_text("Authorization Failed")
-            error.run()
-            error.destroy()
-            return
-        success = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO, Gtk.ButtonsType.OK, "Update successful")
-        success.format_secondary_text("The app will now close. Please reopen to apply changes")
+
+        self.set_sensitive(False)
+        Thread(target=self._run_update, daemon=True).start()
+
+    def _run_update(self):
+        try:
+            updater = run(
+                ["pkexec", "auto-cpufreq", "--update"],
+                input="y\n",
+                text=True,
+                stderr=PIPE,
+            )
+            error = None
+        except OSError as exc:
+            updater = None
+            error = exc
+
+        if not self.destroyed:
+            GLib.idle_add(
+                self._finish_update,
+                updater,
+                error,
+            )
+
+    def _finish_update(self, updater, error):
+        self.set_sensitive(True)
+
+        if error is not None:
+            message = str(error)
+        elif updater is None:
+            message = "Update command failed to start"
+        elif updater.returncode == 0:
+            message = None
+        elif updater.returncode == 126:
+            message = "Authorization was cancelled"
+        elif updater.returncode == 127:
+            message = "Authorization failed"
+        else:
+            message = (updater.stderr or "").strip() or (
+                "Update failed with exit status "
+                f"{updater.returncode}"
+            )
+
+        if message is not None:
+            dialog = Gtk.MessageDialog(
+                self,
+                0,
+                Gtk.MessageType.ERROR,
+                Gtk.ButtonsType.OK,
+                "Error updating",
+            )
+            dialog.format_secondary_text(message)
+            dialog.run()
+            dialog.destroy()
+            return False
+
+        success = Gtk.MessageDialog(
+            self,
+            0,
+            Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            "Update successful",
+        )
+        success.format_secondary_text(
+            "The app will now close. Please reopen to apply changes"
+        )
         success.run()
         success.destroy()
-        exit(0)
+        self.destroy()
+        return False
 
     def daemon_not_running(self):
         self.box = DaemonNotRunningView(self)
@@ -799,9 +871,12 @@ class ToolWindow(Gtk.Window):
     def _refresh(self):
         try:
             report = system_info.generate_system_report()
-        except Exception:
+        except Exception as error:
             if not self.destroyed:
-                GLib.idle_add(self._finish_refresh)
+                GLib.idle_add(
+                    self._finish_refresh_error,
+                    str(error),
+                )
             return
 
         if not self.destroyed:
@@ -817,13 +892,29 @@ class ToolWindow(Gtk.Window):
                 report,
                 self.pending_power_updates,
             )
+            self.refresh_error_label.hide()
+        except Exception as error:
+            self.refresh_error_label.set_text(
+                "Unable to refresh system information: "
+                f"{error}"
+            )
+            self.refresh_error_label.show()
         finally:
             self.refresh_in_progress = False
             self._run_pending_refresh()
 
         return False
 
-    def _finish_refresh(self):
+    def _finish_refresh_error(self, message):
+        if self.destroyed:
+            self.refresh_in_progress = False
+            return False
+
+        self.refresh_error_label.set_text(
+            "Unable to refresh system information: "
+            f"{message}"
+        )
+        self.refresh_error_label.show()
         self.refresh_in_progress = False
         self._run_pending_refresh()
         return False

--- a/auto_cpufreq/gui/app.py
+++ b/auto_cpufreq/gui/app.py
@@ -6,7 +6,6 @@ from gi.repository import Gdk, GdkPixbuf, Gio, GLib, Gtk
 
 from contextlib import redirect_stdout
 from io import StringIO
-from os.path import isfile
 from subprocess import PIPE, run
 from threading import Thread
 
@@ -107,6 +106,15 @@ def _turbo_status(report):
     return "On" if enabled else "Off"
 
 
+def _configuration_label_text():
+    prefix = (
+        "Using configuration file"
+        if config.has_config()
+        else "Configuration file"
+    )
+    return f"{prefix}: {config.path}"
+
+
 class SystemReportView(Gtk.Box):
     """Shared read-only presentation of SystemReport."""
 
@@ -140,12 +148,6 @@ class SystemReportView(Gtk.Box):
         ):
             _, self.system_values[key] = _add_row(system_grid, row, name)
         self.left_column.pack_start(system_frame, False, False, 0)
-
-        self.config_label = Gtk.Label(label="")
-        self.config_label.set_halign(Gtk.Align.START)
-        self.config_label.set_xalign(0)
-        self.config_label.set_line_wrap(True)
-        self.left_column.pack_start(self.config_label, False, False, 0)
 
         cpu_frame = Gtk.Frame()
         cpu_heading = Gtk.Label(label="CPU Statistics", name="bold")
@@ -238,7 +240,7 @@ class SystemReportView(Gtk.Box):
             )
         ):
             _, self.stats_values[key] = _add_row(stats_grid, row, name)
-        self.right_column.pack_start(stats_frame, False, False, 0)
+        self.left_column.pack_start(stats_frame, False, False, 0)
 
         self.pack_start(self.columns, True, True, 0)
 
@@ -304,13 +306,6 @@ class SystemReportView(Gtk.Box):
         self.system_values["driver"].set_text(
             report.cpu_driver or "Unknown"
         )
-
-        config_path = config.path
-        if config_path and isfile(config_path):
-            self.config_label.set_text(f"Configuration: {config_path}")
-            self.config_label.show()
-        else:
-            self.config_label.hide()
 
         self.max_freq_value.set_text(
             f"{report.cpu_max_freq:.0f} MHz"
@@ -464,9 +459,16 @@ class ToolWindow(Gtk.Window):
         controls_box.set_margin_end(10)
         controls_frame.add(controls_box)
 
+        controls_actions = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=10,
+        )
+        controls_actions.set_halign(Gtk.Align.END)
+        controls_box.pack_start(controls_actions, False, False, 0)
+
         self.menu = DropDownMenu(self)
         self._add_refresh_interval_menu()
-        controls_box.pack_start(self.menu, False, False, 0)
+        controls_actions.pack_end(self.menu, False, False, 0)
 
         self.governor_control = RadioButtonView()
         self.governor_control.label.set_xalign(0.0)
@@ -511,7 +513,15 @@ class ToolWindow(Gtk.Window):
                 button.set_halign(Gtk.Align.START)
 
         if bluetoothctl_exists:
-            self.bluetooth_control = BluetoothBootControl()
+            self.bluetooth_control = BluetoothBootControl(
+                show_advanced_button=False
+            )
+            controls_actions.pack_end(
+                self.bluetooth_control.advanced_btn,
+                False,
+                False,
+                0,
+            )
             self.bluetooth_control.label.set_xalign(0.0)
             self.bluetooth_control.on_btn.set_margin_start(
                 CONTROL_OPTION_MARGIN
@@ -535,6 +545,16 @@ class ToolWindow(Gtk.Window):
             controls_box.pack_start(
                 self.bluetooth_control, False, False, 0
             )
+
+        self.config_label = Gtk.Label(
+            label=_configuration_label_text()
+        )
+        self.config_label.set_halign(Gtk.Align.START)
+        self.config_label.set_xalign(0)
+        self.config_label.set_line_wrap(True)
+        controls_box.pack_start(
+            self.config_label, False, False, 0
+        )
 
         self.report_view.prepend_right(controls_frame)
 
@@ -891,6 +911,9 @@ class ToolWindow(Gtk.Window):
             self.report_view.apply_report(
                 report,
                 self.pending_power_updates,
+            )
+            self.config_label.set_text(
+                _configuration_label_text()
             )
             self.refresh_error_label.hide()
         except Exception as error:

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -1,9 +1,10 @@
 import gi
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 import sys
-from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from os.path import isfile
 from platform import python_version
@@ -59,6 +60,44 @@ def get_bluetooth_boot_status():
     except Exception:
         return None
 
+def _run_privileged_async(arguments, callback):
+    def worker():
+        try:
+            result = run(
+                ["pkexec", "auto-cpufreq", *arguments],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+            error = None
+        except OSError as e:
+            result = None
+            error = e
+
+        GLib.idle_add(callback, result, error)
+
+    Thread(target=worker, daemon=True).start()
+
+
+def _privileged_command_error(result, error):
+    if error is not None:
+        return str(error)
+    if result is None:
+        return "Command failed to start"
+    if result.returncode == 0:
+        return None
+    if result.returncode == 126:
+        return "Authorization was cancelled"
+    if result.returncode == 127:
+        return "Authorization failed"
+
+    stderr = (result.stderr or "").strip()
+    return stderr or (
+        f"Command failed with exit status "
+        f"{result.returncode}"
+    )
+
+
 class RadioButtonView(Gtk.Box):
     def __init__(self):
         super().__init__(orientation=Gtk.Orientation.HORIZONTAL)
@@ -88,13 +127,26 @@ class RadioButtonView(Gtk.Box):
         self.pack_start(self.performance, True, True, 0)
 
     def on_button_toggled(self, button, override):
-        if button.get_active():
-            if not self.set_by_app:
-                result = run(f"pkexec auto-cpufreq --force={override}", shell=True, stdout=PIPE, stderr=PIPE)
-                if result.returncode in (126, 127):
-                    self.set_by_app = True
-                    self.set_selected()
-            else: self.set_by_app = False
+        if not button.get_active():
+            return
+        if self.set_by_app:
+            self.set_by_app = False
+            return
+
+        self.set_sensitive(False)
+        _run_privileged_async(
+            [f"--force={override}"],
+            self._finish_command,
+        )
+
+    def _finish_command(self, result, error):
+        self.set_sensitive(True)
+
+        if _privileged_command_error(result, error) is not None:
+            self.set_by_app = True
+            self.set_selected()
+
+        return False
 
     def set_selected(self):
         override = get_override()
@@ -134,13 +186,26 @@ class CPUTurboOverride(Gtk.Box):
         self.pack_start(self.always, True, True, 0)
 
     def on_button_toggled(self, button, override):
-        if button.get_active():
-            if not self.set_by_app:
-                result = run(f"pkexec auto-cpufreq --turbo={override}", shell=True, stdout=PIPE, stderr=PIPE)
-                if result.returncode in (126, 127):
-                    self.set_by_app = True
-                    self.set_selected()
-            else: self.set_by_app = False
+        if not button.get_active():
+            return
+        if self.set_by_app:
+            self.set_by_app = False
+            return
+
+        self.set_sensitive(False)
+        _run_privileged_async(
+            [f"--turbo={override}"],
+            self._finish_command,
+        )
+
+    def _finish_command(self, result, error):
+        self.set_sensitive(True)
+
+        if _privileged_command_error(result, error) is not None:
+            self.set_by_app = True
+            self.set_selected()
+
+        return False
 
     def set_selected(self):
         override = get_turbo_override()
@@ -199,16 +264,32 @@ class BluetoothBootControl(Gtk.Box):
             self.advanced_btn.set_label("Hide Advanced Settings")
 
     def on_button_toggled(self, button, action):
-        if button.get_active():
-            if not self.set_by_app:
-                if action == "on":
-                    result = run("pkexec auto-cpufreq --bluetooth_boot_on", shell=True, stdout=PIPE, stderr=PIPE)
-                else:
-                    result = run("pkexec auto-cpufreq --bluetooth_boot_off", shell=True, stdout=PIPE, stderr=PIPE)
-                if result.returncode in (126, 127):
-                    self.set_by_app = True
-                    self.set_selected()
-            else: self.set_by_app = False
+        if not button.get_active():
+            return
+        if self.set_by_app:
+            self.set_by_app = False
+            return
+
+        option = (
+            "--bluetooth_boot_on"
+            if action == "on"
+            else "--bluetooth_boot_off"
+        )
+
+        self.set_sensitive(False)
+        _run_privileged_async(
+            [option],
+            self._finish_command,
+        )
+
+    def _finish_command(self, result, error):
+        self.set_sensitive(True)
+
+        if _privileged_command_error(result, error) is not None:
+            self.set_by_app = True
+            self.set_selected()
+
+        return False
 
     def set_selected(self):
         status = get_bluetooth_boot_status()
@@ -518,37 +599,65 @@ class DropDownMenu(Gtk.MenuButton):
         dialog.destroy()
 
     def _remove_daemon(self, MenuItem, parent):
-        confirm = ConfirmDialog(parent, message="Are you sure you want to remove the daemon?")
+        confirm = ConfirmDialog(
+            parent,
+            message="Are you sure you want to remove the daemon?",
+        )
         response = confirm.run()
         confirm.destroy()
-        if response == Gtk.ResponseType.YES:
-            try:
-                # run in thread to prevent GUI from hanging
-                with ThreadPoolExecutor() as executor:
-                    kwargs = {"shell": True, "stdout": PIPE, "stderr": PIPE}
-                    future = executor.submit(run, "pkexec auto-cpufreq --remove", **kwargs)
-                    result = future.result()
-                assert result.returncode not in (126, 127), Exception("Authorization was cancelled")
-                dialog = Gtk.MessageDialog(
-                    transient_for=parent,
-                    message_type=Gtk.MessageType.INFO,
-                    buttons=Gtk.ButtonsType.OK,
-                    text="Daemon successfully removed"
-                )
-                dialog.format_secondary_text("The app will now close. Please reopen to apply changes")
-                dialog.run()
-                dialog.destroy()
-                parent.destroy()
-            except Exception as e:
-                dialog = Gtk.MessageDialog(
-                    transient_for=parent,
-                    message_type=Gtk.MessageType.ERROR,
-                    buttons=Gtk.ButtonsType.OK,
-                    text="Daemon removal failed"
-                )
-                dialog.format_secondary_text(f"The following error occured:\n{e}")
-                dialog.run()
-                dialog.destroy()
+
+        if response != Gtk.ResponseType.YES:
+            return
+
+        self.set_sensitive(False)
+        _run_privileged_async(
+            ["--remove"],
+            lambda result, error: self._finish_remove(
+                parent,
+                result,
+                error,
+            ),
+        )
+
+    def _finish_remove(self, parent, result, error):
+        self.set_sensitive(True)
+
+        try:
+            command_error = _privileged_command_error(
+                result,
+                error,
+            )
+            if command_error is not None:
+                raise RuntimeError(command_error)
+
+            dialog = Gtk.MessageDialog(
+                transient_for=parent,
+                message_type=Gtk.MessageType.INFO,
+                buttons=Gtk.ButtonsType.OK,
+                text="Daemon successfully removed",
+            )
+            dialog.format_secondary_text(
+                "The app will now close. "
+                "Please reopen to apply changes"
+            )
+            dialog.run()
+            dialog.destroy()
+            parent.destroy()
+
+        except Exception as e:
+            dialog = Gtk.MessageDialog(
+                transient_for=parent,
+                message_type=Gtk.MessageType.ERROR,
+                buttons=Gtk.ButtonsType.OK,
+                text="Daemon removal failed",
+            )
+            dialog.format_secondary_text(
+                f"The following error occured:\n{e}"
+            )
+            dialog.run()
+            dialog.destroy()
+
+        return False
 
 class AboutDialog(Gtk.Dialog):
     def __init__(self, parent):
@@ -646,33 +755,50 @@ class MonitorModeView(Gtk.Box):
 
         self.pack_start(self.columns, True, True, 0)
 
-        self.refresh()
-        self.refresh_id = GLib.timeout_add_seconds(5, self.refresh_in_thread)
+        self.refresh_id = None
+        self.refresh_in_thread()
 
     def refresh_in_thread(self):
+        self.refresh_id = None
         if not self.running:
             return False
+
         Thread(target=self._refresh, daemon=True).start()
-        return True
+        return False
 
     def _refresh(self):
         try:
             report = system_info.generate_system_report()
-            GLib.idle_add(self._update_display, report)
-        except Exception as e:
-            GLib.idle_add(self._show_error, str(e))
+            suggested_governor = system_info.governor_suggestion(report)
 
-    def refresh(self):
-        try:
-            report = system_info.generate_system_report()
-            self._update_display(report)
+            suggested_turbo = None
+            if report.is_turbo_on[0] is not None:
+                suggested_turbo = system_info.turbo_on_suggestion(report)
         except Exception as e:
-            self._show_error(str(e))
+            if self.running:
+                GLib.idle_add(self._show_error, str(e))
+            return
+
+        if self.running:
+            GLib.idle_add(
+                self._update_display,
+                report,
+                suggested_governor,
+                suggested_turbo,
+            )
 
     def _show_error(self, error_msg):
+        if not self.running:
+            return False
+
         self._clear_boxes()
         self.left_box.pack_start(self._label(f"Error: {error_msg}"), False, False, 0)
         self.left_box.show_all()
+        self.refresh_id = GLib.timeout_add_seconds(
+            5,
+            self.refresh_in_thread,
+        )
+        return False
 
     def _clear_boxes(self):
         for child in self.left_box.get_children():
@@ -701,7 +827,15 @@ class MonitorModeView(Gtk.Box):
         label.set_halign(Gtk.Align.START)
         return label
 
-    def _update_display(self, report):
+    def _update_display(
+        self,
+        report,
+        suggested_governor,
+        suggested_turbo,
+    ):
+        if not self.running:
+            return False
+
         self._clear_boxes()
 
         current_time = time.strftime("%H:%M:%S")
@@ -712,7 +846,17 @@ class MonitorModeView(Gtk.Box):
         self.left_box.pack_start(self._label(f"Linux distro: {report.distro_name} {report.distro_ver}"), False, False, 0)
         self.left_box.pack_start(self._label(f"Linux kernel: {report.kernel_version}"), False, False, 0)
         self.left_box.pack_start(self._label(f"Processor: {report.processor_model}"), False, False, 0)
-        self.left_box.pack_start(self._label(f"Cores: {report.total_core}"), False, False, 0)
+        core_count = (
+            str(report.total_core)
+            if report.total_core is not None
+            else "Unknown"
+        )
+        self.left_box.pack_start(
+            self._label(f"Cores: {core_count}"),
+            False,
+            False,
+            0,
+        )
         self.left_box.pack_start(self._label(f"Architecture: {report.arch}"), False, False, 0)
         self.left_box.pack_start(self._label(f"Driver: {report.cpu_driver}"), False, False, 0)
 
@@ -729,9 +873,24 @@ class MonitorModeView(Gtk.Box):
         self.left_box.pack_start(self._label("Core    Usage   Temperature     Frequency"), False, False, 0)
 
         for core in report.cores_info:
+            temperature = (
+                f"{core.temperature:>6.0f} °C"
+                if core.temperature > 0
+                else "     —"
+            )
+            frequency = (
+                f"{core.frequency:>6.0f} MHz"
+                if core.frequency > 0
+                else "     —"
+            )
             self.left_box.pack_start(
-                self._label(f"CPU{core.id:<2}    {core.usage:>4.1f}%    {core.temperature:>6.0f} °C    {core.frequency:>6.0f} MHz"),
-                False, False, 0
+                self._label(
+                    f"CPU{core.id:<2}    {core.usage:>4.1f}%    "
+                    f"{temperature}    {frequency}"
+                ),
+                False,
+                False,
+                0,
             )
 
         if report.cpu_fan_speed:
@@ -754,26 +913,42 @@ class MonitorModeView(Gtk.Box):
         current_gov = report.current_gov if report.current_gov else "Unknown"
         self.right_box.pack_start(self._label(f'Setting to use: "{current_gov}" governor'), False, False, 0)
 
-        suggested_gov = system_info.governor_suggestion()
-        if report.current_gov and suggested_gov != report.current_gov:
-            self.right_box.pack_start(self._suggestion(f'Suggesting use of: "{suggested_gov}" governor'), False, False, 0)
+        if (
+            report.current_gov
+            and suggested_governor is not None
+            and suggested_governor != report.current_gov
+        ):
+            self.right_box.pack_start(
+                self._suggestion(
+                    f'Suggesting use of: "{suggested_governor}" governor'
+                ),
+                False,
+                False,
+                0,
+            )
 
         if report.current_epp:
             self.right_box.pack_start(self._label(f"Current EPP: {report.current_epp}"), False, False, 0)
         else:
             self.right_box.pack_start(self._label("Not setting EPP (not supported by system)"), False, False, 0)
 
-        if report.current_epb:
-            self.right_box.pack_start(self._label(f"Current EPB: {report.current_epb}"), False, False, 0)
-
         if report.current_hwp_dynamic_boost is not None:
-            state = "on" if report.current_hwp_dynamic_boost else "off"
+            state = (
+                "on"
+                if report.current_hwp_dynamic_boost
+                else "off"
+            )
             self.right_box.pack_start(
-                self._label(f"Intel HWP Dynamic Boost: {state}"),
+                self._label(
+                    f"Intel HWP Dynamic Boost: {state}"
+                ),
                 False,
                 False,
                 0,
             )
+
+        if report.current_epb:
+            self.right_box.pack_start(self._label(f"Current EPB: {report.current_epb}"), False, False, 0)
 
         self.right_box.pack_start(self._label(""), False, False, 0)
 
@@ -781,10 +956,25 @@ class MonitorModeView(Gtk.Box):
         self.right_box.pack_start(self._label(f"Total CPU usage: {report.cpu_usage:.1f} %"), False, False, 0)
         self.right_box.pack_start(self._label(f"Total system load: {report.load:.2f}"), False, False, 0)
 
-        avg_temp = 0.0
-        if report.cores_info:
-            avg_temp = sum(core.temperature for core in report.cores_info) / len(report.cores_info)
-            self.right_box.pack_start(self._label(f"Average temp. of all cores: {avg_temp:.2f} °C"), False, False, 0)
+        avg_temp = report.cpu_avg_temp
+        if avg_temp is None:
+            temperatures = [
+                core.temperature
+                for core in report.cores_info
+                if core.temperature > 0
+            ]
+            if temperatures:
+                avg_temp = sum(temperatures) / len(temperatures)
+
+        if avg_temp is not None:
+            self.right_box.pack_start(
+                self._label(
+                    f"Average temp. of all cores: {avg_temp:.2f} °C"
+                ),
+                False,
+                False,
+                0,
+            )
 
         if report.avg_load:
             load_status = "Load optimal" if report.load < 1.0 else "Load high"
@@ -793,12 +983,18 @@ class MonitorModeView(Gtk.Box):
                 False, False, 0
             )
 
-        if report.cores_info:
+        if avg_temp is not None:
             usage_status = "Optimal" if report.cpu_usage < 70 else "High"
             temp_status = "high" if avg_temp > 75 else "normal"
             self.right_box.pack_start(
-                self._label(f"{usage_status} total CPU usage: {report.cpu_usage:.1f}%, {temp_status} average core temp: {avg_temp:.1f}°C"),
-                False, False, 0
+                self._label(
+                    f"{usage_status} total CPU usage: "
+                    f"{report.cpu_usage:.1f}%, {temp_status} "
+                    f"average core temp: {avg_temp:.1f}°C"
+                ),
+                False,
+                False,
+                0,
             )
 
         turbo_status = "Unknown"
@@ -808,14 +1004,30 @@ class MonitorModeView(Gtk.Box):
             turbo_status = f"Auto mode {'enabled' if report.is_turbo_on[1] else 'disabled'}"
         self.right_box.pack_start(self._label(f"Setting turbo boost: {turbo_status}"), False, False, 0)
 
-        if report.is_turbo_on[0] is not None:
-            suggested_turbo = system_info.turbo_on_suggestion()
-            if suggested_turbo != report.is_turbo_on[0]:
-                turbo_text = "on" if suggested_turbo else "off"
-                self.right_box.pack_start(self._suggestion(f"Suggesting to set turbo boost: {turbo_text}"), False, False, 0)
+        if (
+            report.is_turbo_on[0] is not None
+            and suggested_turbo is not None
+            and suggested_turbo != report.is_turbo_on[0]
+        ):
+            turbo_text = "on" if suggested_turbo else "off"
+            self.right_box.pack_start(
+                self._suggestion(
+                    f"Suggesting to set turbo boost: {turbo_text}"
+                ),
+                False,
+                False,
+                0,
+            )
 
         self.left_box.show_all()
         self.right_box.show_all()
+
+        if self.running:
+            self.refresh_id = GLib.timeout_add_seconds(
+                5,
+                self.refresh_in_thread,
+            )
+
         return False
 
     def on_back_clicked(self, button):
@@ -826,8 +1038,9 @@ class MonitorModeView(Gtk.Box):
 
     def cleanup(self):
         self.running = False
-        if hasattr(self, 'refresh_id') and self.refresh_id:
+        if self.refresh_id is not None:
             GLib.source_remove(self.refresh_id)
+            self.refresh_id = None
 
 
 class DaemonNotRunningView(Gtk.Box):
@@ -857,34 +1070,52 @@ class DaemonNotRunningView(Gtk.Box):
         parent.show_all()
 
     def install_daemon(self, button, parent):
+        self.set_sensitive(False)
+        _run_privileged_async(
+            ["--install"],
+            lambda result, error: self._finish_install(
+                parent,
+                result,
+                error,
+            ),
+        )
+
+    def _finish_install(self, parent, result, error):
+        self.set_sensitive(True)
+
         try:
-            # run in thread to prevent GUI from hanging
-            with ThreadPoolExecutor() as executor:
-                kwargs = {"shell": True, "stdout": PIPE, "stderr": PIPE}
-                future = executor.submit(run, "pkexec auto-cpufreq --install", **kwargs)
-                result = future.result()
-            if result.returncode in (126, 127):
-                raise RuntimeError("Authorization was cancelled")
-            # enable for debug. causes issues if kept
-            # elif result.stderr is not None:
-            #     raise Exception(result.stderr.decode())
+            command_error = _privileged_command_error(
+                result,
+                error,
+            )
+            if command_error is not None:
+                raise RuntimeError(command_error)
+
             dialog = Gtk.MessageDialog(
                 transient_for=parent,
                 message_type=Gtk.MessageType.INFO,
                 buttons=Gtk.ButtonsType.OK,
-                text="Daemon successfully installed"
+                text="Daemon successfully installed",
             )
-            dialog.format_secondary_text("The app will now close. Please reopen to apply changes")
+            dialog.format_secondary_text(
+                "The app will now close. "
+                "Please reopen to apply changes"
+            )
             dialog.run()
             dialog.destroy()
             parent.destroy()
+
         except Exception as e:
             dialog = Gtk.MessageDialog(
                 transient_for=parent,
                 message_type=Gtk.MessageType.ERROR,
                 buttons=Gtk.ButtonsType.OK,
-                text="Daemon install failed"
+                text="Daemon install failed",
             )
-            dialog.format_secondary_text(f"The following error occured:\n{e}")
+            dialog.format_secondary_text(
+                f"The following error occured:\n{e}"
+            )
             dialog.run()
             dialog.destroy()
+
+        return False

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -98,6 +98,42 @@ def _privileged_command_error(result, error):
     )
 
 
+def _request_status_refresh(widget):
+    parent = widget.get_toplevel()
+    refresh = getattr(parent, "request_refresh", None)
+
+    if callable(refresh):
+        refresh()
+
+
+def _run_power_state_command(
+    widget,
+    state_key,
+    arguments,
+    callback,
+):
+    parent = widget.get_toplevel()
+    begin = getattr(parent, "begin_power_state_apply", None)
+    finish = getattr(parent, "finish_power_state_apply", None)
+
+    tracked = (
+        callable(begin)
+        and callable(finish)
+        and begin(state_key)
+    )
+
+    def complete(result, error):
+        if tracked:
+            finish(
+                state_key,
+                _privileged_command_error(result, error) is None,
+            )
+
+        return callback(result, error)
+
+    _run_privileged_async(arguments, complete)
+
+
 class RadioButtonView(Gtk.Box):
     def __init__(self):
         super().__init__(orientation=Gtk.Orientation.HORIZONTAL)
@@ -134,7 +170,9 @@ class RadioButtonView(Gtk.Box):
             return
 
         self.set_sensitive(False)
-        _run_privileged_async(
+        _run_power_state_command(
+            self,
+            "governor",
             [f"--force={override}"],
             self._finish_command,
         )
@@ -142,7 +180,9 @@ class RadioButtonView(Gtk.Box):
     def _finish_command(self, result, error):
         self.set_sensitive(True)
 
-        if _privileged_command_error(result, error) is not None:
+        if _privileged_command_error(result, error) is None:
+            _request_status_refresh(self)
+        else:
             self.set_by_app = True
             self.set_selected()
 
@@ -193,7 +233,9 @@ class CPUTurboOverride(Gtk.Box):
             return
 
         self.set_sensitive(False)
-        _run_privileged_async(
+        _run_power_state_command(
+            self,
+            "turbo",
             [f"--turbo={override}"],
             self._finish_command,
         )
@@ -201,7 +243,9 @@ class CPUTurboOverride(Gtk.Box):
     def _finish_command(self, result, error):
         self.set_sensitive(True)
 
-        if _privileged_command_error(result, error) is not None:
+        if _privileged_command_error(result, error) is None:
+            _request_status_refresh(self)
+        else:
             self.set_by_app = True
             self.set_selected()
 
@@ -720,63 +764,170 @@ class ConfirmDialog(Gtk.Dialog):
 
 
 class MonitorModeView(Gtk.Box):
-    def __init__(self, parent):
-        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+    def __init__(
+        self,
+        parent,
+        report_view,
+        refresh_interval=5,
+    ):
+        super().__init__(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=12,
+        )
         self.parent = parent
+        self.report_view = report_view
         self.running = True
-
-        self.header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        self.header.set_margin_bottom(10)
-
-        self.title = Gtk.Label(label="Monitor Mode", name="bold")
-        self.title.set_halign(Gtk.Align.START)
-        self.header.pack_start(self.title, True, True, 0)
-
-        self.back_button = Gtk.Button.new_with_label("Back")
-        self.back_button.connect("clicked", self.on_back_clicked)
-        self.header.pack_end(self.back_button, False, False, 0)
-
-        self.pack_start(self.header, False, False, 0)
-
-        self.columns = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
-        self.columns.set_vexpand(True)
-        self.columns.set_hexpand(True)
-
-        self.left_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
-        self.left_box.set_valign(Gtk.Align.START)
-        self.columns.pack_start(self.left_box, True, True, 0)
-
-        self.separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
-        self.columns.pack_start(self.separator, False, False, 0)
-
-        self.right_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
-        self.right_box.set_valign(Gtk.Align.START)
-        self.columns.pack_start(self.right_box, True, True, 0)
-
-        self.pack_start(self.columns, True, True, 0)
-
+        self.refresh_interval = refresh_interval
         self.refresh_id = None
+
+        self.header = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL
+        )
+        self.header.set_margin_bottom(2)
+
+        self.title = Gtk.Label(
+            label="Monitor Mode",
+            name="bold",
+        )
+        self.title.set_halign(Gtk.Align.START)
+        self.header.pack_start(
+            self.title, True, True, 0
+        )
+
+        self.back_button = Gtk.Button.new_with_label(
+            "Back"
+        )
+        self.back_button.connect(
+            "clicked",
+            self.on_back_clicked,
+        )
+        self.header.pack_end(
+            self.back_button, False, False, 0
+        )
+
+        self.pack_start(
+            self.header, False, False, 0
+        )
+
+        self.error_label = Gtk.Label(label="")
+        self.error_label.set_halign(Gtk.Align.START)
+        self.error_label.set_xalign(0)
+        self.error_label.set_no_show_all(True)
+        self.pack_start(
+            self.error_label, False, False, 0
+        )
+
+        suggestions = Gtk.Frame()
+        heading = Gtk.Label(
+            label="Suggestions",
+            name="bold",
+        )
+        heading.set_halign(Gtk.Align.START)
+        suggestions.set_label_widget(heading)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(18)
+        grid.set_row_spacing(4)
+        grid.set_margin_top(8)
+        grid.set_margin_bottom(8)
+        grid.set_margin_start(10)
+        grid.set_margin_end(10)
+        suggestions.add(grid)
+
+        governor_name = Gtk.Label(label="Governor")
+        governor_name.set_halign(Gtk.Align.START)
+        governor_name.set_xalign(0)
+
+        self.governor_suggestion = Gtk.Label(
+            label="—"
+        )
+        self.governor_suggestion.set_halign(
+            Gtk.Align.START
+        )
+        self.governor_suggestion.set_xalign(0)
+
+        grid.attach(governor_name, 0, 0, 1, 1)
+        grid.attach(
+            self.governor_suggestion,
+            1, 0, 1, 1,
+        )
+
+        self.turbo_name = Gtk.Label(
+            label="Turbo Boost"
+        )
+        self.turbo_name.set_halign(Gtk.Align.START)
+        self.turbo_name.set_xalign(0)
+        self.turbo_name.set_no_show_all(True)
+
+        self.turbo_suggestion = Gtk.Label(
+            label="—"
+        )
+        self.turbo_suggestion.set_halign(
+            Gtk.Align.START
+        )
+        self.turbo_suggestion.set_xalign(0)
+        self.turbo_suggestion.set_no_show_all(True)
+
+        grid.attach(self.turbo_name, 0, 1, 1, 1)
+        grid.attach(
+            self.turbo_suggestion,
+            1, 1, 1, 1,
+        )
+
+        self.report_view.prepend_right(
+            suggestions
+        )
+
+        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled.set_policy(
+            Gtk.PolicyType.NEVER,
+            Gtk.PolicyType.AUTOMATIC,
+        )
+        self.scrolled.set_can_focus(False)
+        self.scrolled.add(self.report_view)
+
+        self.pack_start(
+            self.scrolled, True, True, 0
+        )
+
         self.refresh_in_thread()
 
     def refresh_in_thread(self):
         self.refresh_id = None
+
         if not self.running:
             return False
 
-        Thread(target=self._refresh, daemon=True).start()
+        Thread(
+            target=self._refresh,
+            daemon=True,
+        ).start()
+
         return False
 
     def _refresh(self):
         try:
-            report = system_info.generate_system_report()
-            suggested_governor = system_info.governor_suggestion(report)
+            report = (
+                system_info.generate_system_report()
+            )
+            suggested_governor = (
+                system_info.governor_suggestion(report)
+            )
 
             suggested_turbo = None
             if report.is_turbo_on[0] is not None:
-                suggested_turbo = system_info.turbo_on_suggestion(report)
-        except Exception as e:
+                suggested_turbo = (
+                    system_info.turbo_on_suggestion(
+                        report
+                    )
+                )
+
+        except Exception as error:
             if self.running:
-                GLib.idle_add(self._show_error, str(e))
+                GLib.idle_add(
+                    self._show_error,
+                    str(error),
+                )
             return
 
         if self.running:
@@ -787,45 +938,23 @@ class MonitorModeView(Gtk.Box):
                 suggested_turbo,
             )
 
-    def _show_error(self, error_msg):
+    def _show_error(self, message):
         if not self.running:
             return False
 
-        self._clear_boxes()
-        self.left_box.pack_start(self._label(f"Error: {error_msg}"), False, False, 0)
-        self.left_box.show_all()
-        self.refresh_id = GLib.timeout_add_seconds(
-            5,
-            self.refresh_in_thread,
+        self.error_label.set_text(
+            "Unable to refresh system information: "
+            f"{message}"
+        )
+        self.error_label.show()
+
+        self.refresh_id = (
+            GLib.timeout_add_seconds(
+                self.refresh_interval,
+                self.refresh_in_thread,
+            )
         )
         return False
-
-    def _clear_boxes(self):
-        for child in self.left_box.get_children():
-            self.left_box.remove(child)
-        for child in self.right_box.get_children():
-            self.right_box.remove(child)
-
-    def _header(self, text):
-        label = Gtk.Label(label=text, name="bold")
-        label.set_halign(Gtk.Align.START)
-        return label
-
-    def _label(self, text):
-        label = Gtk.Label(label=text)
-        label.set_halign(Gtk.Align.START)
-        return label
-
-    def _suggestion(self, text):
-        label = Gtk.Label(label=text)
-        label.set_halign(Gtk.Align.START)
-        label.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(0.9, 0.7, 0.1, 1.0))
-        return label
-
-    def _separator(self, text):
-        label = Gtk.Label(label="-" * 28 + f" {text} " + "-" * 28)
-        label.set_halign(Gtk.Align.START)
-        return label
 
     def _update_display(
         self,
@@ -836,201 +965,63 @@ class MonitorModeView(Gtk.Box):
         if not self.running:
             return False
 
-        self._clear_boxes()
-
-        current_time = time.strftime("%H:%M:%S")
-        self.title.set_text(f"Monitor Mode - {current_time}")
-
-
-        self.left_box.pack_start(self._separator("System Information"), False, False, 5)
-        self.left_box.pack_start(self._label(f"Linux distro: {report.distro_name} {report.distro_ver}"), False, False, 0)
-        self.left_box.pack_start(self._label(f"Linux kernel: {report.kernel_version}"), False, False, 0)
-        self.left_box.pack_start(self._label(f"Processor: {report.processor_model}"), False, False, 0)
-        core_count = (
-            str(report.total_core)
-            if report.total_core is not None
-            else "Unknown"
+        self.error_label.hide()
+        self.title.set_text(
+            "Monitor Mode - "
+            f"{time.strftime('%H:%M:%S')}"
         )
-        self.left_box.pack_start(
-            self._label(f"Cores: {core_count}"),
-            False,
-            False,
-            0,
-        )
-        self.left_box.pack_start(self._label(f"Architecture: {report.arch}"), False, False, 0)
-        self.left_box.pack_start(self._label(f"Driver: {report.cpu_driver}"), False, False, 0)
 
-        config_path = config.path if config.has_config() else find_config_file(None)
-        if isfile(config_path):
-            self.left_box.pack_start(self._label(f"\nUsing settings defined in {config_path}"), False, False, 0)
-
-        self.left_box.pack_start(self._label(""), False, False, 0)
-
-        self.left_box.pack_start(self._separator("Current CPU Stats"), False, False, 5)
-        self.left_box.pack_start(self._label(f"CPU max frequency: {report.cpu_max_freq:.0f} MHz" if report.cpu_max_freq else "CPU max frequency: Unknown"), False, False, 0)
-        self.left_box.pack_start(self._label(f"CPU min frequency: {report.cpu_min_freq:.0f} MHz" if report.cpu_min_freq else "CPU min frequency: Unknown"), False, False, 0)
-        self.left_box.pack_start(self._label(""), False, False, 0)
-        self.left_box.pack_start(self._label("Core    Usage   Temperature     Frequency"), False, False, 0)
-
-        for core in report.cores_info:
-            temperature = (
-                f"{core.temperature:>6.0f} °C"
-                if core.temperature > 0
-                else "     —"
-            )
-            frequency = (
-                f"{core.frequency:>6.0f} MHz"
-                if core.frequency > 0
-                else "     —"
-            )
-            self.left_box.pack_start(
-                self._label(
-                    f"CPU{core.id:<2}    {core.usage:>4.1f}%    "
-                    f"{temperature}    {frequency}"
-                ),
-                False,
-                False,
-                0,
-            )
-
-        if report.cpu_fan_speed:
-            self.left_box.pack_start(self._label(""), False, False, 0)
-            self.left_box.pack_start(self._label(f"CPU fan speed: {report.cpu_fan_speed} RPM"), False, False, 0)
-
-
-        if report.battery_info is not None:
-            self.right_box.pack_start(self._separator("Battery Stats"), False, False, 5)
-            self.right_box.pack_start(self._label(f"Battery status: {str(report.battery_info)}"), False, False, 0)
-            battery_level = f"{report.battery_info.battery_level}%" if report.battery_info.battery_level is not None else "Unknown"
-            self.right_box.pack_start(self._label(f"Battery percentage: {battery_level}"), False, False, 0)
-            ac_status = "Yes" if report.battery_info.is_ac_plugged else "No" if report.battery_info.is_ac_plugged is not None else "Unknown"
-            self.right_box.pack_start(self._label(f"AC plugged: {ac_status}"), False, False, 0)
-            self.right_box.pack_start(self._label(f"Charging start threshold: {report.battery_info.charging_start_threshold}"), False, False, 0)
-            self.right_box.pack_start(self._label(f"Charging stop threshold: {report.battery_info.charging_stop_threshold}"), False, False, 0)
-            self.right_box.pack_start(self._label(""), False, False, 0)
-
-        self.right_box.pack_start(self._separator("CPU Frequency Scaling"), False, False, 5)
-        current_gov = report.current_gov if report.current_gov else "Unknown"
-        self.right_box.pack_start(self._label(f'Setting to use: "{current_gov}" governor'), False, False, 0)
+        # Same observed-state renderer as the normal GTK dashboard.
+        self.report_view.apply_report(report)
 
         if (
-            report.current_gov
-            and suggested_governor is not None
-            and suggested_governor != report.current_gov
+            suggested_governor is not None
+            and suggested_governor
+            != report.current_gov
         ):
-            self.right_box.pack_start(
-                self._suggestion(
-                    f'Suggesting use of: "{suggested_governor}" governor'
-                ),
-                False,
-                False,
-                0,
+            self.governor_suggestion.set_text(
+                f"Use {suggested_governor}"
             )
-
-        if report.current_epp:
-            self.right_box.pack_start(self._label(f"Current EPP: {report.current_epp}"), False, False, 0)
         else:
-            self.right_box.pack_start(self._label("Not setting EPP (not supported by system)"), False, False, 0)
-
-        if report.current_hwp_dynamic_boost is not None:
-            state = (
-                "on"
-                if report.current_hwp_dynamic_boost
-                else "off"
-            )
-            self.right_box.pack_start(
-                self._label(
-                    f"Intel HWP Dynamic Boost: {state}"
-                ),
-                False,
-                False,
-                0,
+            self.governor_suggestion.set_text(
+                "No change suggested"
             )
 
-        if report.current_epb:
-            self.right_box.pack_start(self._label(f"Current EPB: {report.current_epb}"), False, False, 0)
-
-        self.right_box.pack_start(self._label(""), False, False, 0)
-
-        self.right_box.pack_start(self._separator("System Statistics"), False, False, 5)
-        self.right_box.pack_start(self._label(f"Total CPU usage: {report.cpu_usage:.1f} %"), False, False, 0)
-        self.right_box.pack_start(self._label(f"Total system load: {report.load:.2f}"), False, False, 0)
-
-        avg_temp = report.cpu_avg_temp
-        if avg_temp is None:
-            temperatures = [
-                core.temperature
-                for core in report.cores_info
-                if core.temperature > 0
-            ]
-            if temperatures:
-                avg_temp = sum(temperatures) / len(temperatures)
-
-        if avg_temp is not None:
-            self.right_box.pack_start(
-                self._label(
-                    f"Average temp. of all cores: {avg_temp:.2f} °C"
-                ),
-                False,
-                False,
-                0,
-            )
-
-        if report.avg_load:
-            load_status = "Load optimal" if report.load < 1.0 else "Load high"
-            self.right_box.pack_start(
-                self._label(f"{load_status} (load average: {report.avg_load[0]:.2f}, {report.avg_load[1]:.2f}, {report.avg_load[2]:.2f})"),
-                False, False, 0
-            )
-
-        if avg_temp is not None:
-            usage_status = "Optimal" if report.cpu_usage < 70 else "High"
-            temp_status = "high" if avg_temp > 75 else "normal"
-            self.right_box.pack_start(
-                self._label(
-                    f"{usage_status} total CPU usage: "
-                    f"{report.cpu_usage:.1f}%, {temp_status} "
-                    f"average core temp: {avg_temp:.1f}°C"
-                ),
-                False,
-                False,
-                0,
-            )
-
-        turbo_status = "Unknown"
-        if report.is_turbo_on[0] is not None:
-            turbo_status = "On" if report.is_turbo_on[0] else "Off"
-        elif report.is_turbo_on[1] is not None:
-            turbo_status = f"Auto mode {'enabled' if report.is_turbo_on[1] else 'disabled'}"
-        self.right_box.pack_start(self._label(f"Setting turbo boost: {turbo_status}"), False, False, 0)
-
-        if (
+        turbo_available = (
             report.is_turbo_on[0] is not None
-            and suggested_turbo is not None
-            and suggested_turbo != report.is_turbo_on[0]
-        ):
-            turbo_text = "on" if suggested_turbo else "off"
-            self.right_box.pack_start(
-                self._suggestion(
-                    f"Suggesting to set turbo boost: {turbo_text}"
-                ),
-                False,
-                False,
-                0,
-            )
+        )
 
-        self.left_box.show_all()
-        self.right_box.show_all()
+        if turbo_available:
+            self.turbo_name.show()
+            self.turbo_suggestion.show()
 
-        if self.running:
-            self.refresh_id = GLib.timeout_add_seconds(
-                5,
+            if (
+                suggested_turbo is not None
+                and suggested_turbo
+                != report.is_turbo_on[0]
+            ):
+                self.turbo_suggestion.set_text(
+                    "Turn on"
+                    if suggested_turbo
+                    else "Turn off"
+                )
+            else:
+                self.turbo_suggestion.set_text(
+                    "No change suggested"
+                )
+        else:
+            self.turbo_name.hide()
+            self.turbo_suggestion.hide()
+
+        self.refresh_id = (
+            GLib.timeout_add_seconds(
+                self.refresh_interval,
                 self.refresh_in_thread,
             )
-
+        )
         return False
 
-    def on_back_clicked(self, button):
+    def on_back_clicked(self, _button):
         self.cleanup()
         self.parent.remove(self)
         self.parent.daemon_not_running()
@@ -1038,6 +1029,7 @@ class MonitorModeView(Gtk.Box):
 
     def cleanup(self):
         self.running = False
+
         if self.refresh_id is not None:
             GLib.source_remove(self.refresh_id)
             self.refresh_id = None

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -21,9 +21,10 @@ from auto_cpufreq.power_helper import bluetoothctl_exists
 auto_cpufreq_stats_path = ("/var/snap/auto-cpufreq/current" if IS_INSTALLED_WITH_SNAP else "/var/run") + "/auto-cpufreq.stats"
 
 def get_stats():
-    if isfile(auto_cpufreq_stats_path):
-        with open(auto_cpufreq_stats_path, "r") as file: stats = [line for line in (file.readlines() [-50:])]
-        return "".join(stats)
+    if not isfile(auto_cpufreq_stats_path):
+        return ""
+    with open(auto_cpufreq_stats_path, "r") as file:
+        return "".join(file.readlines()[-50:])
 
 def get_version():
     # snap package
@@ -696,7 +697,7 @@ class DropDownMenu(Gtk.MenuButton):
                 text="Daemon removal failed",
             )
             dialog.format_secondary_text(
-                f"The following error occured:\n{e}"
+                f"The following error occurred:\n{e}"
             )
             dialog.run()
             dialog.destroy()
@@ -883,7 +884,7 @@ class MonitorModeView(Gtk.Box):
             Gtk.PolicyType.NEVER,
             Gtk.PolicyType.AUTOMATIC,
         )
-        self.scrolled.set_can_focus(False)
+        self.scrolled.set_can_focus(True)
         self.scrolled.add(self.report_view)
 
         self.pack_start(
@@ -975,7 +976,8 @@ class MonitorModeView(Gtk.Box):
         self.report_view.apply_report(report)
 
         if (
-            suggested_governor is not None
+            report.current_gov is not None
+            and suggested_governor is not None
             and suggested_governor
             != report.current_gov
         ):
@@ -1105,7 +1107,7 @@ class DaemonNotRunningView(Gtk.Box):
                 text="Daemon install failed",
             )
             dialog.format_secondary_text(
-                f"The following error occured:\n{e}"
+                f"The following error occurred:\n{e}"
             )
             dialog.run()
             dialog.destroy()

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -263,7 +263,7 @@ class CPUTurboOverride(Gtk.Box):
                 if self.set_by_app: self.set_by_app = False
 
 class BluetoothBootControl(Gtk.Box):
-    def __init__(self):
+    def __init__(self, show_advanced_button=True):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=10)
 
         self.set_hexpand(True)
@@ -297,7 +297,8 @@ class BluetoothBootControl(Gtk.Box):
 
         self.revealer.add(self.inner_box)
 
-        self.pack_start(self.advanced_btn, False, False, 0)
+        if show_advanced_button:
+            self.pack_start(self.advanced_btn, False, False, 0)
         self.pack_start(self.revealer, False, False, 0)
 
     def on_advanced_clicked(self, button):
@@ -322,6 +323,7 @@ class BluetoothBootControl(Gtk.Box):
         )
 
         self.set_sensitive(False)
+        self.advanced_btn.set_sensitive(False)
         _run_privileged_async(
             [option],
             self._finish_command,
@@ -329,6 +331,7 @@ class BluetoothBootControl(Gtk.Box):
 
     def _finish_command(self, result, error):
         self.set_sensitive(True)
+        self.advanced_btn.set_sensitive(True)
 
         if _privileged_command_error(result, error) is not None:
             self.set_by_app = True

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -191,7 +191,7 @@ class SystemInfo:
     ) -> tuple[dict[int, float], float | None]:
         try:
             temps = psutil.sensors_temperatures()
-        except (AttributeError, OSError):
+        except (AttributeError, NotImplementedError, OSError):
             return {}, None
 
         ids = cpu_ids if cpu_ids is not None else SystemInfo.cpu_ids("online")
@@ -247,16 +247,18 @@ class SystemInfo:
 
                 if temperatures_by_core and not duplicate_core_id:
                     by_cpu = {}
+                    matched_core_ids = set()
                     for cpu_id in ids:
                         core_id = SystemInfo._cpu_core_id(cpu_id)
                         if core_id in temperatures_by_core:
                             by_cpu[cpu_id] = temperatures_by_core[core_id]
+                            matched_core_ids.add(core_id)
 
                     if by_cpu:
-                        average = (
-                            sum(temperatures_by_core.values())
-                            / len(temperatures_by_core)
-                        )
+                        average = sum(
+                            temperatures_by_core[core_id]
+                            for core_id in matched_core_ids
+                        ) / len(matched_core_ids)
                         return by_cpu, average
 
             snapshot = snapshot_from_entries(coretemp_entries)
@@ -409,7 +411,7 @@ class SystemInfo:
     def cpu_fan_speed() -> int | None:
         try:
             fans = psutil.sensors_fans()
-        except (AttributeError, OSError):
+        except (AttributeError, NotImplementedError, OSError):
             return None
 
         for entries in fans.values():

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Tuple
 import distro
 import psutil
 
-from auto_cpufreq.config.config import config, find_config_file
+from auto_cpufreq.config.config import config
 from auto_cpufreq.core import (
     get_hwp_dynamic_boost,
     get_power_supply_ignore_list,
@@ -102,7 +102,6 @@ class SystemInfo:
         self.processor_model: str = (
             getoutput("grep -E 'model name' /proc/cpuinfo -m 1").split(":")[-1].strip()
         )
-        self.total_cores: int | None = psutil.cpu_count(logical=True)
         self.cpu_driver: str = getoutput(
             "cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_driver"
         ).strip()
@@ -132,6 +131,24 @@ class SystemInfo:
             for freq in cpu_freqs
         )
         return max((value for value in values if value > 0), default=None)
+
+    @staticmethod
+    def cpu_current_frequency(cpu_id: int) -> float | None:
+        cpufreq_path = CPU_SYSFS_ROOT / f"cpu{cpu_id}" / "cpufreq"
+        for name in ("cpuinfo_cur_freq", "scaling_cur_freq"):
+            value = SystemInfo.read_file(str(cpufreq_path / name))
+            if value is None:
+                continue
+
+            try:
+                frequency = float(value) / 1000
+            except ValueError:
+                continue
+
+            if frequency > 0:
+                return frequency
+
+        return None
 
     @staticmethod
     def _parse_cpu_list(value: str) -> list[int]:
@@ -346,15 +363,14 @@ class SystemInfo:
         cpu_usage=None,
     ) -> List[CoreInfo]:
         """Returns detailed CPU information for each online logical CPU."""
+        # Keep the existing argument for callers, but do not map its positional
+        # entries to CPU IDs: psutil may return one entry per CPUFreq policy.
         if cpu_usage is None:
             try:
                 cpu_usage = psutil.cpu_percent(interval=0.5, percpu=True)
             except (AttributeError, OSError):
                 cpu_usage = []
 
-        frequencies = (
-            cpu_freqs if cpu_freqs is not None else SystemInfo.cpu_frequencies()
-        )
         online = (
             list(online_cpus)
             if online_cpus
@@ -386,14 +402,7 @@ class SystemInfo:
         cores = []
         for position, cpu_id in enumerate(online):
             usage = value_for_cpu(cpu_usage, cpu_id, position)
-            frequency_info = value_for_cpu(frequencies, cpu_id, position)
-
-            frequency = 0.0
-            if frequency_info is not None:
-                frequency = float(
-                    getattr(frequency_info, "current", 0.0) or 0.0
-                )
-
+            frequency = SystemInfo.cpu_current_frequency(cpu_id) or 0.0
             temperature = temperatures.get(cpu_id, avg_temp)
 
             cores.append(
@@ -767,6 +776,11 @@ class SystemInfo:
         battery_info = self.battery_info()
         cpu_freqs = self.cpu_frequencies()
         online_cpus = self.cpu_ids("online")
+        total_cores = (
+            len(online_cpus)
+            if online_cpus
+            else psutil.cpu_count(logical=True)
+        )
         core_temps, avg_temp = self.cpu_temperature_snapshot(online_cpus)
         total_usage, per_cpu_usage = self.cpu_usage_snapshot(online_cpus)
         load_average = self.avg_load()
@@ -776,7 +790,7 @@ class SystemInfo:
             distro_ver=self.distro_version,
             arch=self.architecture,
             processor_model=self.processor_model,
-            total_core=self.total_cores,
+            total_core=total_cores,
             cpu_driver=self.cpu_driver,
             kernel_version=self.kernel_version,
             current_gov=self.current_gov(),
@@ -837,7 +851,7 @@ def format_system_report(
     )
 
     if include_config:
-        config_path = config.path if config.has_config() else find_config_file(None)
+        config_path = config.path
         if config_path and os.path.isfile(config_path):
             lines.extend(["", f"Using settings defined in {config_path}"])
 

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -3,11 +3,12 @@ import os
 from pathlib import Path
 import platform
 from subprocess import getoutput
-from typing import Tuple, List
-import psutil
+from typing import List, Optional, Tuple
+
 import distro
-from pathlib import Path
-from auto_cpufreq.config.config import config
+import psutil
+
+from auto_cpufreq.config.config import config, find_config_file
 from auto_cpufreq.core import (
     get_hwp_dynamic_boost,
     get_power_supply_ignore_list,
@@ -18,7 +19,10 @@ from auto_cpufreq.globals import (
     IS_INSTALLED_WITH_SNAP,
     POWER_SUPPLY_DIR,
 )
-from typing import Optional
+
+
+CPU_SYSFS_ROOT = Path("/sys/devices/system/cpu")
+SNAP_HOST_ROOT = "/var/lib/snapd/hostfs"
 
 
 @dataclass
@@ -50,6 +54,8 @@ class BatteryInfo:
 
 @dataclass
 class SystemReport:
+    """Point-in-time telemetry snapshot for reporting frontends, not control policy."""
+
     distro_name: str
     distro_ver: str
     arch: str
@@ -70,6 +76,8 @@ class SystemReport:
     cores_info: list[CoreInfo]
     battery_info: BatteryInfo
     is_turbo_on: Tuple[bool | None, bool | None]
+    cpu_avg_temp: float | None = None
+    offline_cpus: tuple[int, ...] = ()
 
 
 class SystemInfo:
@@ -78,12 +86,18 @@ class SystemInfo:
     """
 
     def __init__(self):
-        self.distro_name: str = (
-            distro.name(pretty=True) if not IS_INSTALLED_WITH_SNAP else "UNKNOWN"
-        )
-        self.distro_version: str = (
-            distro.version() if not IS_INSTALLED_WITH_SNAP else "UNKNOWN"
-        )
+        if IS_INSTALLED_WITH_SNAP:
+            try:
+                host_distro = distro.LinuxDistribution(root_dir=SNAP_HOST_ROOT)
+                self.distro_name = host_distro.name(pretty=False) or "UNKNOWN"
+                self.distro_version = host_distro.version() or "UNKNOWN"
+            except (OSError, UnicodeError, ValueError):
+                self.distro_name = "UNKNOWN"
+                self.distro_version = "UNKNOWN"
+        else:
+            self.distro_name = distro.name(pretty=False)
+            self.distro_version = distro.version()
+
         self.architecture: str = platform.machine()
         self.processor_model: str = (
             getoutput("grep -E 'model name' /proc/cpuinfo -m 1").split(":")[-1].strip()
@@ -95,49 +109,318 @@ class SystemInfo:
         self.kernel_version: str = platform.release()
 
     @staticmethod
-    def cpu_min_freq() -> float | None:
-        freqs = psutil.cpu_freq(percpu=True)
-        return min((freq.min for freq in freqs), default=None)
+    def cpu_frequencies():
+        try:
+            return psutil.cpu_freq(percpu=True) or []
+        except (AttributeError, NotImplementedError, OSError):
+            return []
 
     @staticmethod
-    def cpu_max_freq() -> float | None:
-        freqs = psutil.cpu_freq(percpu=True)
-        return max((freq.max for freq in freqs), default=None)
+    def cpu_min_freq(freqs=None) -> float | None:
+        cpu_freqs = freqs if freqs is not None else SystemInfo.cpu_frequencies()
+        values = (
+            float(getattr(freq, "min", 0.0) or 0.0)
+            for freq in cpu_freqs
+        )
+        return min((value for value in values if value > 0), default=None)
 
     @staticmethod
-    def get_cpu_info() -> List[CoreInfo]:
-        """Returns detailed CPU information for each core."""
-        cpu_usage = psutil.cpu_percent(percpu=True)
-        cpu_freqs = psutil.cpu_freq(percpu=True)
+    def cpu_max_freq(freqs=None) -> float | None:
+        cpu_freqs = freqs if freqs is not None else SystemInfo.cpu_frequencies()
+        values = (
+            float(getattr(freq, "max", 0.0) or 0.0)
+            for freq in cpu_freqs
+        )
+        return max((value for value in values if value > 0), default=None)
+
+    @staticmethod
+    def _parse_cpu_list(value: str) -> list[int]:
+        cpus = []
+        for part in value.split(","):
+            part = part.strip()
+            if not part:
+                continue
+
+            if "-" in part:
+                start, end = part.split("-", 1)
+                start_cpu = int(start)
+                end_cpu = int(end)
+                if end_cpu < start_cpu:
+                    raise ValueError("invalid CPU range")
+                cpus.extend(range(start_cpu, end_cpu + 1))
+            else:
+                cpus.append(int(part))
+
+        return cpus
+
+    @staticmethod
+    def cpu_ids(mask: str) -> list[int]:
+        value = SystemInfo.read_file(str(CPU_SYSFS_ROOT / mask))
+        if not value:
+            return []
 
         try:
+            return SystemInfo._parse_cpu_list(value)
+        except ValueError:
+            return []
+
+    @staticmethod
+    def offline_cpu_ids() -> list[int]:
+        present = set(SystemInfo.cpu_ids("present"))
+        online = set(SystemInfo.cpu_ids("online"))
+        if not present or not online:
+            return []
+        return sorted(present - online)
+
+    @staticmethod
+    def _cpu_core_id(cpu_id: int) -> int | None:
+        value = SystemInfo.read_file(
+            str(CPU_SYSFS_ROOT / f"cpu{cpu_id}" / "topology" / "core_id")
+        )
+        if value is None:
+            return None
+
+        try:
+            return int(value)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def cpu_temperature_snapshot(
+        cpu_ids: list[int] | None = None,
+    ) -> tuple[dict[int, float], float | None]:
+        try:
             temps = psutil.sensors_temperatures()
-            temp_sensor = []
-            for sensor in CPU_TEMP_SENSOR_PRIORITY:
-                temp_sensor = temps.get(sensor, [])
-                if temp_sensor != []:
-                    break
+        except (AttributeError, OSError):
+            return {}, None
 
-            core_temps = [temp.current for temp in temp_sensor]
-        except AttributeError:
-            core_temps = []
+        ids = cpu_ids if cpu_ids is not None else SystemInfo.cpu_ids("online")
 
-        avg_temp = sum(core_temps) / len(core_temps) if core_temps else 0.0
+        def snapshot_from_entries(entries):
+            readings = []
+            for entry in entries:
+                try:
+                    current = float(entry.current)
+                except (AttributeError, TypeError, ValueError):
+                    continue
+                if current > 0:
+                    readings.append(current)
 
-        return [
-            CoreInfo(
-                id=i,
-                usage=cpu_usage[i],
-                temperature=core_temps[i] if i < len(core_temps) else avg_temp,
-                frequency=cpu_freqs[i].current,
+            if not readings:
+                return None
+
+            average = sum(readings) / len(readings)
+
+            if not ids:
+                return {
+                    cpu_id: temperature
+                    for cpu_id, temperature in enumerate(readings)
+                }, average
+
+            if len(readings) == len(ids):
+                return dict(zip(ids, readings)), average
+
+            return {cpu_id: average for cpu_id in ids}, average
+
+        coretemp_entries = temps.get("coretemp", [])
+        if coretemp_entries:
+            if ids:
+                temperatures_by_core = {}
+                duplicate_core_id = False
+                for entry in coretemp_entries:
+                    label = str(getattr(entry, "label", "") or "")
+                    if not label.startswith("Core "):
+                        continue
+
+                    try:
+                        core_id = int(label.removeprefix("Core ").strip())
+                        current = float(entry.current)
+                    except (AttributeError, TypeError, ValueError):
+                        continue
+
+                    if current <= 0:
+                        continue
+                    if core_id in temperatures_by_core:
+                        duplicate_core_id = True
+                        break
+                    temperatures_by_core[core_id] = current
+
+                if temperatures_by_core and not duplicate_core_id:
+                    by_cpu = {}
+                    for cpu_id in ids:
+                        core_id = SystemInfo._cpu_core_id(cpu_id)
+                        if core_id in temperatures_by_core:
+                            by_cpu[cpu_id] = temperatures_by_core[core_id]
+
+                    if by_cpu:
+                        average = (
+                            sum(temperatures_by_core.values())
+                            / len(temperatures_by_core)
+                        )
+                        return by_cpu, average
+
+            snapshot = snapshot_from_entries(coretemp_entries)
+            if snapshot is not None:
+                return snapshot
+
+        # Preserve the legacy fallback for hwmon drivers that expose
+        # CPU temperature under a device-specific sensor group.
+        for entries in temps.values():
+            for entry in entries:
+                label = str(getattr(entry, "label", "") or "")
+                if "CPU" not in label and "Tctl" not in label:
+                    continue
+
+                try:
+                    current = float(entry.current)
+                except (AttributeError, TypeError, ValueError):
+                    continue
+
+                if current <= 0:
+                    continue
+
+                if not ids:
+                    return {0: current}, current
+
+                return {
+                    cpu_id: current
+                    for cpu_id in ids
+                }, current
+
+        for sensor in CPU_TEMP_SENSOR_PRIORITY:
+            if sensor == "coretemp":
+                continue
+
+            snapshot = snapshot_from_entries(
+                temps.get(sensor, [])
             )
-            for i in range(len(cpu_usage))
+            if snapshot is not None:
+                return snapshot
+
+        return {}, None
+
+    @staticmethod
+    def cpu_temperatures() -> List[float]:
+        temperatures, _ = SystemInfo.cpu_temperature_snapshot()
+        return [
+            temperatures[cpu_id]
+            for cpu_id in sorted(temperatures)
         ]
 
     @staticmethod
+    def cpu_usage_snapshot(
+        online_cpus: list[int] | None = None,
+    ) -> tuple[float, list[float]]:
+        try:
+            per_cpu = psutil.cpu_percent(interval=0.5, percpu=True)
+        except (AttributeError, OSError):
+            return 0.0, []
+
+        if not per_cpu:
+            return 0.0, []
+
+        online = list(online_cpus) if online_cpus else []
+        if not online:
+            sampled = per_cpu
+        elif len(per_cpu) == len(online):
+            sampled = per_cpu
+        else:
+            sampled = [
+                per_cpu[cpu_id]
+                for cpu_id in online
+                if cpu_id < len(per_cpu)
+            ]
+
+        if not sampled:
+            return 0.0, per_cpu
+
+        return sum(sampled) / len(sampled), per_cpu
+
+    @staticmethod
+    def get_cpu_info(
+        cpu_freqs=None,
+        core_temps=None,
+        online_cpus=None,
+        cpu_usage=None,
+    ) -> List[CoreInfo]:
+        """Returns detailed CPU information for each online logical CPU."""
+        if cpu_usage is None:
+            try:
+                cpu_usage = psutil.cpu_percent(interval=0.5, percpu=True)
+            except (AttributeError, OSError):
+                cpu_usage = []
+
+        frequencies = (
+            cpu_freqs if cpu_freqs is not None else SystemInfo.cpu_frequencies()
+        )
+        online = (
+            list(online_cpus)
+            if online_cpus
+            else list(range(len(cpu_usage)))
+        )
+        temperatures = (
+            core_temps
+            if core_temps is not None
+            else SystemInfo.cpu_temperature_snapshot(online)[0]
+        )
+        valid_temperatures = [
+            temperature
+            for temperature in temperatures.values()
+            if temperature > 0
+        ]
+        avg_temp = (
+            sum(valid_temperatures) / len(valid_temperatures)
+            if valid_temperatures
+            else 0.0
+        )
+
+        def value_for_cpu(values, cpu_id, position):
+            if len(values) == len(online):
+                return values[position]
+            if cpu_id < len(values):
+                return values[cpu_id]
+            return None
+
+        cores = []
+        for position, cpu_id in enumerate(online):
+            usage = value_for_cpu(cpu_usage, cpu_id, position)
+            frequency_info = value_for_cpu(frequencies, cpu_id, position)
+
+            frequency = 0.0
+            if frequency_info is not None:
+                frequency = float(
+                    getattr(frequency_info, "current", 0.0) or 0.0
+                )
+
+            temperature = temperatures.get(cpu_id, avg_temp)
+
+            cores.append(
+                CoreInfo(
+                    id=cpu_id,
+                    usage=float(usage or 0.0),
+                    temperature=temperature if temperature > 0 else avg_temp,
+                    frequency=frequency,
+                )
+            )
+
+        return cores
+
+    @staticmethod
     def cpu_fan_speed() -> int | None:
-        fans = psutil.sensors_fans()
-        return next((fan[0].current for fan in fans.values() if fan), None)
+        try:
+            fans = psutil.sensors_fans()
+        except (AttributeError, OSError):
+            return None
+
+        for entries in fans.values():
+            for fan in entries:
+                try:
+                    current = float(fan.current)
+                except (AttributeError, TypeError, ValueError):
+                    continue
+                if current > 0:
+                    return int(current)
+        return None
 
     @staticmethod
     def current_gov() -> str | None:
@@ -150,7 +433,7 @@ class SystemInfo:
             return None
 
     @staticmethod
-    def current_epp(_is_ac_plugged: bool) -> str | None:
+    def current_epp(_is_ac_plugged: bool | None = None) -> str | None:
         paths = list(Path("/sys/devices/system/cpu").glob(
             "cpu[0-9]*/cpufreq/energy_performance_preference"
         ))
@@ -169,7 +452,7 @@ class SystemInfo:
         return values.pop()
 
     @staticmethod
-    def current_epb(_is_ac_plugged: bool) -> str | None:
+    def current_epb(_is_ac_plugged: bool | None = None) -> str | None:
         epb_names = {
             "0": "performance",
             "4": "balance_performance",
@@ -196,9 +479,10 @@ class SystemInfo:
 
     @staticmethod
     def cpu_usage() -> float:
-        return psutil.cpu_percent(
-            interval=0.5
-        )  # Reduced interval for better responsiveness
+        try:
+            return psutil.cpu_percent(interval=0.5)
+        except (AttributeError, OSError):
+            return 0.0
 
     @staticmethod
     def system_load() -> float:
@@ -210,8 +494,8 @@ class SystemInfo:
 
     @staticmethod
     def avg_temp() -> int:
-        temps: List[float] = [i.temperature for i in SystemInfo.get_cpu_info()]
-        return int(sum(temps) / len(temps))
+        _, average = SystemInfo.cpu_temperature_snapshot()
+        return int(average) if average is not None else 0
 
     @staticmethod
     def turbo_on() -> Tuple[bool | None, bool | None]:
@@ -234,7 +518,10 @@ class SystemInfo:
             control_file = cpu_freq
             inverse_logic = False
         elif amd_pstate.exists():
-            amd_status: str = amd_pstate.read_text().strip()
+            try:
+                amd_status = amd_pstate.read_text().strip()
+            except OSError:
+                return None, None
             if amd_status == "active":
                 return None, True
             return None, False
@@ -244,7 +531,7 @@ class SystemInfo:
         try:
             current_value = int(control_file.read_text().strip())
             return bool(current_value) ^ inverse_logic, False
-        except Exception as e:
+        except (OSError, ValueError):
             return None, None
 
     @staticmethod
@@ -406,7 +693,7 @@ class SystemInfo:
 
             if (current and current.isdigit()) and (voltage and voltage.isdigit()):
                 energy_rate = (int(current) * int(voltage)) / 1_000_000
- 
+
 
 
         charge_start_threshold = (
@@ -436,23 +723,51 @@ class SystemInfo:
         )
 
     @staticmethod
-    def turbo_on_suggestion() -> bool:
-        usage = SystemInfo.cpu_usage()
+    def turbo_on_suggestion(report: SystemReport | None = None) -> bool:
+        usage = report.cpu_usage if report is not None else SystemInfo.cpu_usage()
+
+        if report is not None:
+            if report.cpu_avg_temp is not None:
+                avg_temp = report.cpu_avg_temp
+            else:
+                temperatures = [
+                    core.temperature
+                    for core in report.cores_info
+                    if core.temperature > 0
+                ]
+                avg_temp = (
+                    sum(temperatures) / len(temperatures)
+                    if temperatures
+                    else 0.0
+                )
+        else:
+            avg_temp = SystemInfo.avg_temp()
+
         if usage >= 20.0:
             return True
-        elif usage <= 25 and SystemInfo.avg_temp() >= 70:
+        elif usage <= 25 and avg_temp >= 70:
             return False
         return False
 
     @staticmethod
-    def governor_suggestion() -> str:
-        is_ac_plugged = SystemInfo.external_power_state()
-        if is_ac_plugged is not False:
+    def governor_suggestion(report: SystemReport | None = None) -> str:
+        battery_info = (
+            report.battery_info
+            if report is not None
+            else SystemInfo.battery_info()
+        )
+        if battery_info.is_ac_plugged is not False:
             return AVAILABLE_GOVERNORS_SORTED[0]
         return AVAILABLE_GOVERNORS_SORTED[-1]
 
     def generate_system_report(self) -> SystemReport:
+        """Collect one reporting snapshot without changing system state."""
         battery_info = self.battery_info()
+        cpu_freqs = self.cpu_frequencies()
+        online_cpus = self.cpu_ids("online")
+        core_temps, avg_temp = self.cpu_temperature_snapshot(online_cpus)
+        total_usage, per_cpu_usage = self.cpu_usage_snapshot(online_cpus)
+        load_average = self.avg_load()
 
         return SystemReport(
             distro_name=self.distro_name,
@@ -467,15 +782,132 @@ class SystemInfo:
             current_epb=self.current_epb(battery_info.is_ac_plugged),
             current_hwp_dynamic_boost=get_hwp_dynamic_boost(),
             cpu_fan_speed=self.cpu_fan_speed(),
-            cpu_usage=self.cpu_usage(),
-            cpu_max_freq=self.cpu_max_freq(),
-            cpu_min_freq=self.cpu_min_freq(),
-            load=self.system_load(),
-            avg_load=self.avg_load(),
-            cores_info=self.get_cpu_info(),
+            cpu_usage=total_usage,
+            cpu_max_freq=self.cpu_max_freq(cpu_freqs),
+            cpu_min_freq=self.cpu_min_freq(cpu_freqs),
+            load=load_average[0],
+            avg_load=load_average,
+            cores_info=self.get_cpu_info(
+                cpu_freqs,
+                core_temps,
+                online_cpus,
+                per_cpu_usage,
+            ),
             is_turbo_on=self.turbo_on(),
             battery_info=battery_info,
+            cpu_avg_temp=avg_temp,
+            offline_cpus=tuple(self.offline_cpu_ids()),
         )
 
 
 system_info = SystemInfo()
+
+
+def format_system_report(
+    report: SystemReport,
+    include_distro: bool = True,
+    include_config: bool = True,
+) -> str:
+    """Format one SystemReport using the legacy textual status layout."""
+    lines = []
+
+    if include_distro:
+        distro_name = f"{report.distro_name} {report.distro_ver}".strip()
+        lines.extend(
+            [
+                f"Linux distro: {distro_name}",
+                f"Linux kernel: {report.kernel_version}",
+            ]
+        )
+
+    total_core = (
+        str(report.total_core)
+        if report.total_core is not None
+        else "Unknown"
+    )
+    lines.extend(
+        [
+            f"Processor: {report.processor_model}",
+            f"Cores: {total_core}",
+            f"Architecture: {report.arch}",
+            f"Driver: {report.cpu_driver}",
+        ]
+    )
+
+    if include_config:
+        config_path = config.path if config.has_config() else find_config_file(None)
+        if config_path and os.path.isfile(config_path):
+            lines.extend(["", f"Using settings defined in {config_path}"])
+
+    max_freq = (
+        f"{report.cpu_max_freq:.0f} MHz"
+        if report.cpu_max_freq is not None
+        else "Unknown"
+    )
+    min_freq = (
+        f"{report.cpu_min_freq:.0f} MHz"
+        if report.cpu_min_freq is not None
+        else "Unknown"
+    )
+
+    lines.extend(
+        [
+            "",
+            "-" * 30 + " Current CPU stats " + "-" * 30,
+            "",
+            f"CPU max frequency: {max_freq}",
+            f"CPU min frequency: {min_freq}",
+            "",
+            "Core\tUsage\tTemperature\tFrequency",
+        ]
+    )
+
+    for core in report.cores_info:
+        temperature = (
+            f"{core.temperature:>3.0f} °C"
+            if core.temperature > 0
+            else "  —"
+        )
+        frequency = (
+            f"{core.frequency:>5.0f} MHz"
+            if core.frequency > 0
+            else "    —"
+        )
+        lines.append(
+            f"CPU{core.id}    {core.usage:>5.1f}%       "
+            f"{temperature}     {frequency}"
+        )
+
+    if report.offline_cpus:
+        lines.extend(
+            [
+                "",
+                "Disabled CPUs: "
+                + ",".join(str(cpu) for cpu in report.offline_cpus),
+            ]
+        )
+
+    if report.cpu_fan_speed:
+        lines.extend(["", f"CPU fan speed: {report.cpu_fan_speed} RPM"])
+
+    return "\n".join(lines)
+
+
+def print_system_report(
+    report: SystemReport | None = None,
+    output=None,
+    include_distro: bool = True,
+    include_config: bool = True,
+):
+    """Print a structured snapshot without collecting the same status twice."""
+    if report is None:
+        report = system_info.generate_system_report()
+
+    print(
+        format_system_report(
+            report,
+            include_distro=include_distro,
+            include_config=include_config,
+        ),
+        file=output,
+    )

--- a/auto_cpufreq/modules/system_monitor.py
+++ b/auto_cpufreq/modules/system_monitor.py
@@ -1,4 +1,7 @@
+import os
 import sys
+from queue import Empty, SimpleQueue
+from threading import Thread
 from typing import Callable
 import urwid
 import time
@@ -80,39 +83,131 @@ class SystemMonitor:
         self.last_focus_right = 0
         self.on_quit: Callable[[], None] | None = None
         self.suggestion = suggestion
+        self.running = False
+        self._refresh_pipe_fd: int | None = None
+        self._alarm_handle = None
+        self._refresh_results = SimpleQueue()
 
     def update(self, loop: urwid.MainLoop, user_data: dict) -> None:
-        # Store current focus positions
+        self._alarm_handle = None
+
+        if not self.running:
+            return
+
+        Thread(target=self._collect_report, daemon=True).start()
+
+    def _collect_report(self):
+        try:
+            report = system_info.generate_system_report()
+
+            if self.suggestion:
+                suggested_governor = system_info.governor_suggestion(report)
+                suggested_turbo = system_info.turbo_on_suggestion(report)
+            else:
+                suggested_governor = None
+                suggested_turbo = None
+
+            result = (
+                report,
+                suggested_governor,
+                suggested_turbo,
+                None,
+            )
+        except Exception as exc:
+            result = (None, None, None, exc)
+
+        if not self.running:
+            return
+
+        self._refresh_results.put(result)
+
+        wakeup_fd = self._refresh_pipe_fd
+        if wakeup_fd is None:
+            return
+
+        try:
+            os.write(wakeup_fd, b"1")
+        except OSError:
+            # The monitor may have been closed while collection
+            # was still finishing.
+            pass
+
+    def _refresh_ready(self, _data):
+        try:
+            (
+                report,
+                suggested_governor,
+                suggested_turbo,
+                error,
+            ) = self._refresh_results.get_nowait()
+        except Empty:
+            return True
+
+        if error is not None:
+            raise error
+
+        if report is None:
+            raise RuntimeError(
+                "System monitor refresh completed without a report"
+            )
+
+        # Capture focus only now. The user may have scrolled while
+        # the worker was collecting telemetry.
         if len(self.left_content) > 0:
             _, self.last_focus_left = self.left_listbox.get_focus()
             if self.last_focus_left is None:
                 self.last_focus_left = 0
+
         if len(self.right_content) > 0:
             _, self.last_focus_right = self.right_listbox.get_focus()
             if self.last_focus_right is None:
                 self.last_focus_right = 0
 
         current_time = time.strftime("%H:%M:%S")
-        self.title_header.set_text(f"{self.type} Mode - {current_time}")
+        self.title_header.set_text(
+            f"{self.type} Mode - {current_time}"
+        )
 
-        report: SystemReport = system_info.generate_system_report()
-        self.format_system_info(report)
+        self.format_system_info(
+            report,
+            suggested_governor,
+            suggested_turbo,
+        )
 
-        # Restore focus positions
         if len(self.left_content) > 0:
-            self.left_listbox.set_focus(min(self.last_focus_left, len(self.left_content) - 1))  # type: ignore
-        if len(self.right_content) > 0:
-            self.right_listbox.set_focus(min(self.last_focus_right, len(self.right_content) - 1))  # type: ignore
+            self.left_listbox.set_focus(
+                min(
+                    self.last_focus_left,
+                    len(self.left_content) - 1,
+                )
+            )
 
-        self.loop.set_alarm_in(2, self.update)  # type: ignore
+        if len(self.right_content) > 0:
+            self.right_listbox.set_focus(
+                min(
+                    self.last_focus_right,
+                    len(self.right_content) - 1,
+                )
+            )
+
+        if self.running:
+            self._alarm_handle = self.loop.set_alarm_in(
+                2,
+                self.update,
+            )
+
+        return True
 
     def handle_input(self, key):
         if key in ("q", "Q"):
-            if self.on_quit:
-                self.on_quit()
             raise urwid.ExitMainLoop()
 
-    def format_system_info(self, report: SystemReport):
+    def format_system_info(
+        self,
+        report: SystemReport,
+        suggested_governor: str | None = None,
+        suggested_turbo: bool | None = None,
+    ):
         self.left_content.clear()
         self.right_content.clear()
 
@@ -128,7 +223,11 @@ class SystemMonitor:
                 aligned_text(f"Linux distro: {report.distro_name} {report.distro_ver}"),
                 aligned_text(f"Linux kernel: {report.kernel_version}"),
                 aligned_text(f"Processor: {report.processor_model}"),
-                aligned_text(f"Cores: {report.total_core}"),
+                aligned_text(
+                    f"Cores: {report.total_core}"
+                    if report.total_core is not None
+                    else "Cores: Unknown"
+                ),
                 aligned_text(f"Architecture: {report.arch}"),
                 aligned_text(f"Driver: {report.cpu_driver}"),
                 aligned_text(""),
@@ -146,17 +245,36 @@ class SystemMonitor:
             [
                 urwid.AttrMap(aligned_text("Current CPU Stats"), "header"),
                 aligned_text(""),
-                aligned_text(f"CPU max frequency: {report.cpu_max_freq} MHz"),
-                aligned_text(f"CPU min frequency: {report.cpu_min_freq} MHz"),
+                aligned_text(
+                    f"CPU max frequency: {report.cpu_max_freq:.0f} MHz"
+                    if report.cpu_max_freq is not None
+                    else "CPU max frequency: Unknown"
+                ),
+                aligned_text(
+                    f"CPU min frequency: {report.cpu_min_freq:.0f} MHz"
+                    if report.cpu_min_freq is not None
+                    else "CPU min frequency: Unknown"
+                ),
                 aligned_text(""),
                 aligned_text("Core    Usage   Temperature     Frequency"),
             ]
         )
 
         for core in report.cores_info:
+            temperature = (
+                f"{core.temperature:>6.0f} °C"
+                if core.temperature > 0
+                else "     —"
+            )
+            frequency = (
+                f"{core.frequency:>6.0f} MHz"
+                if core.frequency > 0
+                else "     —"
+            )
             self.left_content.append(
                 aligned_text(
-                    f"CPU{core.id:<2}    {core.usage:>4.1f}%    {core.temperature:>6.0f} °C    {core.frequency:>6.0f} MHz"
+                    f"CPU{core.id:<2}    {core.usage:>4.1f}%    "
+                    f"{temperature}    {frequency}"
                 )
             )
 
@@ -203,12 +321,13 @@ class SystemMonitor:
         if (
             self.suggestion
             and report.current_gov != None
-            and system_info.governor_suggestion() != report.current_gov
+            and suggested_governor != None
+            and suggested_governor != report.current_gov
         ):
             self.right_content.append(
                 urwid.AttrMap(
                     aligned_text(
-                        f'Suggesting use of: "{system_info.governor_suggestion()}" governor'
+                        f'Suggesting use of: "{suggested_governor}" governor'
                     ),
                     "suggestion",
                 )
@@ -247,10 +366,17 @@ class SystemMonitor:
             ]
         )
 
-        if report.cores_info:
-            avg_temp = sum(core.temperature for core in report.cores_info) / len(
-                report.cores_info
-            )
+        avg_temp = report.cpu_avg_temp
+        if avg_temp is None and report.cores_info:
+            temperatures = [
+                core.temperature
+                for core in report.cores_info
+                if core.temperature > 0
+            ]
+            if temperatures:
+                avg_temp = sum(temperatures) / len(temperatures)
+
+        if avg_temp is not None:
             self.right_content.append(
                 aligned_text(f"Average temp. of all cores: {avg_temp:.2f} °C")
             )
@@ -263,12 +389,12 @@ class SystemMonitor:
                 )
             )
 
-        if report.cores_info:
+        if avg_temp is not None:
             usage_status = "Optimal" if report.cpu_usage < 70 else "High"
-            temp_status = "high" if avg_temp > 75 else "normal"  # type: ignore
+            temp_status = "high" if avg_temp > 75 else "normal"
             self.right_content.append(
                 aligned_text(
-                    f"{usage_status} total CPU usage: {report.cpu_usage:.1f}%, {temp_status} average core temp: {avg_temp:.1f}°C"  # type: ignore
+                    f"{usage_status} total CPU usage: {report.cpu_usage:.1f}%, {temp_status} average core temp: {avg_temp:.1f}°C"
                 )
             )
 
@@ -285,24 +411,57 @@ class SystemMonitor:
         if (
             self.suggestion
             and report.is_turbo_on[0] != None
-            and system_info.turbo_on_suggestion() != report.is_turbo_on[0]
+            and suggested_turbo != None
+            and suggested_turbo != report.is_turbo_on[0]
         ):
             self.right_content.append(
                 urwid.AttrMap(
                     aligned_text(
-                        f'Suggesting to set turbo boost: {"on" if system_info.turbo_on_suggestion() else "off"}'
+                        f'Suggesting to set turbo boost: {"on" if suggested_turbo else "off"}'
                     ),
                     "suggestion",
                 )
             )
 
     def run(self, on_quit: Callable[[], None] | None = None):
+        self.on_quit = on_quit
+        self.running = True
+
         try:
-            if on_quit:
-                self.on_quit = on_quit
-            self.loop.set_alarm_in(0, self.update)  # type: ignore
+            self._refresh_pipe_fd = self.loop.watch_pipe(
+                self._refresh_ready
+            )
+            self._alarm_handle = self.loop.set_alarm_in(
+                0,
+                self.update,
+            )
             self.loop.run()
         except KeyboardInterrupt:
-            if on_quit:
-                on_quit()
             sys.exit(0)
+        finally:
+            self.running = False
+
+            callback = self.on_quit
+            self.on_quit = None
+
+            try:
+                alarm_handle = self._alarm_handle
+                self._alarm_handle = None
+
+                if alarm_handle is not None:
+                    self.loop.remove_alarm(alarm_handle)
+
+                wakeup_fd = self._refresh_pipe_fd
+                self._refresh_pipe_fd = None
+
+                if wakeup_fd is not None:
+                    try:
+                        self.loop.remove_watch_pipe(wakeup_fd)
+                    finally:
+                        try:
+                            os.close(wakeup_fd)
+                        except OSError:
+                            pass
+            finally:
+                if callback:
+                    callback()


### PR DESCRIPTION
## Summary

Consolidate system reporting around `SystemReport` and make the GTK frontend show a consistent view of the state actually observed from the system.

## System reporting

The GTK dashboard, GTK Monitor mode, terminal monitor, and legacy status output previously collected overlapping system information through different paths.

The shared report now handles several cases that those paths could not represent reliably:

- Snap reads the host distribution instead of reporting the confined environment as `UNKNOWN`.
- CPU frequency limits reported as `0.0` by psutil are treated as unavailable rather than real limits.
- Linux `present` and `online` CPU lists are used so offline or hotplugged logical CPUs do not shift per-CPU data onto the wrong CPU.
- Current per-CPU frequency is read through each online CPU's CPUFreq sysfs link instead of assuming psutil returns one entry per logical CPU. This keeps shared CPUFreq policies and non-contiguous CPU IDs mapped correctly.
- `cpuinfo_cur_freq` is preferred for current frequency when available, with `scaling_cur_freq` as a fallback.
- The logical CPU count is derived from the current online CPU mask so runtime hotplug changes do not leave a stale startup value in the report.
- `coretemp` readings are matched through CPU topology when possible, while generic CPU/Tctl and known platform sensor fallbacks remain available.
- Missing optional fan, frequency, or temperature data does not make the whole report fail.
- Existing battery charge-threshold information remains available when the platform exposes it.
- The already resolved configuration path is reused by the textual report instead of rediscovering it on every refresh.

`SystemReport` only describes observed state. The daemon still selects the charger/battery profile and performs power-policy writes.

## Runtime controls

Governor and Turbo overrides remain configuration requests rather than substitutes for observed system state.

`--force` now overrides only the governor inside the profile selected from the detected power source. Reading Turbo state no longer consults the configured Turbo override; the override is used only when a value is actually written.

Privileged GTK actions continue to use the existing `pkexec auto-cpufreq ...` backend, but they no longer block the GTK main loop. Every non-zero command status is treated as a failure, including authorization cancellation and other command errors.

Daemon detection can also fall back to the systemd service state when process inspection cannot see the running daemon.

## Monitor refresh lifecycle

GTK Monitor mode and the Urwid monitor collect system information outside their UI loops.

If a refresh is already running, another worker is not started on top of it. Timers and watch pipes are cleaned up when their views exit, and GTK Monitor recommendations reuse the `SystemReport` already collected for that refresh instead of immediately collecting the same information again.

## GTK dashboard

The main GTK window groups the report into:

- System Information
- CPU Statistics
- System Statistics
- Controls
- CPU Power State
- Battery

The window is resizable and vertically scrollable. The dashboard can refresh every 1, 2, or 5 seconds, with 2 seconds as the default.

The dashboard layout was adjusted during review to keep the normal 920×680 window more useful without removing scrolling as a fallback for systems with many logical CPUs:

- `System Statistics` is placed below `CPU Statistics` in the left column.
- `Advanced Settings` is placed next to the hamburger menu at the top-right of `Controls`.
- Expanding `Advanced Settings` reveals the Bluetooth-on-boot control inside `Controls`.
- The configuration path stays at the bottom of `Controls`, below the advanced setting when it is expanded.
- When a configuration file is active, the dashboard displays `Using configuration file: <path>`.
- When no file is currently active, it still shows the resolved default path as `Configuration file: <path>`.

The normal dashboard and GTK Monitor Mode share the same read-only `SystemReportView` renderer. Monitor Mode adds only its own header, navigation, and Governor/Turbo suggestions, while the normal dashboard adds the interactive controls.

On supported Intel systems, CPU Power State also reports HWP Dynamic Boost, addressing the GTK reporting gap noted after #954.

This keeps system information, CPU statistics, power state, battery information, and system statistics consistent between both views and avoids maintaining a second GTK renderer for the same data.

If the next refresh interval arrives while system information is still being collected, the GUI waits for the current collection instead of starting another worker.

Governor and Turbo changes have a separate transition state. A successful privileged command means that the requested override has been stored; it does not mean that the daemon has already reached its next control cycle and changed the hardware state.

During that interval, the affected CPU Power State row shows `Applying…` instead of immediately restoring an older observed value. A later fresh report returns the row to the governor or Turbo state actually observed from the system.

### Screenshots

**GTK dashboard**
<img width="924" height="715" alt="GTK dashboard" src="https://github.com/user-attachments/assets/c118a233-5b8b-4ad6-9470-5255f9ef3b58" />

**GTK Monitor Mode**
<img width="923" height="716" alt="GTK Monitor Mode" src="https://github.com/user-attachments/assets/3ad30ddb-cbef-49ad-8919-e22ef279674d" />

## Legacy status output

The existing live/daemon debug paths now use `print_system_report()` instead of independently calling `distro_info()` and `sysinfo()`.

This removes a second reporting path without changing the surrounding control loop or CLI mode behavior.

## Documentation

The README now documents the GTK dashboard, refresh options, Monitor Mode, and daemon installation path.

The existing README screenshot is intentionally left unchanged so it can be updated separately if the UI changes during review.

## Intentionally unchanged

- The daemon remains responsible for profile selection and kernel writes.
- `SystemReport` remains a reporting snapshot, not a control engine.
- `--monitor`, `--live`, and `--stats` remain terminal modes.
- Missing optional system data is reported as unavailable rather than invented.
- Governor and Turbo changes still go through the existing auto-cpufreq backend instead of writing sysfs directly from GTK.
- The separate `--live` / running-daemon guard being handled in #953 is not changed here.

## Validation

Validation performed on this code includes:

- `git diff --check`
- compilation of the affected Python modules
- GTK imports with `PyGIWarning` promoted to an error
- focused synthetic checks for reporting fallbacks, refresh scheduling, monitor cleanup, privileged-command failures, Governor/Turbo transition handling, shared GTK report rendering, shared CPUFreq policies, non-contiguous CPU IDs, and CPU hotplug reporting
- manual GTK testing of the normal dashboard and Monitor Mode, including shared report rendering, live refresh, scrolling, navigation, and the 1 / 2 / 5 second refresh options
- manual GTK testing of the review-requested layout, including Advanced Settings closed/open and configuration placement
- manual Governor and Turbo tests on real hardware, including the `Applying…` state
- Linux Build and Nix Flake GitHub Actions

No temporary regression-test files are included in the PR history.

## Review structure

The #964-specific work is kept in seven commits:

1. `Harden shared system reporting`
2. `Align runtime controls and monitor lifecycle`
3. `Polish GTK dashboard and refresh behavior`
4. `Share SystemReport with legacy status output`
5. `Address review findings in runtime reporting`
6. `Fix CPU reporting across shared policies and hotplug`
7. `Adjust GTK dashboard layout from review feedback`
