### PR TITLE
Preserve zero RPM fan readings and stabilize GTK CPU columns

### DIFF
--- a/auto_cpufreq/gui/app.py
+++ b/auto_cpufreq/gui/app.py
@@ -319,7 +319,7 @@ class SystemReportView(Gtk.Box):
         )
         self._refresh_core_rows(report.cores_info)
 
-        if report.cpu_fan_speed:
+        if report.cpu_fan_speed is not None:
             self.fan_label.set_text(
                 f"CPU fan speed: {report.cpu_fan_speed} RPM"
             )

--- a/auto_cpufreq/gui/app.py
+++ b/auto_cpufreq/gui/app.py
@@ -281,6 +281,9 @@ class SystemReportView(Gtk.Box):
                 label = Gtk.Label(label=text)
                 label.set_halign(Gtk.Align.START)
                 label.set_xalign(0)
+                if column == 1:
+                    # Keep later columns stable when usage reaches 100.0%.
+                    label.set_width_chars(len("100.0%"))
                 self.cores_grid.attach(label, column, row, 1, 1)
 
         self.cores_grid.show_all()

--- a/auto_cpufreq/gui/objects.py
+++ b/auto_cpufreq/gui/objects.py
@@ -543,7 +543,7 @@ class SystemStatisticsBox(Gtk.Box):
             else:
                 self.temp_label.hide()
 
-            if report.cpu_fan_speed:
+            if report.cpu_fan_speed is not None:
                 self.fan_label.set_label(f"CPU fan speed: {report.cpu_fan_speed} RPM")
                 self.fan_label.show()
             else:

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -429,7 +429,7 @@ class SystemInfo:
                     current = float(fan.current)
                 except (AttributeError, TypeError, ValueError):
                     continue
-                if current > 0:
+                if current >= 0:
                     return int(current)
         return None
 
@@ -903,7 +903,7 @@ def format_system_report(
             ]
         )
 
-    if report.cpu_fan_speed:
+    if report.cpu_fan_speed is not None:
         lines.extend(["", f"CPU fan speed: {report.cpu_fan_speed} RPM"])
 
     return "\n".join(lines)

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from math import isfinite
 import os
 from pathlib import Path
 import platform
@@ -423,15 +424,20 @@ class SystemInfo:
         except (AttributeError, NotImplementedError, OSError):
             return None
 
+        stopped_fan_reported = False
         for entries in fans.values():
             for fan in entries:
                 try:
                     current = float(fan.current)
                 except (AttributeError, TypeError, ValueError):
                     continue
-                if current >= 0:
+                if not isfinite(current):
+                    continue
+                if current > 0:
                     return int(current)
-        return None
+                if current == 0:
+                    stopped_fan_reported = True
+        return 0 if stopped_fan_reported else None
 
     @staticmethod
     def current_gov() -> str | None:

--- a/auto_cpufreq/modules/system_monitor.py
+++ b/auto_cpufreq/modules/system_monitor.py
@@ -278,7 +278,7 @@ class SystemMonitor:
                 )
             )
 
-        if report.cpu_fan_speed:
+        if report.cpu_fan_speed is not None:
             self.left_content.append(aligned_text(""))
             self.left_content.append(
                 aligned_text(f"CPU fan speed: {report.cpu_fan_speed} RPM")


### PR DESCRIPTION
## Summary

Small follow-up fixes found while validating the reporting and GTK changes merged in #964.

This preserves a valid stopped-fan reading of `0 RPM` throughout the reporting frontends and prevents the GTK CPU table from shifting horizontally when CPU usage reaches `100.0%`.

## Fan speed reporting

The post-merge review of #964 pointed out that `cpu_fan_speed()` treated `0 RPM` as unavailable.

While checking the full data path, I found that preserving zero in the collector alone was not enough: several report views also used truthiness checks and would still hide the value.

The reporting semantics are now kept distinct:

- `None` → fan speed unavailable
- `0` → valid reading, fan stopped
- positive value → fan running

The explicit `None` check is used consistently in the shared GTK view, textual report, terminal/Urwid view, and the remaining `SystemReport` GTK consumer.

Invalid and negative readings continue to be ignored.

## GTK CPU table

While testing the merged #964 dashboard from the installed upstream `master`, I also noticed that the CPU table shifted horizontally whenever a core changed between values below `100%` and `100.0%`.

The cause was the `Usage` column sizing itself from the current label contents:

- `4.2%`
- `88.2%`
- `100.0%`

The usage cells now reserve enough character width for `100.0%`, keeping the later Temperature and Frequency columns stable without introducing fixed pixel widths or changing the overall layout.

## Validation

The fan fix was tested with temporary focused checks covering:

- missing/empty fan sensors
- unsupported fan sensors
- invalid values
- negative values
- `0 RPM`
- positive RPM
- multiple readings
- shared textual report
- GTK report view
- Urwid terminal view
- remaining `SystemReport` GTK consumer

The GTK width issue was reproduced against the exact #964 merge commit (`999cb58`):

```text
  4.2% ... grid=(minimum_width=285, natural_width=285)
 88.2% ... grid=(minimum_width=285, natural_width=285)
100.0% ... grid=(minimum_width=293, natural_width=293)

VARIABLE: grid preferred width changes with CPU usage
```

With this change:

```text
  4.2% ... grid=(minimum_width=293, natural_width=293)
 88.2% ... grid=(minimum_width=293, natural_width=293)
100.0% ... grid=(minimum_width=293, natural_width=293)

STABLE: grid preferred width does not change
```

The issue was also reproduced manually using an installed build of upstream master, and the fix was visually verified with live CPU usage and fan readings.

Additional checks:

- `python -m py_compile` on affected modules
- `python -m compileall -q auto_cpufreq`
- `git diff --check`

The focused regression scripts were temporary and are not included in the PR.

Follow-up to #964.