### PR TITLE
Fix native power-profiles-daemon handling

### DIFF
--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -102,7 +102,6 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                 tlp_service_detect_snap()
             else:
                 gnome_power_detect_live()
-                gnome_power_stop_live()
                 tuned_stop_live()
                 tlp_service_detect()
             
@@ -112,7 +111,8 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                 except KeyboardInterrupt:
                     conf.notifier.stop()
                     sys.exit(0)
-            
+
+            gnome_power_stop_live()
             cpufreqctl()
             def live_daemon():
                 # Redirect stdout to suppress prints

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -93,7 +93,7 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                 gnome_power_detect_snap()
                 tlp_service_detect_snap()
             else:
-                gnome_power_detect_install()
+                gnome_power_detect_live()
                 gnome_power_stop_live()
                 tuned_stop_live()
                 tlp_service_detect()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1331,16 +1331,12 @@ def daemon_is_running():
 
 def daemon_running_msg():
     print("\n" + "-" * 24 + " auto-cpufreq running " + "-" * 30 + "\n")
-    if IS_INSTALLED_WITH_SNAP:
-        print(
-            "auto-cpufreq daemon is already running after auto-cpufreq .snap package is installed.\n\n"
-            "Live stats of CPU/system load monitoring and optimization can be seen by running:\n"
-            "auto-cpufreq --stats"
-        )
-    else:
-        print(
-            "ERROR: auto-cpufreq is running in daemon mode.\n\nMake sure to stop the daemon before running with --live or --monitor mode"
-        )
+    print(
+        "ERROR: auto-cpufreq is running in daemon mode.\n\n"
+        "Live stats of CPU/system load monitoring and optimization can be seen by running:\n"
+        "auto-cpufreq --stats\n\n"
+        "Otherwise make sure to stop the daemon before running with --live or --monitor mode"
+    )
     footer()
 
 def daemon_not_running_msg():

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -3,7 +3,7 @@
 # * if daemon is disabled and auto-cpufreq is removed (snap) remind user to enable it back
 import click
 from shutil import which
-from subprocess import call, getoutput
+from subprocess import call, getoutput, run
 from sys import argv
 
 # ToDo: update README part how to run this script
@@ -58,7 +58,7 @@ def tlp_service_detect_snap():
 
 # alert in case gnome power profile service is running
 def gnome_power_detect():
-    if systemctl_exists and not bool(gnome_power_status):
+    if systemctl_exists and gnome_power_status == 0:
         warning()
         print("Detected running GNOME Power Profiles daemon service!")
         print("\nThis daemon might interfere with auto-cpufreq and will be automatically")
@@ -73,7 +73,7 @@ def gnome_power_detect():
 
 # automatically disable gnome power profile service in case it's running during install
 def gnome_power_detect_install():
-    if systemctl_exists and not bool(gnome_power_status):
+    if systemctl_exists and gnome_power_status == 0:
         warning()
         print("Detected running GNOME Power Profiles daemon service!")
         print("\nThis daemon might interfere with auto-cpufreq and will be disabled.\n")
@@ -104,9 +104,14 @@ def gnome_power_detect_snap():
 
 # stops gnome >= 40 power profiles (live)
 def gnome_power_stop_live():
-    if not IS_INSTALLED_WITH_SNAP and systemctl_exists and not bool(gnome_power_status) and powerprofilesctl_exists:
+    if not IS_INSTALLED_WITH_SNAP and systemctl_exists and gnome_power_status == 0:
+        if powerprofilesctl_exists:
+            try:
+                call(["powerprofilesctl", "set", "balanced"])
+            except (OSError, FileNotFoundError, PermissionError):
+                pass
+
         try:
-            call(["powerprofilesctl", "set", "balanced"])
             call(["systemctl", "stop", "power-profiles-daemon"])
         except (OSError, FileNotFoundError, PermissionError):
             pass
@@ -121,7 +126,7 @@ def tuned_stop_live():
 
 # starts gnome >= 40 power profiles (live)
 def gnome_power_start_live():
-    if not IS_INSTALLED_WITH_SNAP and systemctl_exists:
+    if not IS_INSTALLED_WITH_SNAP and systemctl_exists and gnome_power_status == 0:
         try:
             call(["systemctl", "start", "power-profiles-daemon"])
         except (OSError, FileNotFoundError, PermissionError):
@@ -303,9 +308,25 @@ def gnome_power_svc_disable():
     if not systemctl_exists:
         return
 
+    if gnome_power_status != 0:
+        try:
+            state = run(
+                ["systemctl", "show", "--property=LoadState", "--value", "power-profiles-daemon"],
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, FileNotFoundError, PermissionError):
+            return
+
+        if state.returncode != 0 or state.stdout.strip() not in ("loaded", "masked"):
+            return
+
     if gnome_power_status == 0 and powerprofilesctl_exists:
         print("\nUsing profile: balanced")
-        call(["powerprofilesctl", "set", "balanced"])
+        try:
+            call(["powerprofilesctl", "set", "balanced"])
+        except (OSError, FileNotFoundError, PermissionError):
+            pass
 
     disable_power_profiles_daemon()
 

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -80,6 +80,14 @@ def gnome_power_detect_install():
         print('This daemon is not automatically disabled in "monitor" mode and')
         print("will be enabled after auto-cpufreq daemon is removed.")
 
+# alert before temporarily stopping gnome power profiles in live mode
+def gnome_power_detect_live():
+    if systemctl_exists and gnome_power_status == 0:
+        warning()
+        print("Detected running GNOME Power Profiles daemon service!")
+        print("\nThis daemon might interfere with auto-cpufreq and will be stopped.\n")
+        print('It will be started again when "live" mode exits.')
+
 
 # notification on snap
 def gnome_power_detect_snap():
@@ -279,11 +287,11 @@ def disable_tuned_daemon():
 
 # default gnome_power_svc_disable func (balanced)
 def gnome_power_svc_disable():
-    if not systemctl_exists or gnome_power_status != 0:
+    if not systemctl_exists:
         return
 
-    if powerprofilesctl_exists:
-        print("Using profile: ", "balanced")
+    if gnome_power_status == 0 and powerprofilesctl_exists:
+        print("\nUsing profile: balanced")
         call(["powerprofilesctl", "set", "balanced"])
 
     disable_power_profiles_daemon()

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -3,7 +3,7 @@
 # * if daemon is disabled and auto-cpufreq is removed (snap) remind user to enable it back
 import click
 from shutil import which
-from subprocess import call, DEVNULL, getoutput, STDOUT
+from subprocess import call, getoutput
 from sys import argv
 
 # ToDo: update README part how to run this script
@@ -76,7 +76,7 @@ def gnome_power_detect_install():
     if systemctl_exists and not bool(gnome_power_status):
         warning()
         print("Detected running GNOME Power Profiles daemon service!")
-        print("\nThis daemon might interfere with auto-cpufreq and has been disabled.\n")
+        print("\nThis daemon might interfere with auto-cpufreq and will be disabled.\n")
         print('This daemon is not automatically disabled in "monitor" mode and')
         print("will be enabled after auto-cpufreq daemon is removed.")
 
@@ -279,39 +279,14 @@ def disable_tuned_daemon():
 
 # default gnome_power_svc_disable func (balanced)
 def gnome_power_svc_disable():
-    snap_pkg_check = 0
-    if systemctl_exists:
-        if bool(gnome_power_status):
-            try:
-                # check if snap package installed
-                snap_pkg_check = call(['snap', 'list', '|', 'grep', 'auto-cpufreq'], 
-                stdout=DEVNULL,
-                stderr=STDOUT)
-                # check if snapd is present and if snap package is installed | 0 is success
-                if not bool(snap_pkg_check):
-                    print("GNOME Power Profiles Daemon is already disabled, it can be re-enabled by running:\n"
-                        "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable\n"
-                    )
-                elif snap_pkg_check == 1:
-                    print("auto-cpufreq snap package not installed\nGNOME Power Profiles Daemon should be enabled. run:\n\n"
-                        "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable"
-                    )
-            except (OSError, FileNotFoundError):
-                # snapd not found on the system
-                print("There was a problem, couldn't determine GNOME Power Profiles Daemon")
-                snap_pkg_check = 0
+    if not systemctl_exists or gnome_power_status != 0:
+        return
 
-        if not bool(gnome_power_status) and powerprofilesctl_exists:
-            if snap_pkg_check == 1:
-                print("auto-cpufreq snap package not installed.\nGNOME Power Profiles Daemon should be enabled, run:\n\n"
-                    "sudo python3 -m auto_cpufreq.power_helper --gnome_power_enable"
-                )
-            else:
-                print("auto-cpufreq snap package installed, GNOME Power Profiles Daemon should be disabled.\n")
-                print("Using profile: ", "balanced")
-                call(["powerprofilesctl", "set", "balanced"])
+    if powerprofilesctl_exists:
+        print("Using profile: ", "balanced")
+        call(["powerprofilesctl", "set", "balanced"])
 
-                disable_power_profiles_daemon()
+    disable_power_profiles_daemon()
 
 def tuned_svc_disable():
     if systemctl_exists and tuned_stat_exists:
@@ -323,7 +298,7 @@ def tuned_svc_disable():
 @click.option("--gnome_power_disable", is_flag=True, help="Disable GNOME Power profiles service")
 # ToDo:
 # * update readme/docs
-@click.option("--gnome_power_enable", is_flag=True, help="Enable GNOME Power profiles service")
+@click.option("--gnome_power_enable", is_flag=True, help="Enable GNOME Power Profiles daemon")
 
 @click.option("--gnome_power_status", is_flag=True, help="Get status of GNOME Power profiles service")
 @click.option("--bluetooth_boot_on", is_flag=True, help="Turn on Bluetooth on boot")


### PR DESCRIPTION
## Summary

Fixes the native `power-profiles-daemon` handling issue pointed out by the maintainer in #962.

The native path previously tried to infer a Snap installation with a malformed `snap list | grep` subprocess call. This PR removes that inference and keeps Snap handling on the dedicated Snap path, including the fixes now present on `master` from #971.

## Changes

* Removes the broken Snap inference from the native PPD helper path.
* Separates install and `--live` messaging so each describes the action actually being performed.
* Disables and masks PPD during native daemon installation even when the service is inactive-but-enabled.
* Avoids creating a systemd mask when `power-profiles-daemon.service` is not installed (`LoadState=not-found`).
* Treats `powerprofilesctl set balanced` as optional, so an unavailable or failing `powerprofilesctl` does not prevent PPD from being disabled.
* In `--live`, only stops PPD when it was active before entering live mode, and only restores it in that case.
* Stops PPD only after the live-mode confirmation, so cancelling at the prompt does not leave it stopped.

## Verification

The PPD lifecycle was checked across active, inactive, missing, masked and detection-failure states, including systems without `powerprofilesctl`.

The branch was also updated against the current `master` so the Snap behavior fixed in #971 remains separate from the native PPD handling.
