### PR TITLE
fix: report HWP Dynamic Boost in debug output

### DIFF
--- a/auto_cpufreq/bin/auto_cpufreq.py
+++ b/auto_cpufreq/bin/auto_cpufreq.py
@@ -296,6 +296,9 @@ def main(monitor, live, daemon, install, update, remove, force, turbo, config, s
             get_load()
             get_current_gov()
             get_turbo()
+            hwp_dynamic_boost = get_hwp_dynamic_boost()
+            if hwp_dynamic_boost is not None:
+                print(f"HWP Dynamic Boost: {'On' if hwp_dynamic_boost else 'Off'}")
             footer()
         elif version:
             footer()


### PR DESCRIPTION
## Summary

Report the current Intel HWP Dynamic Boost state in `--debug` when the kernel exposes the control.

This reuses the existing read-only `get_hwp_dynamic_boost()` helper and does not change power-management policy.

## Behavior

- `True` → `HWP Dynamic Boost: On`
- `False` → `HWP Dynamic Boost: Off`
- unavailable or unsupported → no additional line

This makes `--debug` more useful when investigating Intel P-State power behavior while preserving the existing output on systems without HWP Dynamic Boost support.