### PR TITLE
Fix auto-cpufreq >= 3.1.0 snap package release

### DIFF
--- a/auto_cpufreq/battery_scripts/battery.py
+++ b/auto_cpufreq/battery_scripts/battery.py
@@ -10,10 +10,19 @@ from auto_cpufreq.battery_scripts.shared import BatteryDevice
 BATTERY_APPLY_INTERVAL = 3600  # 1 hour
 
 
-def lsmod(module):
-    return (
-        module in run(["lsmod"], stdout=PIPE, stderr=PIPE, text=True).stdout
-    )
+def lsmod(module: str) -> bool:
+    try:
+        with open("/proc/modules", "r") as f:
+            for line in f:
+                parts = line.split()
+                if parts and parts[0] == module:
+                    return True
+        return False
+    except OSError:
+        try:
+            return module in run(["lsmod"], stdout=PIPE, stderr=PIPE, text=True).stdout
+        except (OSError, FileNotFoundError):
+            return False
 
 
 def battery_get_thresholds():

--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -67,6 +67,10 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
             set_turbo_override(turbo)
 
         if monitor:
+            if IS_INSTALLED_WITH_SNAP:
+                daemon_running_msg()
+                sys.exit(0)
+            running_daemon_check()
             root_check()
             conf.notifier.start()
             if IS_INSTALLED_WITH_SNAP:
@@ -86,6 +90,10 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
             monitor = SystemMonitor(suggestion=True, type=ViewType.MONITOR)
             monitor.run(on_quit=conf.notifier.stop)
         elif live:
+            if IS_INSTALLED_WITH_SNAP:
+                daemon_running_msg()
+                sys.exit(0)
+            running_daemon_check()
             root_check()
             start_battery_daemon()
             conf.notifier.start()
@@ -156,19 +164,13 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
                 except KeyboardInterrupt: break
             conf.notifier.stop()
         elif install:
-            root_check()
             if IS_INSTALLED_WITH_SNAP:
-                running_daemon_check()
-                gnome_power_detect_snap()
-                tlp_service_detect_snap()
-                bluetooth_notif_snap()
-                gov_check()
-                run("snapctl set daemon=enabled", shell=True)
-                run("snapctl start --enable auto-cpufreq", shell=True)
-            else:
-                running_daemon_check()
-                gov_check()
-                deploy_daemon()
+                daemon_running_msg()
+                sys.exit(0)
+            root_check()
+            running_daemon_check()
+            gov_check()
+            deploy_daemon()
             deploy_complete_msg()
         elif update:
             root_check()

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1331,9 +1331,16 @@ def daemon_is_running():
 
 def daemon_running_msg():
     print("\n" + "-" * 24 + " auto-cpufreq running " + "-" * 30 + "\n")
-    print(
-        "ERROR: auto-cpufreq is running in daemon mode.\n\nMake sure to stop the daemon before running with --live or --monitor mode"
-    )
+    if IS_INSTALLED_WITH_SNAP:
+        print(
+            "auto-cpufreq daemon is already running after auto-cpufreq .snap package is installed.\n\n"
+            "Live stats of CPU/system load monitoring and optimization can be seen by running:\n"
+            "auto-cpufreq --stats"
+        )
+    else:
+        print(
+            "ERROR: auto-cpufreq is running in daemon mode.\n\nMake sure to stop the daemon before running with --live or --monitor mode"
+        )
     footer()
 
 def daemon_not_running_msg():
@@ -1345,10 +1352,7 @@ def daemon_not_running_msg():
 
 # check if auto-cpufreq --daemon is running
 def running_daemon_check():
-    if is_running("auto-cpufreq", "--daemon"):
-        daemon_running_msg()
-        exit(1)
-    elif IS_INSTALLED_WITH_SNAP and SNAP_DAEMON_CHECK == "enabled":
+    if daemon_is_running():
         daemon_running_msg()
         exit(1)
 

--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -1169,23 +1169,26 @@ def distro_info():
     version = "UNKNOWN version"
     if IS_INSTALLED_WITH_SNAP:
         try:
-            with open("/var/lib/snapd/hostfs/etc/os-release", "r") as searchfile:
-                for line in searchfile:
-                    if line.startswith("NAME="):
-                        dist = line[5 : line.find("$")].strip('"')
-                        continue
-                    elif line.startswith("VERSION="):
-                        version = line[8 : line.find("$")].strip('"')
-                        continue
-        except PermissionError as e: print(repr(e))
-        dist = f"{dist} {version}"
-    else: # get distro information
-        fdist = distro.linux_distribution()
-        dist = " ".join(x for x in fdist)
+            host_os_release = "/var/lib/snapd/hostfs/etc/os-release"
+            if not os.path.exists(host_os_release):
+                host_os_release = "/var/lib/snapd/hostfs/usr/lib/os-release"
+
+            if os.path.exists(host_os_release):
+                host_distro = distro.LinuxDistribution(
+                    include_lsb=False,
+                    os_release_file=host_os_release,
+                    distro_release_file="",
+                )
+                dist = host_distro.name(pretty=False) or "UNKNOWN"
+                version = host_distro.version() or "UNKNOWN"
+        except (OSError, UnicodeError, ValueError) as e:
+            print(repr(e))
+        dist = f"{dist} {version}".strip()
+    else:  # get distro information
+        dist = f"{distro.name(pretty=False)} {distro.version()}".strip()
 
     print("Linux distro: " + dist)
     print("Linux kernel: " + platform.release())
-
 def sysinfo():
     """
     get system information

--- a/auto_cpufreq/modules/system_info.py
+++ b/auto_cpufreq/modules/system_info.py
@@ -89,9 +89,21 @@ class SystemInfo:
     def __init__(self):
         if IS_INSTALLED_WITH_SNAP:
             try:
-                host_distro = distro.LinuxDistribution(root_dir=SNAP_HOST_ROOT)
-                self.distro_name = host_distro.name(pretty=False) or "UNKNOWN"
-                self.distro_version = host_distro.version() or "UNKNOWN"
+                host_os_release = "/var/lib/snapd/hostfs/etc/os-release"
+                if not os.path.exists(host_os_release):
+                    host_os_release = "/var/lib/snapd/hostfs/usr/lib/os-release"
+
+                if os.path.exists(host_os_release):
+                    host_distro = distro.LinuxDistribution(
+                        include_lsb=False,
+                        os_release_file=host_os_release,
+                        distro_release_file="",
+                    )
+                    self.distro_name = host_distro.name(pretty=False) or "UNKNOWN"
+                    self.distro_version = host_distro.version() or "UNKNOWN"
+                else:
+                    self.distro_name = "UNKNOWN"
+                    self.distro_version = "UNKNOWN"
             except (OSError, UnicodeError, ValueError):
                 self.distro_name = "UNKNOWN"
                 self.distro_version = "UNKNOWN"

--- a/auto_cpufreq/power_helper.py
+++ b/auto_cpufreq/power_helper.py
@@ -96,22 +96,35 @@ def gnome_power_detect_snap():
 
 # stops gnome >= 40 power profiles (live)
 def gnome_power_stop_live():
-    if systemctl_exists and not bool(gnome_power_status) and powerprofilesctl_exists:
-        call(["powerprofilesctl", "set", "balanced"])
-        call(["systemctl", "stop", "power-profiles-daemon"])
+    if not IS_INSTALLED_WITH_SNAP and systemctl_exists and not bool(gnome_power_status) and powerprofilesctl_exists:
+        try:
+            call(["powerprofilesctl", "set", "balanced"])
+            call(["systemctl", "stop", "power-profiles-daemon"])
+        except (OSError, FileNotFoundError, PermissionError):
+            pass
 
 # stops tuned (live)
 def tuned_stop_live():
-    if systemctl_exists and tuned_stat_exists:
-        call(["systemctl", "stop", "tuned"])
+    if not IS_INSTALLED_WITH_SNAP and systemctl_exists and tuned_stat_exists:
+        try:
+            call(["systemctl", "stop", "tuned"])
+        except (OSError, FileNotFoundError, PermissionError):
+            pass
 
 # starts gnome >= 40 power profiles (live)
 def gnome_power_start_live():
-    if systemctl_exists: call(["systemctl", "start", "power-profiles-daemon"])
+    if not IS_INSTALLED_WITH_SNAP and systemctl_exists:
+        try:
+            call(["systemctl", "start", "power-profiles-daemon"])
+        except (OSError, FileNotFoundError, PermissionError):
+            pass
 
 def tuned_start_live():
-    if systemctl_exists and tuned_stat_exists: 
-        call(["systemctl", "start", "tuned"])
+    if not IS_INSTALLED_WITH_SNAP and systemctl_exists and tuned_stat_exists: 
+        try:
+            call(["systemctl", "start", "tuned"])
+        except (OSError, FileNotFoundError, PermissionError):
+            pass
 
 # enable gnome >= 40 power profiles (uninstall)
 def gnome_power_svc_enable():


### PR DESCRIPTION
* Fix distro information not being properly displayed on Snap packages
* Fix conflict and messaging between --live --monitor and --install modes on Snap package. Since daemon is installed right after package is installed and should be viewed with --stats
* auto-cpufreq 3.1.0 is live with these changes on https://snapcraft.io/auto-cpufreq